### PR TITLE
fix(W3C-2): Add Upvotes property to PersonalSetting

### DIFF
--- a/W3ChampionsStatisticService/PersonalSettings/PersonalSetting.cs
+++ b/W3ChampionsStatisticService/PersonalSettings/PersonalSetting.cs
@@ -53,6 +53,8 @@ namespace W3ChampionsStatisticService.PersonalSettings
         public string ChatAlias { get; set; }
         public string ChatColor { get; set; }
 
+        public int Upvotes { get; set; }
+
         public AkaSettings AliasSettings { get; set; }
 
         public bool SetProfilePicture(SetPictureCommand cmd)


### PR DESCRIPTION
A Request to https://website-backend.w3champions.com/api/matches/ongoing?offset=0&gateway=20&pageSize=50&gameMode=5&map=Overall results in a 500.
It seems to be caused by the missing property Upvotes in PersonalSetting.

Fixes [W3C-2](https://w3champions.atlassian.net/browse/W3C-2)