### PR TITLE
add missing filtering to finished games for #348

### DIFF
--- a/W3ChampionsStatisticService/Matches/MatchRepository.cs
+++ b/W3ChampionsStatisticService/Matches/MatchRepository.cs
@@ -154,6 +154,7 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
     }
 
     public Task<List<Matchup>> Load(int season,
+        GateWay gateWay,
         GameMode gameMode,
         int offset = 0,
         int pageSize = 100,
@@ -161,7 +162,10 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
     {
         var mongoCollection = CreateCollection<Matchup>();
         return mongoCollection
-            .Find(m => gameMode == m.GameMode && m.Season == season && (map == "Overall" || m.Map == map))
+            .Find(m => gameMode == m.GameMode &&
+                       m.Season == season &&
+                       (map == "Overall" || m.Map == map) &&
+                       (gateWay == GateWay.Undefined || m.GateWay == gateWay))
             .SortByDescending(s => s.EndTime)
             .Skip(offset)
             .Limit(pageSize)
@@ -175,13 +179,16 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
         return (match == null || match.FloMatchId == null) ? 0 : match.FloMatchId.Value;
     }
 
-    public Task<long> Count(
-        int season,
+    public Task<long> Count(int season,
+        GateWay gateWay,
         GameMode gameMode,
         string map = "Overall")
     {
         return CreateCollection<Matchup>().CountDocumentsAsync(m =>
-                gameMode == m.GameMode && m.Season == season && (map == "Overall" || m.Map == map));
+                gameMode == m.GameMode &&
+                m.Season == season &&
+                (map == "Overall" || m.Map == map) &&
+                (gateWay == GateWay.Undefined || m.GateWay == gateWay));
     }
 
     public Task InsertOnGoingMatch(OnGoingMatchup matchup)

--- a/W3ChampionsStatisticService/Matches/MatchRepository.cs
+++ b/W3ChampionsStatisticService/Matches/MatchRepository.cs
@@ -153,15 +153,15 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
             playerBlizzard.teamIndex);
     }
 
-    public Task<List<Matchup>> Load(
-        int season,
+    public Task<List<Matchup>> Load(int season,
         GameMode gameMode,
         int offset = 0,
-        int pageSize = 100)
+        int pageSize = 100,
+        string map = "Overall")
     {
         var mongoCollection = CreateCollection<Matchup>();
         return mongoCollection
-            .Find(m => gameMode == m.GameMode && m.Season == season)
+            .Find(m => gameMode == m.GameMode && m.Season == season && (map == "Overall" || m.Map == map))
             .SortByDescending(s => s.EndTime)
             .Skip(offset)
             .Limit(pageSize)
@@ -177,10 +177,11 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
 
     public Task<long> Count(
         int season,
-        GameMode gameMode)
+        GameMode gameMode,
+        string map = "Overall")
     {
         return CreateCollection<Matchup>().CountDocumentsAsync(m =>
-                gameMode == m.GameMode && m.Season == season);
+                gameMode == m.GameMode && m.Season == season && (map == "Overall" || m.Map == map));
     }
 
     public Task InsertOnGoingMatch(OnGoingMatchup matchup)

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -19,7 +19,8 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
         int offset = 0,
         int pageSize = 100,
         GameMode gameMode = GameMode.Undefined,
-        int season = -1)
+        int season = -1,
+        string map = "Overall")
     {
         if (season < 0)
         {
@@ -27,8 +28,8 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
             season = lastSeason.Id;
         }
         if (pageSize > 100) pageSize = 100;
-        var matches = await _matchRepository.Load(season, gameMode, offset, pageSize);
-        var count = await _matchRepository.Count(season, gameMode);
+        var matches = await _matchRepository.Load(season, gameMode, offset, pageSize, map);
+        var count = await _matchRepository.Count(season, gameMode, map);
         return Ok(new { matches, count });
     }
 

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -19,6 +19,7 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
         int offset = 0,
         int pageSize = 100,
         GameMode gameMode = GameMode.Undefined,
+        GateWay gateWay = GateWay.Undefined,
         int season = -1,
         string map = "Overall")
     {
@@ -28,8 +29,8 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
             season = lastSeason.Id;
         }
         if (pageSize > 100) pageSize = 100;
-        var matches = await _matchRepository.Load(season, gameMode, offset, pageSize, map);
-        var count = await _matchRepository.Count(season, gameMode, map);
+        var matches = await _matchRepository.Load(season, gateWay, gameMode, offset, pageSize, map);
+        var count = await _matchRepository.Count(season, gateWay, gameMode, map);
         return Ok(new { matches, count });
     }
 

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -12,13 +12,14 @@ namespace W3ChampionsStatisticService.Ports;
 public interface IMatchRepository
 {
     Task<List<Matchup>> Load(int season,
+        GateWay gateWay,
         GameMode gameMode,
         int offset = 0,
         int pageSize = 100,
         string map = "Overall");
 
-    Task<long> Count(
-        int season,
+    Task<long> Count(int season,
+        GateWay gateWay,
         GameMode gameMode,
         string map = "Overall");
 

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -11,15 +11,16 @@ namespace W3ChampionsStatisticService.Ports;
 
 public interface IMatchRepository
 {
-    Task<List<Matchup>> Load(
-        int season,
+    Task<List<Matchup>> Load(int season,
         GameMode gameMode,
         int offset = 0,
-        int pageSize = 100);
+        int pageSize = 100,
+        string map = "Overall");
 
     Task<long> Count(
         int season,
-        GameMode gameMode);
+        GameMode gameMode,
+        string map = "Overall");
 
     Task Insert(Matchup matchup);
 

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -33,7 +33,7 @@ public class MatchupRepoTests : IntegrationTestBase
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent2));
-        var matches = await matchRepository.Load(matchFinishedEvent1.match.season, matchFinishedEvent1.match.gameMode);
+        var matches = await matchRepository.Load(matchFinishedEvent1.match.season, matchFinishedEvent1.match.gameMode, map: "Overall");
 
         Assert.AreEqual(2, matches.Count);
     }
@@ -86,10 +86,11 @@ public class MatchupRepoTests : IntegrationTestBase
         var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
 
         var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
+        var mapName = new MapName(matchFinishedEvent.match.map).Name;
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
-        var matches = await matchRepository.Load(matchFinishedEvent.match.season, matchFinishedEvent.match.gameMode);
+        var matches = await matchRepository.Load(matchFinishedEvent.match.season, matchFinishedEvent.match.gameMode, map: mapName);
 
         Assert.AreEqual(1, matches.Count);
     }

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -33,7 +33,7 @@ public class MatchupRepoTests : IntegrationTestBase
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent2));
-        var matches = await matchRepository.Load(matchFinishedEvent1.match.season, matchFinishedEvent1.match.gameMode, map: "Overall");
+        var matches = await matchRepository.Load(matchFinishedEvent1.match.season, matchFinishedEvent1.match.gateway, matchFinishedEvent1.match.gameMode, map: "Overall");
 
         Assert.AreEqual(2, matches.Count);
     }
@@ -90,7 +90,7 @@ public class MatchupRepoTests : IntegrationTestBase
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
-        var matches = await matchRepository.Load(matchFinishedEvent.match.season, matchFinishedEvent.match.gameMode, map: mapName);
+        var matches = await matchRepository.Load(matchFinishedEvent.match.season, matchFinishedEvent.match.gateway, matchFinishedEvent.match.gameMode, map: mapName);
 
         Assert.AreEqual(1, matches.Count);
     }
@@ -354,7 +354,7 @@ public class MatchupRepoTests : IntegrationTestBase
         matchFinishedEvent1.match.gameMode = GameMode.GM_1v1;
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
-        var matches = await matchRepository.Load(0, GameMode.GM_2v2_AT);
+        var matches = await matchRepository.Load(0, GateWay.Undefined, GameMode.GM_2v2_AT);
 
         Assert.AreEqual(0, matches.Count);
     }
@@ -367,7 +367,7 @@ public class MatchupRepoTests : IntegrationTestBase
         matchFinishedEvent1.match.gameMode = GameMode.GM_2v2_AT;
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
-        var matches = await matchRepository.Load(0, GameMode.GM_2v2_AT);
+        var matches = await matchRepository.Load(0, GateWay.Undefined, GameMode.GM_2v2_AT);
 
         Assert.AreEqual(1, matches.Count);
     }
@@ -383,7 +383,7 @@ public class MatchupRepoTests : IntegrationTestBase
         
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent2));
-        var matches = await matchRepository.Load(0, GameMode.GM_1v1, map: mapName);
+        var matches = await matchRepository.Load(0, GateWay.Undefined, GameMode.GM_1v1, map: mapName);
 
         Assert.AreEqual(1, matches.Count);
     }
@@ -396,7 +396,7 @@ public class MatchupRepoTests : IntegrationTestBase
         matchFinishedEvent1.match.gameMode = GameMode.GM_2v2_AT;
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
-        var matches = await matchRepository.Load(matchFinishedEvent1.match.season, matchFinishedEvent1.match.gameMode);
+        var matches = await matchRepository.Load(matchFinishedEvent1.match.season, matchFinishedEvent1.match.gateway, matchFinishedEvent1.match.gameMode);
 
         Assert.AreEqual(1, matches.Count);
     }

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -389,6 +389,20 @@ public class MatchupRepoTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task SearchForGateway_NotFound()
+    {
+        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
+        var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
+        
+        await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
+        await matchRepository.Insert(Matchup.Create(matchFinishedEvent2));
+        var matches = await matchRepository.Load(0, GateWay.America, GameMode.GM_1v1);
+
+        Assert.AreEqual(0, matches.Count);
+    }
+    
+    [Test]
     public async Task SearchForGameMode2v2_LoadDefault()
     {
         var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -371,6 +371,22 @@ public class MatchupRepoTests : IntegrationTestBase
 
         Assert.AreEqual(1, matches.Count);
     }
+    
+    [Test]
+    public async Task SearchForMap()
+    {
+        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
+        matchFinishedEvent1.match.map = "Maps/frozenthrone/(4)TurtleRock.w3x";
+        var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
+        var mapName = new MapName(matchFinishedEvent1.match.map).Name;
+        
+        await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
+        await matchRepository.Insert(Matchup.Create(matchFinishedEvent2));
+        var matches = await matchRepository.Load(0, GameMode.GM_1v1, map: mapName);
+
+        Assert.AreEqual(1, matches.Count);
+    }
 
     [Test]
     public async Task SearchForGameMode2v2_LoadDefault()

--- a/WC3ChampionsStatisticService.UnitTests/ReadModel/ReadModelHandlerBaseTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/ReadModel/ReadModelHandlerBaseTests.cs
@@ -112,7 +112,7 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
 
         var version = await versionRepository.GetLastVersion<MatchReadModelHandler>();
 
-        var matches = await matchRepository.Load(1, GameMode.GM_1v1);
+        var matches = await matchRepository.Load(1, GateWay.Undefined, GameMode.GM_1v1);
 
         Assert.AreEqual(1, version.Season);
         Assert.AreEqual(fakeEvent5.Id.ToString(), version.Version);


### PR DESCRIPTION
Adds missing filters to Finished Games filtering as noted in the following issue:
https://github.com/w3champions/website-backend/issues/348

Unsure as to what refactoring rules there are but some could be applied in MatchesController like the following:

- [unecessary fields due to primary constructors](https://github.com/w3champions/website-backend/blob/master/W3ChampionsStatisticService/Matches/MatchesController.cs#L14-L15) 
- typos such as ["Match" -> "Matche"](https://github.com/w3champions/website-backend/blob/master/W3ChampionsStatisticService/Matches/MatchesController.cs#L51)