### PR TITLE
endpoints case insensitive

### DIFF
--- a/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
@@ -92,14 +92,14 @@ namespace W3ChampionsStatisticService.PlayerProfiles
             int season)
         {
             return LoadAll<PlayerGameModeStatPerGateway>(t =>
-                t.Id.Contains(battleTag) &&
+                t.Id.ToLower().Contains(battleTag.ToLower()) &&
                 t.GateWay == gateWay &&
                 t.Season == season);
         }
 
         public Task<List<PlayerRaceStatPerGateway>> LoadRaceStatPerGateway(string battleTag, GateWay gateWay, int season)
         {
-            return LoadAll<PlayerRaceStatPerGateway>(t => t.Id.StartsWith($"{season}_{battleTag}_@{gateWay}"));
+            return LoadAll<PlayerRaceStatPerGateway>(t => t.Id.ToLower().StartsWith($"{season}_{battleTag.ToLower()}_@{gateWay}"));
         }
 
         public Task<PlayerRaceStatPerGateway> LoadRaceStatPerGateway(string battleTag, Race race, GateWay gateWay, int season)
@@ -114,7 +114,7 @@ namespace W3ChampionsStatisticService.PlayerProfiles
 
         public Task<PlayerOverallStats> LoadPlayerProfile(string battleTag)
         {
-            return LoadFirst<PlayerOverallStats>(p => p.BattleTag == battleTag);
+            return LoadFirst<PlayerOverallStats>(p => p.BattleTag.ToLower() == battleTag.ToLower());
         }
 
         public Task<PlayerOverview> LoadOverview(string battleTag)

--- a/W3ChampionsStatisticService/ReadModelBase/MongoDbRepositoryBase.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/MongoDbRepositoryBase.cs
@@ -31,7 +31,7 @@ namespace W3ChampionsStatisticService.ReadModelBase
 
         protected Task<T> LoadFirst<T>(string id) where T : IIdentifiable
         {
-            return LoadFirst<T>(x => x.Id == id);
+            return LoadFirst<T>(x => x.Id.ToLower() == id.ToLower());
         }
 
         protected Task Insert<T>(T element)


### PR DESCRIPTION
seanmcnabb (community dev who is building a stats tool for streams) requested that I make the endpoints which query battletag case-insensitive.

I know this has been done in at least one other endpoint, I wanted to make it universal.