### PR TITLE
W3CStatsController Create GetRecentRaceVersusRaceStat

### DIFF
--- a/W3ChampionsStatisticService/Services/W3StatsService.cs
+++ b/W3ChampionsStatisticService/Services/W3StatsService.cs
@@ -1,0 +1,69 @@
+ using System.Collections.Generic;
+ using System.Linq;
+ using System.Threading.Tasks;
+ using W3ChampionsStatisticService.Ports;
+ using System;
+ using W3ChampionsStatisticService.W3ChampionsStats.OverallRaceAndWinStats;
+ using System.Text.RegularExpressions;
+
+ namespace W3ChampionsStatisticService.Services;
+
+ public class W3StatsService
+ {
+
+   private readonly IW3StatsRepo _w3StatsRepo;
+
+   public W3StatsService(IW3StatsRepo w3StatsRepo)
+     {
+         _w3StatsRepo = w3StatsRepo;
+     }
+
+   public async Task<List<OverallRaceAndWinStat>> LoadNRaceVsRaceStats(int n = 3)
+     {
+         var overallRaceAndWinStats = await _w3StatsRepo.LoadRaceVsRaceStats();
+         var nRaceAndWinStats = new List<OverallRaceAndWinStat>();
+         var nPatchNames = new HashSet<String>();
+
+         foreach(var overallRaceAndWinPerStat in overallRaceAndWinStats)
+         {
+             var recentOverallRaceAndWinPerStat = new OverallRaceAndWinStat(overallRaceAndWinPerStat.MmrRange);
+             var patchNames = overallRaceAndWinPerStat.PatchToStatsPerModes.Keys.ToList();
+
+             if (nPatchNames.Count == 0)
+             {
+                 nPatchNames = GetNPatchNames(patchNames, n, true);
+             }
+             var nPatchToStatsPerModes = overallRaceAndWinPerStat.PatchToStatsPerModes.Where(kv => nPatchNames.Contains(kv.Key)).ToDictionary(kv => kv.Key, kv => kv.Value);
+             recentOverallRaceAndWinPerStat.PatchToStatsPerModes = nPatchToStatsPerModes;
+             nRaceAndWinStats.Add(recentOverallRaceAndWinPerStat);
+         }
+         return nRaceAndWinStats;
+     }
+
+     private HashSet<String> GetNPatchNames(List<String> allVersionPatchNames, int n = 3, bool includeAll = true)
+     {
+         // Define a regular expression pattern for valid version numbers
+         var validVersionNamePattern = @"^\d+(\.\d+)*$";
+
+         // Filter out invalid version numbers (Eg: "All")
+         var validVersionNames = allVersionPatchNames
+         .Where(v => Regex.IsMatch(v, validVersionNamePattern))
+         .ToList();
+         var invalidVersionNames = allVersionPatchNames
+         .Where(v => !Regex.IsMatch(v, validVersionNamePattern))
+         .ToList();
+
+         var sortedVersions = validVersionNames
+             .Select(Version.Parse) // Convert strings to Version objects
+             .OrderByDescending(v => v)     // Sort versions in descending order
+             .Take(n)
+             .Select(v => v.ToString())
+             .ToList();
+
+         var nPatchNames = new HashSet<string>(sortedVersions);
+         nPatchNames.UnionWith(invalidVersionNames);
+
+         return nPatchNames;
+     }
+
+ }

--- a/W3ChampionsStatisticService/Startup.cs
+++ b/W3ChampionsStatisticService/Startup.cs
@@ -141,6 +141,7 @@ public class Startup
         services.AddTransient<IFriendRepository, FriendRepository>();
         services.AddTransient<PlayerStatisticsService>();
         services.AddTransient<PlayerService>();
+        services.AddTransient<W3StatsService>();
         services.AddTransient<IPermissionsRepository, PermissionsRepository>();
         services.AddTransient<ILogsRepository, LogsRepository>();
 

--- a/W3ChampionsStatisticService/W3ChampionsStats/W3CStatsController.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/W3CStatsController.cs
@@ -19,23 +19,33 @@ public class W3CStatsController : ControllerBase
     private readonly HeroStatsQueryHandler _heroStatsQueryHandler;
     private readonly MmrDistributionHandler _mmrDistributionHandler;
     private readonly PlayerStatisticsService _statisticsService;
+    private readonly W3StatsService _w3StatsService;
 
     public W3CStatsController(
         IW3StatsRepo w3StatsRepo,
         HeroStatsQueryHandler heroStatsQueryHandler,
         MmrDistributionHandler mmrDistributionHandler,
-        PlayerStatisticsService statisticsService)
+        PlayerStatisticsService statisticsService,
+        W3StatsService w3StatsService)
     {
         _w3StatsRepo = w3StatsRepo;
         _heroStatsQueryHandler = heroStatsQueryHandler;
         _mmrDistributionHandler = mmrDistributionHandler;
         _statisticsService = statisticsService;
+        _w3StatsService = w3StatsService;
     }
 
     [HttpGet("map-race-wins")]
     public async Task<IActionResult> GetRaceVersusRaceStat()
     {
         var stats = await _w3StatsRepo.LoadRaceVsRaceStats();
+        return Ok(stats);
+    }
+
+    [HttpGet("map-race-recent-wins")]
+    public async Task<IActionResult> GetRecentRaceVersusRaceStat()
+    {
+        var stats = await _w3StatsService.LoadNRaceVsRaceStats();
         return Ok(stats);
     }
 

--- a/W3ChampionsStatisticService/W3ChampionsStats/W3CStatsController.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/W3CStatsController.cs
@@ -26,7 +26,8 @@ public class W3CStatsController : ControllerBase
         HeroStatsQueryHandler heroStatsQueryHandler,
         MmrDistributionHandler mmrDistributionHandler,
         PlayerStatisticsService statisticsService,
-        W3StatsService w3StatsService)
+        W3StatsService w3StatsService
+        )
     {
         _w3StatsRepo = w3StatsRepo;
         _heroStatsQueryHandler = heroStatsQueryHandler;
@@ -43,9 +44,9 @@ public class W3CStatsController : ControllerBase
     }
 
     [HttpGet("map-race-recent-wins")]
-    public async Task<IActionResult> GetRecentRaceVersusRaceStat()
+    public async Task<IActionResult> GetRecentRaceVersusRaceStat(int n = 3)
     {
-        var stats = await _w3StatsService.LoadNRaceVsRaceStats();
+        var stats = await _w3StatsService.LoadNRaceVsRaceStats(n);
         return Ok(stats);
     }
 

--- a/W3ChampionsStatisticService/W3ChampionsStats/W3StatsRepo.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/W3StatsRepo.cs
@@ -2,6 +2,7 @@ using MongoDB.Driver;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.Repositories;

--- a/W3ChampionsStatisticService/W3ChampionsStats/W3StatsRepo.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/W3StatsRepo.cs
@@ -2,7 +2,6 @@ using MongoDB.Driver;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.Repositories;


### PR DESCRIPTION
**IGNORE THIS PR. Will need to update. Will update existing make-race-wins and have the query parameters directly. By default, will have no behavior change. Also, no longer facing issue so this PR isn't needed.**

What it does: Prepare faster stats tab with limited patch history. By default limits to 3 most recent patch + names that cannot be parsed as patch (eg: All)

**TODO**: Update FE code to call "map-race-recent-wins" instead of "map-race-wins". Or just have this on map-race-wins by default.

GetRecentRaceVersusRaceStat(int n = 3)

I think https://www.w3champions.com/OverallStatistics/winrates-per-race-and-map page is too inefficient at calls nowadays
It looks like that page calls all the tabs without needing to. If that change is too difficult, I think we should at least do some filtering on
https://website-backend.w3champions.com/api/w3c-stats/map-race-wins

maybe by default only return the 3 most recent balance patches or something (to keep it simple). Seems the javascript page cannot take that much data.

A simple GET request javascript page shouldnt need to take multiple minutes.

ofc ideally we want to only call when necessary but that might be too much work for a volunteer work site.

is the codebase for w3c available? Just annoyed by how slow that page is. 611k lines of json code in one get request call doesnt seem ideal.

the laziest/shortest way to fix without touching FE is to just have BE only pass in 3 most recent patches or whatever for now (no need even for query parameters, etc). That can be done in like a few minutes top. I'm not expecting much (no need to modify FE code to optimize calls per button or whatever)

-
Since this a document database (mongodb), there's no way not to get all the data as 1 document in the BE to database call. But there's nothing stopping BE from sending filtered data to the FE.

![image](https://github.com/w3champions/website-backend/assets/12979442/40828d27-8cf2-43b5-86ee-3a3f6515e1ae)
![image](https://github.com/w3champions/website-backend/assets/12979442/9a85db45-1d07-4958-b004-d8ac8e280d45)


Testing (screw unit test cause no one else has it)
<img width="2056" alt="image" src="https://github.com/w3champions/website-backend/assets/12979442/9c04c449-634c-44b5-a12a-7acb9fbcebb0">
