### PR TITLE
Upgrade swagger from v5.6.3 to v6.4.0

### DIFF
--- a/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
+++ b/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
@@ -10,9 +10,9 @@
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.6.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.6.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.6.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="countries.json">


### PR DESCRIPTION
Making this PR instead of dependabot's PR https://github.com/w3champions/website-backend/pull/220 because it only wanted to upgrade `Swashbuckle.AspNetCore.SwaggerUI` but not `Swashbuckle.AspNetCore.SwaggerGen` and `Swashbuckle.AspNetCore.Swagger`.