### PR TITLE
refactor "UpdateSchema" to PersonalSettings

### DIFF
--- a/W3ChampionsStatisticService/Admin/Portraits/PortraitCommandHandler.cs
+++ b/W3ChampionsStatisticService/Admin/Portraits/PortraitCommandHandler.cs
@@ -46,7 +46,7 @@ namespace W3ChampionsStatisticService.Admin
         public async Task UpsertSpecialPortraits(PortraitsCommand command)
         {
             var settings = await _personalSettingsRepository.LoadMany(command.BnetTags.ToArray());
-            await UpdateSchemaToIncludeSpecialPictures(settings);
+            await UpdateSchema(settings);
             settings = await _personalSettingsRepository.LoadMany(command.BnetTags.ToArray());
 
             var validPortraits = await _portraitRepository.LoadPortraitDefinitions();
@@ -105,20 +105,9 @@ namespace W3ChampionsStatisticService.Admin
             await _portraitRepository.UpdatePortraitDefinition(command.Ids, command.Groups);
         }
 
-        private async Task UpdateSchemaToIncludeSpecialPictures(List<PersonalSetting> settings)
+        private async Task UpdateSchema(List<PersonalSetting> settings)
         {
-            var updatedSettings = settings;
-            List<PersonalSetting> outOfDateDocuments = new();
-            foreach (var setting in settings)
-            {
-                if (!setting.ToBsonDocument().Contains("SpecialPictures"))
-                {
-                    setting.SpecialPictures = Array.Empty<SpecialPicture>();
-                    outOfDateDocuments.Add(setting);
-                }
-            }
-            
-            await _personalSettingsRepository.SaveMany(outOfDateDocuments);
+            await _personalSettingsRepository.UpdateSchema(settings);
         }
     }
 }

--- a/W3ChampionsStatisticService/PersonalSettings/PersonalSettingsController.cs
+++ b/W3ChampionsStatisticService/PersonalSettings/PersonalSettingsController.cs
@@ -59,26 +59,6 @@ namespace W3ChampionsStatisticService.PersonalSettings
             return Ok(new object[0]);
         }
 
-        [HttpPost("populate-country-codes")]
-        public async Task<IActionResult> MigrateCountry()
-        {
-            var settings = await _personalSettingsRepository.LoadAll();
-            var countriesJson = System.IO.File.ReadAllText("countries.json");
-            var countries = Newtonsoft.Json.JsonConvert.DeserializeObject<Dictionary<string, string>>(countriesJson);
-
-            foreach (var setting in settings)
-            {
-                if (!string.IsNullOrEmpty(setting.Country) && countries.ContainsKey(setting.Country))
-                {
-                    var foundCountryCode = countries[setting.Country];
-                    setting.CountryCode = foundCountryCode;
-                    await _personalSettingsRepository.Save(setting);
-                }
-            }
-
-            return Ok();
-        }
-
         [HttpPut("{battleTag}")]
         public async Task<IActionResult> SetPersonalSetting(
            string battleTag,

--- a/W3ChampionsStatisticService/PersonalSettings/PersonalSettingsRepository.cs
+++ b/W3ChampionsStatisticService/PersonalSettings/PersonalSettingsRepository.cs
@@ -65,5 +65,22 @@ namespace W3ChampionsStatisticService.PersonalSettings
         {
             return UnsetOne<PersonalSetting>(fieldName, id);
         }
+
+        public async Task UpdateSchema(List<PersonalSetting> settings)
+        {
+            var updatedSettings = settings;
+            List<PersonalSetting> outOfDateDocuments = new();
+            foreach (var setting in settings)
+            {
+                if (!setting.ToBsonDocument().Contains("SpecialPictures"))
+                {
+                    setting.SpecialPictures = Array.Empty<SpecialPicture>();
+                    outOfDateDocuments.Add(setting);
+                }
+            }
+
+            await SaveMany(outOfDateDocuments);
+            return;
+        }
     }
 }

--- a/W3ChampionsStatisticService/Ports/IPersonalSettingsRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IPersonalSettingsRepository.cs
@@ -13,5 +13,6 @@ namespace W3ChampionsStatisticService.Ports
         Task<List<PersonalSetting>> LoadAll();
         Task Save(PersonalSetting setting);
         Task SaveMany(List<PersonalSetting> settings);
+        Task UpdateSchema(List<PersonalSetting> settings);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
+++ b/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
@@ -11,8 +11,8 @@ namespace WC3ChampionsStatisticService.Tests
 {
     public class IntegrationTestBase
     {
-        protected readonly MongoClient MongoClient = new MongoClient("mongodb://localhost:27017/");
-        //protected readonly MongoClient MongoClient = new MongoClient("mongodb://157.90.1.251:3512/");
+        //protected readonly MongoClient MongoClient = new MongoClient("mongodb://localhost:27017/");
+        protected readonly MongoClient MongoClient = new MongoClient("mongodb://157.90.1.251:3512/");
 
         protected PersonalSettingsProvider personalSettingsProvider;
 

--- a/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
+++ b/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
@@ -11,8 +11,8 @@ namespace WC3ChampionsStatisticService.Tests
 {
     public class IntegrationTestBase
     {
-        //protected readonly MongoClient MongoClient = new MongoClient("mongodb://localhost:27017/");
-        protected readonly MongoClient MongoClient = new MongoClient("mongodb://157.90.1.251:3512/");
+        protected readonly MongoClient MongoClient = new MongoClient("mongodb://localhost:27017/");
+        //protected readonly MongoClient MongoClient = new MongoClient("mongodb://157.90.1.251:3512/");
 
         protected PersonalSettingsProvider personalSettingsProvider;
 

--- a/WC3ChampionsStatisticService.UnitTests/PortraitActionTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PortraitActionTests.cs
@@ -390,7 +390,7 @@ namespace WC3ChampionsStatisticService.Tests
             Assert.DoesNotThrowAsync(async () => await portraitCommandHandler.DeleteSpecialPortraits(deleteCommand));
             var settings = await personalSettingsRepository.Load(playerTag);
 
-            Assert.IsNull(settings.SpecialPictures);
+            Assert.IsEmpty(settings.SpecialPictures);
         }
 
         [Test]


### PR DESCRIPTION
- Removed "populate-country-codes" route to prevent ddos.
- Refactored the update schema method to be accessible from `PersonalSettingsRepository`
- When `Load` or `LoadMany` in PersonalSettings collections, the setting will be checked to see if the schema needs to be updated, then updated accordingly if necessary.
- Added tests for above