### PR TITLE
Portraits can now be grouped by a string identifier

### DIFF
--- a/W3ChampionsStatisticService/Admin/AdminController.cs
+++ b/W3ChampionsStatisticService/Admin/AdminController.cs
@@ -244,7 +244,7 @@ namespace W3ChampionsStatisticService.Admin
         [CheckIfBattleTagIsAdmin]
         public async Task<IActionResult> DefinePortraits([FromBody] PortraitsDefinitionCommand command)
         {
-            await _portraitCommandHandler.AddPortraitDefinition(command.Ids);
+            await _portraitCommandHandler.AddPortraitDefinition(command);
             return Ok();
         }
 
@@ -252,7 +252,7 @@ namespace W3ChampionsStatisticService.Admin
         [CheckIfBattleTagIsAdmin]
         public async Task<IActionResult> RemovePortraits([FromBody] PortraitsDefinitionCommand command)
         {
-            await _portraitCommandHandler.RemovePortraitDefinition(command.Ids);
+            await _portraitCommandHandler.RemovePortraitDefinition(command);
             return Ok();
         }
     }

--- a/W3ChampionsStatisticService/Admin/Portraits/PortraitCommandHandler.cs
+++ b/W3ChampionsStatisticService/Admin/Portraits/PortraitCommandHandler.cs
@@ -77,6 +77,11 @@ namespace W3ChampionsStatisticService.Admin
             await _personalSettingsRepository.SaveMany(settings);
         }
 
+        public async Task<List<PortraitDefinition>> GetPortraitDefinitions()
+        {
+            return await _portraitRepository.LoadPortraitDefinitions();
+        }
+
         public async Task AddPortraitDefinition(PortraitsDefinitionCommand command)
         {
             await _portraitRepository.SaveNewPortraitDefinitions(command.Ids, command.Groups);

--- a/W3ChampionsStatisticService/Admin/Portraits/PortraitCommandHandler.cs
+++ b/W3ChampionsStatisticService/Admin/Portraits/PortraitCommandHandler.cs
@@ -52,7 +52,7 @@ namespace W3ChampionsStatisticService.Admin
                 foreach (var portraitId in command.Portraits)
                 {
                     if (!specialPortraitsList.Exists(x => x.PictureId == portraitId) && 
-                        validPortraits.Any(x => x.Id == portraitId))
+                        validPortraits.Any(x => x.Number == portraitId))
                     {
                         specialPortraitsList.Add(new SpecialPicture(portraitId, command.Tooltip));
                     }
@@ -77,14 +77,19 @@ namespace W3ChampionsStatisticService.Admin
             await _personalSettingsRepository.SaveMany(settings);
         }
 
-        public async Task AddPortraitDefinition(List<int> portraitIds)
+        public async Task AddPortraitDefinition(PortraitsDefinitionCommand command)
         {
-            await _portraitRepository.SaveNewPortraitDefinitions(portraitIds);
+            await _portraitRepository.SaveNewPortraitDefinitions(command.Ids, command.Groups);
         }
 
-        public async Task RemovePortraitDefinition(List<int> portraitIds)
+        public async Task RemovePortraitDefinition(PortraitsDefinitionCommand command)
         {
-            await _portraitRepository.DeletePortraitDefinitions(portraitIds);
+            await _portraitRepository.DeletePortraitDefinitions(command.Ids);
+        }
+
+        public async Task UpdatePortraitDefinition(PortraitsDefinitionCommand command)
+        {
+            await _portraitRepository.UpdatePortraitDefinition(command.Ids, command.Groups);
         }
     }
 }

--- a/W3ChampionsStatisticService/Admin/Portraits/PortraitDefinition.cs
+++ b/W3ChampionsStatisticService/Admin/Portraits/PortraitDefinition.cs
@@ -1,12 +1,18 @@
-﻿namespace W3ChampionsStatisticService.Admin.Portraits
+﻿using System.Collections.Generic;
+using W3ChampionsStatisticService.ReadModelBase;
+
+namespace W3ChampionsStatisticService.Admin.Portraits
 {
-    public class PortraitDefinition
+    public class PortraitDefinition : IIdentifiable
     {
-        public PortraitDefinition(int _id)
+        public PortraitDefinition(int _id, List<string> _group = null)
         {
-            Id = _id;
+            Number = _id;
+            Groups = _group;
         }
 
-        public int Id { get; set; }
+        public string Id => Number.ToString();
+        public int Number { get; set; }
+        public List<string> Groups { get; set; }
     }
 }

--- a/W3ChampionsStatisticService/Admin/Portraits/PortraitRepository.cs
+++ b/W3ChampionsStatisticService/Admin/Portraits/PortraitRepository.cs
@@ -19,28 +19,41 @@ namespace W3ChampionsStatisticService.Admin
             return LoadAll<PortraitDefinition>();
         }
 
-        public async Task SaveNewPortraitDefinitions(List<int> portraitIds)
+        public async Task SaveNewPortraitDefinitions(List<int> _ids, List<string> _group = null)
         {
             var existingPortraits = await LoadPortraitDefinitions();
-            var toAdd = portraitIds.Distinct().ToList();
+            var toAdd = _ids.Distinct().ToList();
             foreach (var id in toAdd)
             {
-                if (!existingPortraits.Any(x => x.Id == id))
+                if (!existingPortraits.Any(x => x.Number == id))
                 {
-                    await Insert(new PortraitDefinition(id));
+                    await Insert(new PortraitDefinition(id, _group ?? new List<string>()));
                 }
             }
         }
 
-        public async Task DeletePortraitDefinitions(List<int> portraitIds)
+        public async Task DeletePortraitDefinitions(List<int> _ids)
         {
             var existingPortraits = await LoadPortraitDefinitions();
-            var toDelete = portraitIds.Distinct().ToList();
+            var toDelete = _ids.Distinct().ToList();
             foreach (var id in toDelete)
             {
-                if (existingPortraits.Any(x => x.Id == id))
+                if (existingPortraits.Any(x => x.Number == id))
                 {
-                    await Delete<PortraitDefinition>(n => n.Id == id);
+                    await Delete<PortraitDefinition>(n => n.Number == id);
+                }
+            }
+        }
+
+        public async Task UpdatePortraitDefinition(List<int> _ids, List<string> _group)
+        {
+            var existingPortraits = await LoadPortraitDefinitions();
+            var toUpdate = _ids.Distinct().ToList();
+            foreach (var id in toUpdate)
+            {
+                if (existingPortraits.Any(x => x.Number == id))
+                {
+                    await Upsert(new PortraitDefinition(id, _group));
                 }
             }
         }

--- a/W3ChampionsStatisticService/Admin/Portraits/PortraitsDefinitionCommand.cs
+++ b/W3ChampionsStatisticService/Admin/Portraits/PortraitsDefinitionCommand.cs
@@ -4,6 +4,12 @@ namespace W3ChampionsStatisticService.Admin.Portraits
 {
     public class PortraitsDefinitionCommand
     {
+        public PortraitsDefinitionCommand(List<int> _ids, List<string> _groups = null)
+        {
+            Ids = _ids;
+            Groups = _groups ?? new List<string>();
+        }
         public List<int> Ids { get; set; }
+        public List<string> Groups { get; set; }
     }
 }

--- a/W3ChampionsStatisticService/Ports/IPortraitRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IPortraitRepository.cs
@@ -7,7 +7,8 @@ namespace W3ChampionsStatisticService.Admin
     public interface IPortraitRepository
     {
         public Task<List<PortraitDefinition>> LoadPortraitDefinitions();
-        public Task SaveNewPortraitDefinitions(List<int> portraitIds);
-        public Task DeletePortraitDefinitions(List<int> portraitIds);
+        public Task SaveNewPortraitDefinitions(List<int> _ids, List<string> _groups = null);
+        public Task DeletePortraitDefinitions(List<int> _ids);
+        public Task UpdatePortraitDefinition(List<int> _ids, List<string> _groups);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
+++ b/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
@@ -11,8 +11,8 @@ namespace WC3ChampionsStatisticService.UnitTests
 {
     public class IntegrationTestBase
     {
-        // protected readonly MongoClient MongoClient = new MongoClient("mongodb://localhost:27017/");
-        protected readonly MongoClient MongoClient = new MongoClient("mongodb://157.90.1.251:3512/");
+        protected readonly MongoClient MongoClient = new MongoClient("mongodb://localhost:27017/");
+        // protected readonly MongoClient MongoClient = new MongoClient("mongodb://157.90.1.251:3512/");
 
         protected PersonalSettingsProvider personalSettingsProvider;
 

--- a/WC3ChampionsStatisticService.UnitTests/PortraitActionTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PortraitActionTests.cs
@@ -45,7 +45,7 @@ namespace WC3ChampionsStatisticService.UnitTests
             var portraitCommandHandler = new PortraitCommandHandler(personalSettingsRepository, playerRepo, portraitRepo);
 
             int[] validPortraits = { 5 };
-            await portraitCommandHandler.AddPortraitDefinition(validPortraits.ToList());
+            await portraitCommandHandler.AddPortraitDefinition(new PortraitsDefinitionCommand(validPortraits.ToList()));
 
             var playerTag = "cepheid#1467";
             var personalSettings = new PersonalSetting(playerTag);
@@ -74,7 +74,7 @@ namespace WC3ChampionsStatisticService.UnitTests
             var portraitCommandHandler = new PortraitCommandHandler(personalSettingsRepository, playerRepo, portraitRepo);
 
             int[] validPortraits = { 3 };
-            await portraitCommandHandler.AddPortraitDefinition(validPortraits.ToList());
+            await portraitCommandHandler.AddPortraitDefinition(new PortraitsDefinitionCommand(validPortraits.ToList()));
 
             var playerTag = "cepheid#1467";
             var personalSettings = new PersonalSetting(playerTag);
@@ -104,7 +104,7 @@ namespace WC3ChampionsStatisticService.UnitTests
             var portraitCommandHandler = new PortraitCommandHandler(personalSettingsRepository, playerRepo, portraitRepo);
             
             int[] validPortraits = { 8 };
-            await portraitCommandHandler.AddPortraitDefinition(validPortraits.ToList());
+            await portraitCommandHandler.AddPortraitDefinition(new PortraitsDefinitionCommand(validPortraits.ToList()));
 
             var listOfSettings = new List<PersonalSetting>();
             string[] playerTags = { "cepheid#1467", "modmoto#123", "toxi#4321" };
@@ -140,7 +140,7 @@ namespace WC3ChampionsStatisticService.UnitTests
             var portraitCommandHandler = new PortraitCommandHandler(personalSettingsRepository, playerRepo, portraitRepo);
 
             int[] validPortraits = { 1 , 50 , 500 , 5000 };
-            await portraitCommandHandler.AddPortraitDefinition(validPortraits.ToList());
+            await portraitCommandHandler.AddPortraitDefinition(new PortraitsDefinitionCommand(validPortraits.ToList()));
 
             var listOfSettings = new List<PersonalSetting>();
             string[] playerTags = { "cepheid#1467", "modmoto#123", "toxi#4321" };
@@ -186,7 +186,7 @@ namespace WC3ChampionsStatisticService.UnitTests
             var portraitCommandHandler = new PortraitCommandHandler(personalSettingsRepository, playerRepo, portraitRepo);
 
             int[] validPortraits = { 1 , 50 , 500 , 5000 };
-            await portraitCommandHandler.AddPortraitDefinition(validPortraits.ToList());
+            await portraitCommandHandler.AddPortraitDefinition(new PortraitsDefinitionCommand(validPortraits.ToList()));
 
             var listOfSettings = new List<PersonalSetting>();
             string[] playerTags = { "cepheid#1467", "modmoto#123", "toxi#4321" };
@@ -228,7 +228,7 @@ namespace WC3ChampionsStatisticService.UnitTests
             var portraitCommandHandler = new PortraitCommandHandler(personalSettingsRepository, playerRepo, portraitRepo);
 
             int[] validPortraits = { 5 , 50 , 500 , 5000 };
-            await portraitCommandHandler.AddPortraitDefinition(validPortraits.ToList());
+            await portraitCommandHandler.AddPortraitDefinition(new PortraitsDefinitionCommand(validPortraits.ToList()));
 
             string[] playerTags = { "cepheid#1467" };
             
@@ -275,7 +275,7 @@ namespace WC3ChampionsStatisticService.UnitTests
             var portraitCommandHandler = new PortraitCommandHandler(personalSettingsRepository, playerRepo, portraitRepo);
 
             int[] validPortraits = { 5 , 50 , 500 , 5000 };
-            await portraitCommandHandler.AddPortraitDefinition(validPortraits.ToList());
+            await portraitCommandHandler.AddPortraitDefinition(new PortraitsDefinitionCommand(validPortraits.ToList()));
 
             string[] playerTags = { "cepheid#1467" };
 
@@ -338,11 +338,14 @@ namespace WC3ChampionsStatisticService.UnitTests
         {
             var portraitRepository = new PortraitRepository(MongoClient);
             int[] portraitIds = { 1, 2, 3, 4 };
-            await portraitRepository.SaveNewPortraitDefinitions(portraitIds.ToList());
+            string[] portraitGroups = { "bronze", "silver", "gold" };
+            await portraitRepository.SaveNewPortraitDefinitions(portraitIds.ToList(), portraitGroups.ToList());
 
             var portraits = await portraitRepository.LoadPortraitDefinitions();
 
             Assert.AreEqual(4, portraits.Count);
+            Assert.AreEqual(3, portraits.First().Groups.Count());
+            Assert.AreSame(portraits.First().Id, portraits.First().Number.ToString());
         }
 
         [Test]
@@ -388,7 +391,7 @@ namespace WC3ChampionsStatisticService.UnitTests
             var portraits = await portraitRepository.LoadPortraitDefinitions();
 
             Assert.AreEqual(1, portraits.Count);
-            Assert.AreEqual(1, portraits[0].Id);
+            Assert.AreEqual(1, portraits[0].Number);
         }
 
         [Test]
@@ -415,9 +418,14 @@ namespace WC3ChampionsStatisticService.UnitTests
 
             foreach(var def in definitions)
             {
-                portraitIds.Append(def.Id);
+                portraitIds.Append(def.Number);
             }
             await portraitRepository.SaveNewPortraitDefinitions(portraitIds.ToList());
         }
+
+        // TODO
+        // Test that updating groups works
+        // more assertions that groups are correct when updating
+        // test adding duplicates with different group values
     }
 }


### PR DESCRIPTION
Portraits can now be assigned to "groups" in the database, this means we can bulk-add portraits by getting those of a certain group, e.g. for patreon tiers: "bronze" / "silver" / "gold"