### PR TITLE
Caching functionality for count and matchup

### DIFF
--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -30,13 +30,12 @@ namespace W3ChampionsStatisticService.Matches
             int minMmr = 0,
             int maxMmr = 3000)
         {
-            List<Matchup> matches = new List<Matchup>();
-            long count = 0;
             if (pageSize > 100) pageSize = 100;
-            //matches = await _matchRepository.Load(gateWay, gameMode, offset, pageSize, map, minMmr, maxMmr);
-            //count = await _matchRepository.Count(gateWay, gameMode, map, minMmr, maxMmr);
-            //return Ok(new { matches, count });
-            return Ok();
+            List<Matchup> matches = _matchRepository.Load(gateWay,gameMode,offset,pageSize,map,minMmr,maxMmr);
+            long count = _matchRepository.Count(gateWay, gameMode, map, minMmr, maxMmr);
+
+            
+            return Ok(new { matches, count });
         }
 
         [HttpGet("{id}")]

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -8,7 +8,7 @@ namespace W3ChampionsStatisticService.Ports
 {
     public interface IMatchRepository
     {
-        Task<List<Matchup>> Load(
+        List<Matchup> Load(
             GateWay gateWay = GateWay.Undefined,
             GameMode gameMode = GameMode.Undefined,
             int offset = 0,
@@ -17,7 +17,7 @@ namespace W3ChampionsStatisticService.Ports
             int minMmr = 0,
             int maxMmr = 3000);
 
-        Task<long> Count(
+        long Count(
             GateWay gateWay = GateWay.Undefined,
             GameMode gameMode = GameMode.Undefined,
             string map = "Overall",

--- a/W3ChampionsStatisticService/Services/MatchesProvider.cs
+++ b/W3ChampionsStatisticService/Services/MatchesProvider.cs
@@ -1,0 +1,162 @@
+﻿using MongoDB.Driver;
+using System.Collections.Generic;
+using System;
+using W3C.Domain.Repositories;
+using W3ChampionsStatisticService.Cache;
+using W3ChampionsStatisticService.PersonalSettings;
+using W3C.Domain.CommonValueObjects;
+using W3ChampionsStatisticService.Matches;
+using System.Threading.Tasks;
+using W3ChampionsStatisticService.Ports;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+
+namespace W3ChampionsStatisticService.Services
+{
+    public class MatchesProvider : MongoDbRepositoryBase
+    {
+        public static CachedData<List<PersonalSetting>> personalSettingsCache;
+        public static Dictionary<GameMode, CachedData<List<Matchup>>> _matchesCache;
+        public static Dictionary<GameMode, CachedData<long>> _matchesCountCache;
+        public MatchesProvider(MongoClient mongoClient) : base(mongoClient)
+        {
+            _matchesCache = new Dictionary<GameMode, CachedData<List<Matchup>>>();
+            _matchesCountCache = new Dictionary<GameMode, CachedData<long>>();
+            foreach (GameMode gm in Enum.GetValues(typeof(GameMode)))
+            {
+                _matchesCache.Add(gm, new CachedData<List<Matchup>>(() => FetchMatchDataSync(gm), TimeSpan.FromMinutes(1)));
+                _matchesCountCache.Add(gm, new CachedData<long>(() => FetchMatchCountSync(gm), TimeSpan.FromMinutes(1)));
+            }
+
+        }
+
+        public List<Matchup> FetchMatchDataSync(GameMode gm)
+        {
+            try
+            {
+                List<Matchup> matchups = FetchMatchData(gm).GetAwaiter().GetResult();
+                return matchups;
+            }
+            catch
+            {
+                return new List<Matchup>();
+            }
+        }
+
+
+
+        private Task<List<Matchup>> FetchMatchData(GameMode gm)
+        {
+            GameMode gameMode = gm;
+
+            GateWay gateWay = GateWay.Undefined;
+            string map = "Overall";
+            int minMmr = 0;
+            int maxMmr = 3000;
+            int offset = 0;
+            int pageSize = 500;
+            return Load(gateWay, gm, offset, pageSize, map, minMmr, maxMmr);
+        }
+        public long FetchMatchCountSync(GameMode gm)
+        {
+            try
+            {
+                return FetchMatchCount(gm).GetAwaiter().GetResult();
+
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+
+        private Task<long> FetchMatchCount(GameMode gm)
+        {
+
+            GateWay gateWay = GateWay.Undefined;
+            string map = "Overall";
+            int minMmr = 0;
+            int maxMmr = 3000;
+            return Count(gateWay, gm, map, minMmr, maxMmr);
+        }
+
+        private Task<List<Matchup>> Load(
+            GateWay gateWay = GateWay.Undefined,
+            GameMode gameMode = GameMode.Undefined,
+            int offset = 0,
+            int pageSize = 100,
+            string map = "Overall",
+            int minMmr = 0,
+            int maxMmr = 3000)
+        {
+            var mongoCollection = CreateCollection<Matchup>();
+            return mongoCollection
+                .Find(m => (gameMode == GameMode.Undefined || m.GameMode == gameMode)
+                    && (gateWay == GateWay.Undefined || m.GateWay == gateWay)
+                    && (map == "Overall" || m.Map == map))
+                .SortByDescending(s => s.EndTime)
+                .Skip(offset)
+                .Limit(pageSize)
+                .ToListAsync();
+        }
+
+        private Task<long> Count(
+            GateWay gateWay = GateWay.Undefined,
+            GameMode gameMode = GameMode.Undefined,
+            string map = "Overall",
+            int minMmr = 0,
+            int maxMmr = 3000)
+        {
+            return CreateCollection<Matchup>().CountDocumentsAsync(m =>
+                    (gameMode == GameMode.Undefined || m.GameMode == gameMode)
+                    && (gateWay == GateWay.Undefined || m.GateWay == gateWay)
+                    && (map == "Overall" || m.Map == map));
+        }
+
+        public List<Matchup> GetMatches(
+            int offset = 0,
+            int pageSize = 100,
+            GameMode gameMode = GameMode.Undefined,
+            GateWay gateWay = GateWay.Undefined,
+            string map = "Overall",
+            int minMmr = 0,
+            int maxMmr = 3000)
+        {
+            List<Matchup> matches = new List<Matchup>();
+            if (pageSize > 100) pageSize = 100;
+            if (offset < 500 && (offset + pageSize) < 501 && map == "Overall" && minMmr == 0 && maxMmr == 3000)
+            {
+                matches = _matchesCache[gameMode].GetCachedData().Skip(offset).Take(pageSize).ToList();
+            }
+            else
+            {
+                matches = Load(gateWay, gameMode, offset, pageSize, map, minMmr, maxMmr).GetAwaiter().GetResult();
+            }
+            
+
+            return  matches;
+        }
+        public long GetCount(
+            GameMode gameMode = GameMode.Undefined,
+            GateWay gateWay = GateWay.Undefined,
+            string map = "Overall",
+            int minMmr = 0,
+            int maxMmr = 3000)
+        {
+            List<Matchup> matches = new List<Matchup>();
+            long count = 0;
+            if (map == "Overall" && minMmr == 0 && maxMmr == 3000)
+            {
+                count = _matchesCountCache[gameMode].GetCachedData();
+            }
+            else
+            {
+                count = Count(gateWay, gameMode, map, minMmr, maxMmr).GetAwaiter().GetResult();
+            }
+
+
+            return count;
+        }
+    }
+    }

--- a/W3ChampionsStatisticService/Startup.cs
+++ b/W3ChampionsStatisticService/Startup.cs
@@ -61,7 +61,7 @@ namespace W3ChampionsStatisticService
             });
 
             var startHandlers = Environment.GetEnvironmentVariable("START_HANDLERS");
-            var mongoConnectionString = Environment.GetEnvironmentVariable("MONGO_CONNECTION_STRING")  ?? "mongodb://157.90.1.251:3513"; // "mongodb://localhost:27017";
+            var mongoConnectionString = Environment.GetEnvironmentVariable("MONGO_CONNECTION_STRING") ?? "mongodb://157.90.1.251:3513"; // "mongodb://localhost:27017";
 
             var mongoSettings = MongoClientSettings.FromConnectionString(mongoConnectionString.Replace("'", ""));
             mongoSettings.ServerSelectionTimeout = TimeSpan.FromSeconds(5);
@@ -78,6 +78,7 @@ namespace W3ChampionsStatisticService
             services.AddSingleton<TrackingService>();
             services.AddSingleton<PlayerAkaProvider>();
             services.AddSingleton<PersonalSettingsProvider>();
+            services.AddSingleton<MatchesProvider>();
 
             services.AddTransient<IMatchEventRepository, MatchEventRepository>();
             services.AddTransient<IVersionRepository, VersionRepository>();

--- a/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
+++ b/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
@@ -15,11 +15,12 @@ namespace WC3ChampionsStatisticService.Tests
         protected readonly MongoClient MongoClient = new MongoClient("mongodb://157.90.1.251:3512/");
 
         protected PersonalSettingsProvider personalSettingsProvider;
-
+        protected MatchesProvider matchesProvider;
         [SetUp]
         public async Task Setup()
         {
             await MongoClient.DropDatabaseAsync("W3Champions-Statistic-Service");
+            matchesProvider = new MatchesProvider(MongoClient);
             personalSettingsProvider= new PersonalSettingsProvider(MongoClient);
         }
 

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
@@ -15,7 +15,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
             var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
             matchFinishedEvent.match.id = "nmhcCLaRc7";
             matchFinishedEvent.Id = ObjectId.GenerateNewId();
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
@@ -34,7 +34,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
 
             await InsertMatchEvent(matchFinishedEvent);
 
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
@@ -58,7 +58,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
 
             await InsertMatchEvent(matchFinishedEvent);
 
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
@@ -84,7 +84,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
 
             await InsertMatchEvent(matchFinishedEvent);
 
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
@@ -110,7 +110,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
 
             await InsertMatchEvent(matchFinishedEvent);
 
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -17,21 +17,21 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [SetUp]
         public async Task SetupSut()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient,matchesProvider, new OngoingMatchesCache(MongoClient));
             await matchRepository.EnsureIndices();
         }
 
         [Test]
         public async Task LoadAndSave()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
             var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
 
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent2));
-            var matches = await matchRepository.Load();
+            var matches =  matchRepository.Load();
 
             Assert.AreEqual(2, matches.Count);
         }
@@ -39,7 +39,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task LoadAndSearch()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
             var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -63,7 +63,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task LoadAndSearch_InvalidString()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
             var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -81,13 +81,13 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task Upsert()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
 
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
-            var matches = await matchRepository.Load();
+            var matches = matchRepository.Load();
 
             Assert.AreEqual(1, matches.Count);
         }
@@ -100,7 +100,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
                 Console.WriteLine($"https://www.test.w3champions.com:{i}/login");
             }
 
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
             var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -129,7 +129,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task SearchForPlayerAndOpponent()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
             var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -154,7 +154,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task SearchForPlayerAndOpponent_FilterByGateway()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
             var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -182,7 +182,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task SearchForPlayerAndOppoRace()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
             var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -210,7 +210,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [TestCase(0, "wolf#456")]
         public async Task SearchForPlayerAndOpponent_FilterBySeason(int season, string playerTwo)
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
             var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -237,7 +237,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [TestCase(0)]
         public async Task SearchForPlayerAndOpponent_FilterBySeason_NoResults(int season)
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
 
@@ -255,7 +255,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task SearchForPlayerAndOpponent_2v2_SameTeam()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent1 = TestDtoHelper.CreateFake2v2AtEvent();
             var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -281,7 +281,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task SearchForPlayerAndOpponent_2v2()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent1 = TestDtoHelper.CreateFake2v2AtEvent();
             var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -313,7 +313,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task SearchForPlayerAndOpponent_2v2And1V1()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent1 = TestDtoHelper.CreateFake2v2AtEvent();
             var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -346,12 +346,12 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task SearchForGameMode2v2_NotFound()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
             var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
             matchFinishedEvent1.match.gameMode = GameMode.GM_1v1;
 
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
-            var matches = await matchRepository.Load(GateWay.Undefined, GameMode.GM_2v2_AT);
+            var matches = matchRepository.Load(GateWay.Undefined, GameMode.GM_2v2_AT);
 
             Assert.AreEqual(0, matches.Count);
         }
@@ -359,12 +359,12 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task SearchForGameMode2v2_Found()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
             var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
             matchFinishedEvent1.match.gameMode = GameMode.GM_2v2_AT;
 
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
-            var matches = await matchRepository.Load(GateWay.Undefined, GameMode.GM_2v2_AT);
+            var matches = matchRepository.Load(GateWay.Undefined, GameMode.GM_2v2_AT);
 
             Assert.AreEqual(1, matches.Count);
         }
@@ -372,12 +372,12 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task SearchForGameMode2v2_LoadDefault()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
             var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
             matchFinishedEvent1.match.gameMode = GameMode.GM_2v2_AT;
 
             await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
-            var matches = await matchRepository.Load();
+            var matches = matchRepository.Load();
 
             Assert.AreEqual(1, matches.Count);
         }
@@ -385,7 +385,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task ReforgedIconGetsReplaced()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
 
@@ -405,7 +405,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task Cache_AllOngoingMatches()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var storedEvent = TestDtoHelper.CreateFakeStartedEvent();
             await matchRepository.InsertOnGoingMatch(OnGoingMatchup.Create(storedEvent));
@@ -435,7 +435,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task Cache_ByPlayerId()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var storedEvent = TestDtoHelper.CreateFakeStartedEvent();
             await matchRepository.InsertOnGoingMatch(OnGoingMatchup.Create(storedEvent));
@@ -462,7 +462,7 @@ namespace WC3ChampionsStatisticService.Tests.Matchups
         [Test]
         public async Task Cache_ByPlayerId_OneTeamEmpty()
         {
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
 
             var storedEvent = TestDtoHelper.Create1v1StartedEvent();
 

--- a/WC3ChampionsStatisticService.UnitTests/Performance/DBPerformanceTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Performance/DBPerformanceTest.cs
@@ -41,7 +41,7 @@ namespace WC3ChampionsStatisticService.Tests.Matches
         [Test]
         public async Task LoadMatchesColorful()
         {
-            var matchesRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchesRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
             Stopwatch sw = new Stopwatch();
             sw.Start();
             string playerId = "COLORFUL#5214";
@@ -65,7 +65,7 @@ namespace WC3ChampionsStatisticService.Tests.Matches
         [Test]
         public async Task LoadCountColorful()
         {
-            var matchesRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchesRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
             Stopwatch sw = new Stopwatch();
             sw.Start();
             string playerId = "COLORFUL#5214";
@@ -89,7 +89,7 @@ namespace WC3ChampionsStatisticService.Tests.Matches
         [Test]
         public async Task LoadMatchesShaDe()
         {
-            var matchesRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchesRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
             Stopwatch sw = new Stopwatch();
             sw.Start();
             string playerId = "ShaDeFaDe#2441";
@@ -113,7 +113,7 @@ namespace WC3ChampionsStatisticService.Tests.Matches
         [Test]
         public async Task LoadCountShaDe()
         {
-            var matchesRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchesRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
             Stopwatch sw = new Stopwatch();
             sw.Start();
             string playerId = "ShaDeFaDe#2441";

--- a/WC3ChampionsStatisticService.UnitTests/ReadModel/ReadModelHandlerBaseTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/ReadModel/ReadModelHandlerBaseTests.cs
@@ -99,7 +99,7 @@ namespace WC3ChampionsStatisticService.Tests.ReadModel
 
             await InsertMatchEvents(new List<MatchFinishedEvent> { fakeEvent1, fakeEvent2, fakeEvent3, fakeEvent4, fakeEvent5 });
 
-            var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+            var matchRepository = new MatchRepository(MongoClient, matchesProvider, new OngoingMatchesCache(MongoClient));
             var versionRepository = new VersionRepository(MongoClient);
 
             var handler = new ReadModelHandler<MatchReadModelHandler>(
@@ -111,7 +111,7 @@ namespace WC3ChampionsStatisticService.Tests.ReadModel
 
             var version = await versionRepository.GetLastVersion<MatchReadModelHandler>();
 
-            var matches = await matchRepository.Load();
+            var matches = matchRepository.Load();
 
             Assert.AreEqual(1, version.Season);
             Assert.AreEqual(fakeEvent5.Id.ToString(), version.Version);


### PR DESCRIPTION
Added caching for heavy load endpoints. First 500 records for all gamemodes are cached. Count is also cached.