### PR TITLE
Add country, country code, and location to matchups on event handle.

### DIFF
--- a/W3ChampionsStatisticService/Matches/MatchReadModelHandler.cs
+++ b/W3ChampionsStatisticService/Matches/MatchReadModelHandler.cs
@@ -8,12 +8,15 @@ namespace W3ChampionsStatisticService.Matches
     public class MatchReadModelHandler : IReadModelHandler
     {
         private readonly IMatchRepository _matchRepository;
+        private readonly IPersonalSettingsRepository _personalSettingsRepository;
 
         public MatchReadModelHandler(
-            IMatchRepository matchRepository
+            IMatchRepository matchRepository,
+            IPersonalSettingsRepository personalSettingsRepository
             )
         {
             _matchRepository = matchRepository;
+            _personalSettingsRepository = personalSettingsRepository;
         }
 
         public async Task Update(MatchFinishedEvent nextEvent)
@@ -22,10 +25,26 @@ namespace W3ChampionsStatisticService.Matches
             var count = await _matchRepository.Count();
             var matchup = Matchup.Create(nextEvent);
 
+            // Use the player's personal settings to set their location info
+            foreach (var team in matchup.Teams)
+            {
+                foreach (var player in team.Players)
+                {
+                    var personalSettings = await _personalSettingsRepository.Load(player.BattleTag);
+                    if (personalSettings != null)
+                    {
+                        player.CountryCode = personalSettings.CountryCode;
+                        player.Location = personalSettings.Location;
+                        player.Country = personalSettings.Country;
+                    }
+                }
+            }
+
             matchup.Number = count + 1;
 
             await _matchRepository.Insert(matchup);
             await _matchRepository.DeleteOnGoingMatch(matchup.MatchId);
         }
     }
+
 }

--- a/W3ChampionsStatisticService/Matches/OngoingMatchesHandler.cs
+++ b/W3ChampionsStatisticService/Matches/OngoingMatchesHandler.cs
@@ -40,8 +40,14 @@ namespace W3ChampionsStatisticService.Matches
                                 if (foundMatchForPlayer != null)
                                     await _matchRepository.DeleteOnGoingMatch(foundMatchForPlayer.MatchId);
 
+                                // Use the players personal settings to update their location information
                                 var personalSettings = await _personalSettingsRepository.Load(player.BattleTag);
-                                if (personalSettings != null) player.CountryCode = personalSettings.CountryCode;
+                                if (personalSettings != null)
+                                {
+                                    player.CountryCode = personalSettings.CountryCode;
+                                    player.Location = personalSettings.Location;
+                                    player.Country = personalSettings.Country;
+                                }
                             }
 
                         await _matchRepository.InsertOnGoingMatch(matchup);

--- a/WC3ChampionsStatisticService.UnitTests/MatchupEventRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/MatchupEventRepoTests.cs
@@ -4,6 +4,7 @@ using MongoDB.Bson;
 using NUnit.Framework;
 using W3ChampionsStatisticService.Matches;
 using W3ChampionsStatisticService.PadEvents;
+using W3ChampionsStatisticService.PersonalSettings;
 
 namespace WC3ChampionsStatisticService.UnitTests
 {
@@ -81,9 +82,10 @@ namespace WC3ChampionsStatisticService.UnitTests
 
             await InsertMatchEvent(matchFinishedEvent1);
 
+            var personalSettingsRepository = new PersonalSettingsRepository(MongoClient);
             var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
             var matchReadModelHandler = new MatchReadModelHandler(
-                matchRepository);
+                matchRepository, personalSettingsRepository);
 
             await matchReadModelHandler.Update(matchFinishedEvent1);
             await matchReadModelHandler.Update(matchFinishedEvent2);

--- a/WC3ChampionsStatisticService.UnitTests/ReadModelHandlerBaseTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/ReadModelHandlerBaseTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using NUnit.Framework;
 using W3ChampionsStatisticService.Matches;
 using W3ChampionsStatisticService.PadEvents;
+using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 
@@ -32,7 +33,7 @@ namespace WC3ChampionsStatisticService.UnitTests
             var handler = new ReadModelHandler<MatchReadModelHandler>(
                 mockEvents.Object,
                 versionRepository,
-                new MatchReadModelHandler(mockMatchRepo.Object));
+                new MatchReadModelHandler(mockMatchRepo.Object, new PersonalSettingsRepository(MongoClient)));
 
             await handler.Update();
 
@@ -58,7 +59,7 @@ namespace WC3ChampionsStatisticService.UnitTests
             var handler = new ReadModelHandler<MatchReadModelHandler>(
                 mockEvents.Object,
                 versionRepository,
-                new MatchReadModelHandler(mockMatchRepo.Object));
+                new MatchReadModelHandler(mockMatchRepo.Object, new PersonalSettingsRepository(MongoClient)));
 
             await handler.Update();
 
@@ -99,7 +100,7 @@ namespace WC3ChampionsStatisticService.UnitTests
              var handler = new ReadModelHandler<MatchReadModelHandler>(
                  new MatchEventRepository(MongoClient),
                  versionRepository,
-                 new MatchReadModelHandler(matchRepository));
+                 new MatchReadModelHandler(matchRepository, new PersonalSettingsRepository(MongoClient)));
 
              await handler.Update();
 


### PR DESCRIPTION
In some cases, players only have a non-null Location field in their personal settings. So when building the matchup records from their events, update the Location field for all players.

This will work for new matchup's going forward, but does not handle past Matchup's.

Resolves w3champions/website#264 ... for future matches only.