### PR TITLE
Set PlayerChatBanTimestamp to use uint instead of int to avoid overflow

### DIFF
--- a/W3ChampionsStatisticService/Admin/GlobalChatBan.cs
+++ b/W3ChampionsStatisticService/Admin/GlobalChatBan.cs
@@ -45,7 +45,7 @@ namespace W3ChampionsStatisticService.Admin
 
     public class PlayerChatBanTimestamp 
     {
-        public int seconds { get; set; }
+        public uint seconds { get; set; }
         public int nanos { get; set; }
     }
 


### PR DESCRIPTION
A mute-ban expiry date at year 2060 causes an Int32 overflow.
```
Microsoft.AspNetCore.Server.Kestrel: Error: Connection id "0HMOPIIQO8HN7", Request id "0HMOPIIQO8HN7:00000003": An unhandled exception was thrown by the application.

Newtonsoft.Json.JsonReaderException: JSON integer 2871072000 is too large or small for an Int32. Path 'player_bans[66].ban_expires_at.seconds', line 1, position 13905.
```

A signed integer can only hold a value of 2,147,483,648, so 2,871,072,000 caused overflow. Changed to uint (unsigned int) to allow values up to 4,294,967,295 (year 2106).

![image](https://user-images.githubusercontent.com/21004208/221884706-2a0ba348-5bf3-4703-8457-dd05a411e548.png)
