### PR TITLE
feat: add handler for player game length statistic

### DIFF
--- a/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
@@ -12,6 +12,7 @@ using W3ChampionsStatisticService.PlayerProfiles.RaceStats;
 using W3ChampionsStatisticService.Ports;
 using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.PlayerProfiles.GlobalSearch;
+using W3ChampionsStatisticService.PlayerStats.GameLengthForPlayerStatistics;
 
 namespace W3ChampionsStatisticService.PlayerProfiles;
 
@@ -144,5 +145,40 @@ public class PlayerRepository : MongoDbRepositoryBase, IPlayerRepository
     public Task UpsertPlayerMmrRpTimeline(PlayerMmrRpTimeline mmrRpTimeline)
     {
         return Upsert(mmrRpTimeline);
+    }
+    
+    public Task<PlayerGameLength> LoadGameLengthForPlayerStats(string battleTag, int season)
+    {
+        var compoundId = PlayerGameLength.compoundId(battleTag, season);
+        return LoadFirst<PlayerGameLength>(compoundId);
+    }
+
+    public async Task<PlayerGameLength> LoadOrCreateGameLengthForPlayerStats(string battleTag, int season)
+    {
+        var mongoCollection = CreateCollection<PlayerGameLength>();
+        var compoundId = PlayerGameLength.compoundId(battleTag, season);
+
+        var gameLengthsForPlayer = await mongoCollection.Find(s =>
+                s.Id == compoundId)
+            .ToListAsync();
+
+        if (gameLengthsForPlayer.Count > 0) {
+          return gameLengthsForPlayer[0];
+        }
+
+        return new PlayerGameLength {
+            AllGamesLengths = new List<int>(),
+            AverageGameLength = 0,
+            BattleTag = battleTag,
+            Season = season,
+            PlayerGameLengthsIntervals = PlayerGameLengthStat.Create(),
+            PlayerGameLengthIntervalByOpponentRace = new Dictionary<string, PlayerGameLengthStat>(),
+            GameLengthsByOpponentRace = new Dictionary<string, List<int>>(),
+            AverageGameLengthByOpponentRace = new Dictionary<string, int>()
+        };
+    }
+    public Task Save(PlayerGameLength gameLengthStats)
+    {
+        return Upsert(gameLengthStats);
     }
 }

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
@@ -164,6 +164,13 @@ public class PlayersController : ControllerBase
         var player = await _playerAkaProvider.GetPlayerAkaDataAsync(battleTag.ToLower());
         return Ok(player);
     }
+
+    [HttpGet("{battleTag}/game-length-stats")]
+    public async Task<IActionResult> GetPlayerGameLengthStats([FromRoute] string battleTag, int season)
+    {
+        var lengthStats = await _playerRepository.LoadGameLengthForPlayerStats(battleTag, season);
+        return Ok(lengthStats);
+    }
 }
 
 public class ProfilePictureDto

--- a/W3ChampionsStatisticService/PlayerStats/GameLengthForPlayerStatistics/GameLengthForPlayerStatisticsHandler.cs
+++ b/W3ChampionsStatisticService/PlayerStats/GameLengthForPlayerStatistics/GameLengthForPlayerStatisticsHandler.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading.Tasks;
+using W3C.Domain.MatchmakingService;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Contracts.Matchmaking;
+
+namespace W3ChampionsStatisticService.PlayerStats.GameLengthForPlayerStatistics;
+public class GameLengthForPlayerStatisticsHandler : IReadModelHandler
+{
+    private readonly IPlayerRepository _playerRepo;
+
+    public GameLengthForPlayerStatisticsHandler(
+        IPlayerRepository playerRepo
+        )
+    {
+        _playerRepo = playerRepo;
+    }
+
+    public async Task Update(MatchFinishedEvent nextEvent)
+    {
+        if (nextEvent.WasFakeEvent || nextEvent.match.gameMode != GameMode.GM_1v1) return;
+
+        for (var i = 0; i < 2; i++) {
+            var players = nextEvent.match.players;
+            var player = players[i];
+            var opponent = i == 0 ? players[1] : players[0];
+            var opponentRace = opponent.race;
+            var battleTag = player.battleTag;
+            var endTime = DateTimeOffset.FromUnixTimeMilliseconds(nextEvent.match.endTime);
+            var startTime = DateTimeOffset.FromUnixTimeMilliseconds(nextEvent.match.startTime);
+            var duration = endTime - startTime;
+            var season = nextEvent.match.season;
+            PlayerGameLength gameLengthStats = await _playerRepo.LoadOrCreateGameLengthForPlayerStats(battleTag, season);
+            gameLengthStats.AddGameLength((int)duration.TotalSeconds, (int)opponentRace);
+            await _playerRepo.Save(gameLengthStats);
+        }
+    }
+}

--- a/W3ChampionsStatisticService/PlayerStats/GameLengthForPlayerStatistics/PlayerGameLengthStat.cs
+++ b/W3ChampionsStatisticService/PlayerStats/GameLengthForPlayerStatistics/PlayerGameLengthStat.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using W3ChampionsStatisticService.W3ChampionsStats.GameLengths;
+
+namespace W3ChampionsStatisticService.PlayerStats.GameLengthForPlayerStatistics;
+
+public class PlayerGameLengthStat
+{
+    // the dictionary key is the interval start: 0, 30, 60, 90, 120..
+    // the dictionary value is the number of games
+    public Dictionary<string, int> Lengths { get; set; }
+
+    public void Record(int duration)
+    {
+        var groupInterval = 30;
+        var maxGroupValue = 120;
+        var group = (int)duration / groupInterval;
+        group = group > maxGroupValue ? maxGroupValue : group;
+        group*=30;
+        var groupString = group.ToString();
+        if (!Lengths.ContainsKey(groupString)) {
+            Lengths.Add(groupString, 0);
+        }
+        Lengths[groupString]++;
+    }
+
+    public void Apply(int duration)
+    {
+        Record(duration);
+    }
+
+    public static PlayerGameLengthStat Create()
+    {
+        return new PlayerGameLengthStat
+        {
+            Lengths = new Dictionary<string, int>()
+        };
+    }
+}

--- a/W3ChampionsStatisticService/Ports/IPlayerRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IPlayerRepository.cs
@@ -7,6 +7,7 @@ using W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
 using W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 using W3ChampionsStatisticService.PlayerProfiles.RaceStats;
 using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.PlayerStats.GameLengthForPlayerStatistics;
 
 namespace W3ChampionsStatisticService.Ports;
 
@@ -31,4 +32,7 @@ public interface IPlayerRepository
     Task UpsertPlayerMmrRpTimeline(PlayerMmrRpTimeline mmrRpTimeline);
     Task<List<PlayerOverview>> LoadOverviews(int season);
     Task<Dictionary<string, PlayerOverallStats>> GetPlayerBattleTagsAsync(ICollection<string> personalSettingIds);
+    Task<PlayerGameLength> LoadGameLengthForPlayerStats(string battleTag, int season);
+    Task<PlayerGameLength> LoadOrCreateGameLengthForPlayerStats(string battleTag, int season);
+    Task Save(PlayerGameLength gameLengthStats);
 }

--- a/W3ChampionsStatisticService/Startup.cs
+++ b/W3ChampionsStatisticService/Startup.cs
@@ -35,6 +35,7 @@ using W3ChampionsStatisticService.Services;
 using W3ChampionsStatisticService.W3ChampionsStats;
 using W3ChampionsStatisticService.W3ChampionsStats.DistinctPlayersPerDays;
 using W3ChampionsStatisticService.W3ChampionsStats.GameLengths;
+using W3ChampionsStatisticService.W3ChampionsStats.GameLengthForPlayerStatistics;
 using W3ChampionsStatisticService.W3ChampionsStats.GamesPerDays;
 using W3ChampionsStatisticService.W3ChampionsStats.HeroPlayedStats;
 using W3ChampionsStatisticService.W3ChampionsStats.HeroWinrate;
@@ -160,6 +161,7 @@ public class Startup
             // General Stats
             services.AddReadModelService<GamesPerDayHandler>();
             services.AddReadModelService<GameLengthStatHandler>();
+            services.AddReadModelService<GameLengthForPlayerStatisticsHandler>();
             services.AddReadModelService<DistinctPlayersPerDayHandler>();
             services.AddReadModelService<PopularHoursStatHandler>();
             services.AddReadModelService<HeroPlayedStatHandler>();

--- a/WC3ChampionsStatisticService.UnitTests/Player/PlayerGameLengthStatsTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Player/PlayerGameLengthStatsTests.cs
@@ -1,0 +1,92 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Domain.MatchmakingService;
+using W3ChampionsStatisticService.W3ChampionsStats;
+using W3ChampionsStatisticService.PlayerStats.GameLengthForPlayerStatistics;
+using W3ChampionsStatisticService.PlayerProfiles;
+
+namespace WC3ChampionsStatisticService.Tests.Statistics;
+
+[TestFixture]
+public class PlayerGameLengthStatsTests : IntegrationTestBase
+{
+    [Test]
+    public async Task PlayerGameLengthStats_GamesLengthsAreOK()
+    {
+        var playerRepo = new PlayerRepository(MongoClient);
+        var gameLengthForPlayerStatHandler = new GameLengthForPlayerStatisticsHandler(playerRepo);
+
+        var mfe1 = CreateMatchFinishedEvent("mad#1", "crazy#1", 5, 1699448621000, 1699448626000, Race.HU, Race.NE);
+        var mfe2 = CreateMatchFinishedEvent("mad#1", "crazy#2", 5, 1699448621000, 1699448636000, Race.HU, Race.NE);
+        var mfe3 = CreateMatchFinishedEvent("mad#1", "crazy#2", 5, 1699448621000, 1699448636000, Race.HU, Race.UD);
+        var mfe4 = CreateMatchFinishedEvent("mad#1", "crazy#1", 5, 1699448621000, 1699448626000, Race.HU, Race.UD);
+
+        await gameLengthForPlayerStatHandler.Update(mfe1);
+        await gameLengthForPlayerStatHandler.Update(mfe2);
+        await gameLengthForPlayerStatHandler.Update(mfe3);
+        await gameLengthForPlayerStatHandler.Update(mfe4);
+
+        var gameLengthForPlayerStatistic1 = await playerRepo.LoadGameLengthForPlayerStats("mad#1", 5);
+
+        var sumOpponentRaceLengths =
+            gameLengthForPlayerStatistic1.GameLengthsByOpponentRace[Race.NE.ToString("D")].Count 
+            + gameLengthForPlayerStatistic1.GameLengthsByOpponentRace[Race.UD.ToString("D")].Count;
+
+        // check first element
+        Assert.AreEqual(5, gameLengthForPlayerStatistic1.AllGamesLengths[0]);
+        
+        // check count of lengths
+        Assert.AreEqual(4, gameLengthForPlayerStatistic1.AllGamesLengths.Count);
+        Assert.AreEqual(sumOpponentRaceLengths, gameLengthForPlayerStatistic1.AllGamesLengths.Count);
+        Assert.AreEqual(2, gameLengthForPlayerStatistic1.GameLengthsByOpponentRace[Race.NE.ToString("D")].Count);
+        Assert.AreEqual(2, gameLengthForPlayerStatistic1.GameLengthsByOpponentRace[Race.UD.ToString("D")].Count);
+        
+        // check avg
+        Assert.AreEqual(10, gameLengthForPlayerStatistic1.AverageGameLength);
+        Assert.AreEqual(10, gameLengthForPlayerStatistic1.AverageGameLengthByOpponentRace[Race.NE.ToString("D")]);
+        Assert.AreEqual(10, gameLengthForPlayerStatistic1.AverageGameLengthByOpponentRace[Race.UD.ToString("D")]);
+        
+        // should not have key that did not play against
+        Assert.False(gameLengthForPlayerStatistic1.AverageGameLengthByOpponentRace.ContainsKey(Race.HU.ToString("D")));
+        Assert.False(gameLengthForPlayerStatistic1.GameLengthsByOpponentRace.ContainsKey(Race.HU.ToString("D")));
+        
+        // check intervals
+        Assert.AreEqual(4, gameLengthForPlayerStatistic1.PlayerGameLengthsIntervals.Lengths["0"]);
+        Assert.AreEqual(2, gameLengthForPlayerStatistic1.PlayerGameLengthIntervalByOpponentRace[Race.NE.ToString("D")].Lengths["0"]);
+        Assert.AreEqual(2, gameLengthForPlayerStatistic1.PlayerGameLengthIntervalByOpponentRace[Race.UD.ToString("D")].Lengths["0"]);
+
+        // should not have key that did not play against
+        Assert.False(gameLengthForPlayerStatistic1.PlayerGameLengthIntervalByOpponentRace.ContainsKey(Race.HU.ToString("D")));
+
+        // assure generated data for opponent as well
+        var gameLengthForPlayerStatistic2 = await playerRepo.LoadGameLengthForPlayerStats("crazy#2", 5);
+        Assert.AreEqual(2, gameLengthForPlayerStatistic2.AllGamesLengths.Count);
+        Assert.AreEqual(15, gameLengthForPlayerStatistic2.AllGamesLengths[0]);
+        Assert.AreEqual(15, gameLengthForPlayerStatistic2.AverageGameLength);
+        Assert.AreEqual(2, gameLengthForPlayerStatistic2.GameLengthsByOpponentRace[Race.HU.ToString("D")].Count);
+        Assert.AreEqual(15, gameLengthForPlayerStatistic2.AverageGameLengthByOpponentRace[Race.HU.ToString("D")]);
+        Assert.False(gameLengthForPlayerStatistic2.AverageGameLengthByOpponentRace.ContainsKey(Race.UD.ToString("D")));
+        Assert.False(gameLengthForPlayerStatistic2.GameLengthsByOpponentRace.ContainsKey(Race.NE.ToString("D")));
+    }
+
+    private MatchFinishedEvent CreateMatchFinishedEvent(
+        string btag1,
+        string btag2,
+        int season,
+        long startTime,
+        long endTime,
+        Race race1,
+        Race race2)
+    {
+        var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
+        matchFinishedEvent.match.players[0].battleTag = btag1;
+        matchFinishedEvent.match.players[1].battleTag = btag2;
+        matchFinishedEvent.match.players[0].race = race1;
+        matchFinishedEvent.match.players[1].race = race2;
+        matchFinishedEvent.match.startTime = startTime;
+        matchFinishedEvent.match.endTime = endTime;
+        matchFinishedEvent.match.season = season;
+        return matchFinishedEvent;
+    }
+}


### PR DESCRIPTION
Adds handler for generating game length statistics per player

The model of the mongo document is the following.

![image](https://github.com/w3champions/website-backend/assets/13929995/1f688c5f-9bf9-461d-944e-9291f98c5870)

10k documents of test base takes approximately 5MB of storage.
