### PR TITLE
fix case when mapAndRaceStat is null

### DIFF
--- a/W3ChampionsStatisticService/PlayerStats/PlayerStatsController.cs
+++ b/W3ChampionsStatisticService/PlayerStats/PlayerStatsController.cs
@@ -23,8 +23,8 @@ namespace W3ChampionsStatisticService.PlayerStats
         [HttpGet("{battleTag}/race-on-map-versus-race")]
         public async Task<IActionResult> GetRaceOnMapVersusRaceStat([FromRoute] string battleTag, int season)
         {
-            var matches = await _playerStatisticsService.GetMapAndRaceStatAsync(battleTag, season);
-            return Ok(matches ?? PlayerRaceOnMapVersusRaceRatioView.Create(battleTag, season));
+            var stats = await _playerStatisticsService.GetMapAndRaceStatAsync(battleTag, season);
+            return Ok(stats);
         }
 
         [HttpGet("{battleTag}/hero-on-map-versus-race")]

--- a/W3ChampionsStatisticService/PlayerStats/RaceOnMapVersusRaceStats/PlayerRaceOnMapVersusRaceRatio.cs
+++ b/W3ChampionsStatisticService/PlayerStats/RaceOnMapVersusRaceStats/PlayerRaceOnMapVersusRaceRatio.cs
@@ -20,7 +20,7 @@ namespace W3ChampionsStatisticService.PlayerStats.RaceOnMapVersusRaceStats
         public string Id { get; set; }
         public MapWinsPerRaceList RaceWinsOnMap { get; set; } = MapWinsPerRaceList.Create();
 
-        public Dictionary<string, MapWinsPerRaceList> RaceWinsOnMapByPatch { get; set; }
+        public Dictionary<string, MapWinsPerRaceList> RaceWinsOnMapByPatch { get; set; } = new Dictionary<string, MapWinsPerRaceList>();
 
         public string BattleTag { get; set; }
         public int Season { get; set; }

--- a/W3ChampionsStatisticService/PlayerStats/RaceOnMapVersusRaceStats/PlayerRaceOnMapVersusRaceRatioView.cs
+++ b/W3ChampionsStatisticService/PlayerStats/RaceOnMapVersusRaceStats/PlayerRaceOnMapVersusRaceRatioView.cs
@@ -6,15 +6,15 @@ namespace W3ChampionsStatisticService.PlayerStats.RaceOnMapVersusRaceStats
 {
     public class PlayerRaceOnMapVersusRaceRatioView
     {
-        public static PlayerRaceOnMapVersusRaceRatioView Create(PlayerRaceOnMapVersusRaceRatio battleTag, SeasonMapInformation mapNames)
+        public static PlayerRaceOnMapVersusRaceRatioView Create(PlayerRaceOnMapVersusRaceRatio player, SeasonMapInformation mapNames)
         {
             var mapVersusRaceRatioView = new PlayerRaceOnMapVersusRaceRatioView
             {
-                Id = battleTag.Id,
-                BattleTag = battleTag.BattleTag,
-                Season = battleTag.Season,
-                RaceWinsOnMap = battleTag.RaceWinsOnMap,
-                RaceWinsOnMapByPatch = battleTag.RaceWinsOnMapByPatch
+                Id = player.Id,
+                BattleTag = player.BattleTag,
+                Season = player.Season,
+                RaceWinsOnMap = player.RaceWinsOnMap,
+                RaceWinsOnMapByPatch = player.RaceWinsOnMapByPatch
             };
 
             foreach (var winLossesPerMap in mapVersusRaceRatioView.RaceWinsOnMap
@@ -33,9 +33,9 @@ namespace W3ChampionsStatisticService.PlayerStats.RaceOnMapVersusRaceStats
             return mapVersusRaceRatioView;
         }
 
-        public static PlayerRaceOnMapVersusRaceRatioView Create(string battleTag, int mapNames)
+        public static PlayerRaceOnMapVersusRaceRatioView Create(string battleTag, int season)
         {
-            return Create(PlayerRaceOnMapVersusRaceRatio.Create(battleTag, mapNames), SeasonMapInformation.Empty);
+            return Create(PlayerRaceOnMapVersusRaceRatio.Create(battleTag, season), SeasonMapInformation.Empty);
         }
 
         public string Id { get; set; }

--- a/W3ChampionsStatisticService/Services/PlayerStatsService.cs
+++ b/W3ChampionsStatisticService/Services/PlayerStatsService.cs
@@ -32,7 +32,9 @@ namespace W3ChampionsStatisticService.Services
 
             var mapInformation = await FetchMapNamesAsync();
 
-            return PlayerRaceOnMapVersusRaceRatioView.Create(mapAndRaceStat, mapInformation);
+            return mapAndRaceStat == null ?
+            PlayerRaceOnMapVersusRaceRatioView.Create(battleTag, season) :
+            PlayerRaceOnMapVersusRaceRatioView.Create(mapAndRaceStat, mapInformation);
         }
 
         private async Task<SeasonMapInformation> FetchMapNamesAsync()


### PR DESCRIPTION
If a player has not played any 1v1 matches this season, `var mapAndRaceStat = await _playerStatsRepository.LoadMapAndRaceStat(battleTag, season);` in `W3ChampionsStatisticService/Services/PlayerStatsService.cs` is null, and we get a 500 error.

![2023-03-06_14-40](https://user-images.githubusercontent.com/21004208/223126724-ff4e05c4-07bc-4b91-b146-0ffd17effbec.png)
