### PR TITLE
W3 c 163 api player stats battle tag race stats

### DIFF
--- a/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
@@ -92,19 +92,19 @@ namespace W3ChampionsStatisticService.PlayerProfiles
             int season)
         {
             return LoadAll<PlayerGameModeStatPerGateway>(t =>
-                t.Id.Contains(battleTag) &&
+                t.PlayerIds.Any(player => player.BattleTag==battleTag) &&
                 t.GateWay == gateWay &&
                 t.Season == season);
         }
 
         public Task<List<PlayerRaceStatPerGateway>> LoadRaceStatPerGateway(string battleTag, GateWay gateWay, int season)
         {
-            return LoadAll<PlayerRaceStatPerGateway>(t => t.BattleTag == battleTag && t.Season == season && t.GateWay == gateWay);
+            return LoadAll<PlayerRaceStatPerGateway>(t => t.BattleTag == battleTag.ToLower() && t.Season == season && t.GateWay == gateWay);
         }
 
         public Task<PlayerRaceStatPerGateway> LoadRaceStatPerGateway(string battleTag, Race race, GateWay gateWay, int season)
         {
-            return LoadFirst<PlayerRaceStatPerGateway>(t => t.BattleTag == battleTag && t.Season == season && t.GateWay == gateWay && t.Race == race);
+            return LoadFirst<PlayerRaceStatPerGateway>(t => t.BattleTag == battleTag.ToLower() && t.Season == season && t.GateWay == gateWay && t.Race == race);
         }
 
         public Task UpsertPlayerRaceStat(PlayerRaceStatPerGateway stat)

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
@@ -99,12 +99,12 @@ namespace W3ChampionsStatisticService.PlayerProfiles
 
         public Task<List<PlayerRaceStatPerGateway>> LoadRaceStatPerGateway(string battleTag, GateWay gateWay, int season)
         {
-            return LoadAll<PlayerRaceStatPerGateway>(t => t.Id.ToLower().StartsWith($"{season}_{battleTag.ToLower()}_@{gateWay}"));
+            return LoadAll<PlayerRaceStatPerGateway>(t => t.BattleTag == battleTag && t.Season == season && t.GateWay == gateWay);
         }
 
         public Task<PlayerRaceStatPerGateway> LoadRaceStatPerGateway(string battleTag, Race race, GateWay gateWay, int season)
         {
-            return LoadFirst<PlayerRaceStatPerGateway>($"{season}_{battleTag}_@{gateWay}_{race}");
+            return LoadFirst<PlayerRaceStatPerGateway>(t => t.BattleTag == battleTag && t.Season == season && t.GateWay == gateWay && t.Race == race);
         }
 
         public Task UpsertPlayerRaceStat(PlayerRaceStatPerGateway stat)

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
@@ -109,10 +109,10 @@ namespace W3ChampionsStatisticService.PlayerProfiles
             GateWay gateWay,
             int season)
         {
-            // var wins = await _queryHandler.LoadPlayerStatsWithRanks(battleTag, gateWay, season);
+            var wins = await _queryHandler.LoadPlayerStatsWithRanks(battleTag, gateWay, season);
 
             // !!! Temp fix until index is added
-            var wins = new List<PlayerGameModeStatPerGateway>();
+            
             return Ok(wins);
         }
 
@@ -122,16 +122,15 @@ namespace W3ChampionsStatisticService.PlayerProfiles
             GateWay gateWay,
             int season)
         {
-            //var wins = await _playerRepository.LoadRaceStatPerGateway(battleTag, gateWay, season);
-            //var ordered = wins.OrderBy(s => s.Race).ToList();
-            //var firstPick = ordered.FirstOrDefault();
-            //if (firstPick?.Race != Race.RnD) return Ok(ordered);
+            var wins = await _playerRepository.LoadRaceStatPerGateway(battleTag, gateWay, season);
+            var ordered = wins.OrderBy(s => s.Race).ToList();
+            var firstPick = ordered.FirstOrDefault();
+            if (firstPick?.Race != Race.RnD) return Ok(ordered);
 
-            //ordered.Remove(firstPick);
-            //ordered.Add(firstPick);
+            ordered.Remove(firstPick);
+            ordered.Add(firstPick);
 
-            // !!! Temp fix until index is added
-            var ordered = new List<PlayerRaceStatPerGateway>();
+            
             return Ok(ordered);
         }
 

--- a/W3ChampionsStatisticService/PlayerProfiles/RaceStats/PlayerRaceStatPerGateway.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/RaceStats/PlayerRaceStatPerGateway.cs
@@ -10,6 +10,7 @@ namespace W3ChampionsStatisticService.PlayerProfiles.RaceStats
             Id = $"{season}_{battleTag}_@{gateWay}_{race}";
             Race = race;
             GateWay = gateWay;
+            BattleTag = battleTag;
             Season = season;
         }
 
@@ -17,5 +18,6 @@ namespace W3ChampionsStatisticService.PlayerProfiles.RaceStats
         public GateWay GateWay { get; set; }
         public int Season { get; set; }
         public string Id { get; set; }
+        public string BattleTag { get; set; }
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Player/PlayerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Player/PlayerTests.cs
@@ -214,14 +214,14 @@ namespace WC3ChampionsStatisticService.Tests.Player
 
             await handler.Update(ev);
 
-            var winners = await playerRepository.LoadGameModeStatPerGateway("1_peter#123@10_wolf#456@10_GM_2v2_AT", GateWay.America, 1);
-            var losers = await playerRepository.LoadGameModeStatPerGateway("1_TEAM2#123@10_TEAM2#456@10_GM_2v2_AT", GateWay.America, 1);
+            var winners = await playerRepository.LoadGameModeStatPerGateway("1_peter#123@10_wolf#456@10_GM_2v2_AT");
+            var losers = await playerRepository.LoadGameModeStatPerGateway("1_TEAM2#123@10_TEAM2#456@10_GM_2v2_AT");
 
-            Assert.AreEqual(1, winners.First(x => x.GameMode == GameMode.GM_2v2_AT).Wins);
-            Assert.AreEqual(0, winners.First(x => x.GameMode == GameMode.GM_2v2_AT).Losses);
+            Assert.AreEqual(1, winners.Wins);
+            Assert.AreEqual(0, winners.Losses);
 
-            Assert.AreEqual(1, losers.First(x => x.GameMode == GameMode.GM_2v2_AT).Losses);
-            Assert.AreEqual(0, losers.First(x => x.GameMode == GameMode.GM_2v2_AT).Wins);
+            Assert.AreEqual(1, losers.Losses);
+            Assert.AreEqual(0, losers.Wins);
         }
 
         [Test]
@@ -249,18 +249,18 @@ namespace WC3ChampionsStatisticService.Tests.Player
 
             await handler.Update(ev);
 
-            var winnerP1 = await playerRepository.LoadGameModeStatPerGateway($"1_peter#123@10_GM_2v2", GateWay.America, 1);
-            var winnerP2 = await playerRepository.LoadGameModeStatPerGateway($"1_wolf#456@10_GM_2v2", GateWay.America, 1);
-            var losers = await playerRepository.LoadGameModeStatPerGateway("1_TEAM2#123@10_TEAM2#456@10_GM_2v2_AT", GateWay.America, 1);
+            var winnerP1 = await playerRepository.LoadGameModeStatPerGateway($"1_peter#123@10_GM_2v2");
+            var winnerP2 = await playerRepository.LoadGameModeStatPerGateway($"1_wolf#456@10_GM_2v2");
+            var losers = await playerRepository.LoadGameModeStatPerGateway("1_TEAM2#123@10_TEAM2#456@10_GM_2v2_AT");
 
-            Assert.AreEqual(1, winnerP1.First(x => x.GameMode == GameMode.GM_2v2).Wins);
-            Assert.AreEqual(0, winnerP1.First(x => x.GameMode == GameMode.GM_2v2).Losses);
+            Assert.AreEqual(1, winnerP1.Wins);
+            Assert.AreEqual(0, winnerP1.Losses);
 
-            Assert.AreEqual(1, winnerP2.First(x => x.GameMode == GameMode.GM_2v2).Wins);
-            Assert.AreEqual(0, winnerP2.First(x => x.GameMode == GameMode.GM_2v2).Losses);
+            Assert.AreEqual(1, winnerP2.Wins);
+            Assert.AreEqual(0, winnerP2.Losses);
 
-            Assert.AreEqual(1, losers.First(x => x.GameMode == GameMode.GM_2v2_AT).Losses);
-            Assert.AreEqual(0, losers.First(x => x.GameMode == GameMode.GM_2v2_AT).Wins);
+            Assert.AreEqual(1, losers.Losses);
+            Assert.AreEqual(0, losers.Wins);
         }
 
         [Test]


### PR DESCRIPTION
The following database changes are needed before the fix is deployed:

 

Run the following script in mongosh to extract the battletag from the id into a separate field/property:


let requests = [];
db.PlayerRaceStatPerGateway.aggregate([
  {
    $addFields: {
      BattleTag: {
        $arrayElemAt: [
          {
            "$split": [
              {
                $toLower: "$_id"
              },
              "_"
            ]
          },
          1
        ]
      }
    }
  }
]).forEach(document => { 
    requests.push({ 
        "updateOne": { 
            "filter": { "_id": document._id }, 
            "update": { 
                "$set": { 
                    "BattleTag":document.BattleTag, 
                }
            }
        }
    });
    if ( requests.length === 500 ) { 
        // Execute per 500 ops and re-init
        db.PlayerRaceStatPerGateway.bulkWrite(requests); 
        requests = []; 
    }}
);

if(requests.length > 0) {
    db.PlayerRaceStatPerGateway.bulkWrite(requests);
}
2. Add the following index to PlayerRaceStatPerGateway:

{
    v: 2,
    key: { BattleTag: 1, GateWay: 1, Season: 1 },
    name: 'battleTag_gw_season'
  }
3. Add the following index to PlayerGameModeStatPerGateway:

{
    v: 2,
    key: { 'PlayerIds.BattleTag': 1, Season: 1, GateWay: 1 },
    name: 'Battletag_gw_season'
  }