### PR TITLE
Add MapName to GamesPlayedOnMap

### DIFF
--- a/W3C.Domain/MatchmakingService/MatchEventDtos.cs
+++ b/W3C.Domain/MatchmakingService/MatchEventDtos.cs
@@ -291,6 +291,7 @@ public class MatchFinishedEvent : MatchmakingEvent
     public Result result { get; set; }
     public bool WasFromSync { get; set; }
     public bool WasFakeEvent { get; set; }
+    public string MapName => match?.mapName;
 }
 
 [BsonIgnoreExtraElements]

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -53,6 +53,7 @@ using W3ChampionsStatisticService.W3ChampionsStats.GamesPerDays;
 using W3ChampionsStatisticService.W3ChampionsStats.HeroPlayedStats;
 using W3ChampionsStatisticService.W3ChampionsStats.PopularHours;
 using W3ChampionsStatisticService.W3ChampionsStats.MapsPerSeasons;
+using W3ChampionsStatisticService.W3ChampionsStats.MapsPerSeasonTemporaryHandler;
 using W3ChampionsStatisticService.W3ChampionsStats.OverallRaceAndWinStats;
 using W3ChampionsStatisticService.W3ChampionsStats.MatchupLengths;
 using Serilog.Events;
@@ -229,6 +230,7 @@ if (startHandlers == "true")
     builder.Services.AddMatchFinishedReadModelService<PopularHoursStatHandler>();
     builder.Services.AddMatchFinishedReadModelService<HeroPlayedStatHandler>();
     builder.Services.AddMatchFinishedReadModelService<MapsPerSeasonHandler>();
+    builder.Services.AddMatchFinishedReadModelService<MapsPerSeasonTemporaryHandler>();
 
     // Game Balance Stats
     builder.Services.AddMatchFinishedReadModelService<OverallRaceAndWinStatHandler>();

--- a/W3ChampionsStatisticService/Services/PlayerStatsService.cs
+++ b/W3ChampionsStatisticService/Services/PlayerStatsService.cs
@@ -60,7 +60,9 @@ public class PlayerStatisticsService(
                         .SelectMany(x => x.MatchesOnMapPerModes)
                         .SelectMany(x => x.Maps))
         {
-            mapsPerSeason.MapName = mapInformation.GetMapName(mapsPerSeason.Map);
+            if (mapsPerSeason.MapName == null) {
+                mapsPerSeason.MapName = mapInformation.GetMapName(mapsPerSeason.Map);
+            }
         }
 
         return loadMatchesOnMap;

--- a/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/GamesPlayedOnMap.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/GamesPlayedOnMap.cs
@@ -4,17 +4,16 @@ namespace W3ChampionsStatisticService.W3ChampionsStats.MapsPerSeasons;
 
 public class GamesPlayedOnMap
 {
-    public static GamesPlayedOnMap Create(string map)
+    public static GamesPlayedOnMap Create(string map, string mapName)
     {
         return new GamesPlayedOnMap
         {
-            Map = map
+            Map = map,
+            MapName = mapName
         };
     }
 
     public string Map { get; set; }
-
-    [BsonIgnore]
     public string MapName { get; set; }
 
     public void CountMatch()

--- a/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeason.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeason.cs
@@ -25,7 +25,7 @@ public class MapsPerSeason : IIdentifiable
     public int Season { get; set; }
 
     [Trace]
-    public void Count(string map, GameMode gameMode)
+    public void Count(string map, string mapName, GameMode gameMode)
     {
         var matchOnMapOverall = MatchesOnMapPerModes.SingleOrDefault(m => m.GameMode == GameMode.Undefined);
         if (matchOnMapOverall == null)
@@ -34,7 +34,7 @@ public class MapsPerSeason : IIdentifiable
         }
 
         matchOnMapOverall = MatchesOnMapPerModes.Single(m => m.GameMode == GameMode.Undefined);
-        matchOnMapOverall.CountMatch(map);
+        matchOnMapOverall.CountMatch(map, mapName);
 
         var matchOnMap = MatchesOnMapPerModes.SingleOrDefault(m => m.GameMode == gameMode);
         if (matchOnMap == null)
@@ -43,6 +43,21 @@ public class MapsPerSeason : IIdentifiable
         }
 
         matchOnMap = MatchesOnMapPerModes.Single(m => m.GameMode == gameMode);
-        matchOnMap.CountMatch(map);
+        matchOnMap.CountMatch(map, mapName);
+    }
+    
+    // Return true if updates were made
+    public bool UpdateMapName(string map, string mapName, GameMode gameMode)
+    {
+        var matchOnMapOverall = MatchesOnMapPerModes.SingleOrDefault(m => m.GameMode == GameMode.Undefined);
+        var matchOnMap = MatchesOnMapPerModes.SingleOrDefault(m => m.GameMode == gameMode);
+        if (matchOnMapOverall == null || matchOnMap == null) {
+            return false;
+        }
+
+        bool onMapUpdated = matchOnMap.UpdateMapName(map, mapName);
+        bool overallUpdated = matchOnMapOverall.UpdateMapName(map, mapName);
+
+        return overallUpdated && onMapUpdated;
     }
 }

--- a/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonHandler.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using W3ChampionsStatisticService.Matches;
 using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;

--- a/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using W3ChampionsStatisticService.Matches;
 using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
@@ -20,8 +21,8 @@ public class MapsPerSeasonHandler(IW3StatsRepo w3Stats) : IMatchFinishedReadMode
 
         var statCurrent = await _w3Stats.LoadMapsPerSeason(match.season) ?? MapsPerSeason.Create(match.season);
 
-        statOverall.Count(new MapName(match.map).Name, match.gameMode);
-        statCurrent.Count(new MapName(match.map).Name, match.gameMode);
+        statOverall.Count(new MapName(match.map).Name, nextEvent.MapName, match.gameMode);
+        statCurrent.Count(new MapName(match.map).Name, nextEvent.MapName, match.gameMode);
 
         await _w3Stats.Save(statOverall);
         await _w3Stats.Save(statCurrent);

--- a/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonTemporaryHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonTemporaryHandler.cs
@@ -7,7 +7,7 @@ using W3ChampionsStatisticService.ReadModelBase;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.MapsPerSeasonTemporaryHandler;
 
-// This handler will add mapNames to previously stored GamesPlayedOnMap documents in the MapsPerSeason collection
+// This handler will add mapNames to previously stored GamesPlayedOnMap objects in the MapsPerSeason collection
 // This handler could be removed after going through currently stored MatchFinishedEvents
 public class MapsPerSeasonTemporaryHandler(IW3StatsRepo w3Stats) : IReadModelHandler
 {

--- a/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonTemporaryHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonTemporaryHandler.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading.Tasks;
+using W3ChampionsStatisticService.Matches;
+using W3C.Domain.MatchmakingService;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.ReadModelBase;
+
+namespace W3ChampionsStatisticService.W3ChampionsStats.MapsPerSeasonTemporaryHandler;
+
+// This handler will add mapNames to previously stored GamesPlayedOnMap documents in the MapsPerSeason collection
+// This handler could be removed after going through currently stored MatchFinishedEvents
+public class MapsPerSeasonTemporaryHandler(IW3StatsRepo w3Stats) : IReadModelHandler
+{
+    private readonly IW3StatsRepo _w3Stats = w3Stats;
+
+    public async Task Update(MatchFinishedEvent nextEvent)
+    {
+        if (nextEvent.WasFakeEvent) return;
+
+        var match = nextEvent.match;
+
+        if (match == null) return;
+        
+        var statOverall = await _w3Stats.LoadMapsPerSeason(-1);
+        var statCurrent = await _w3Stats.LoadMapsPerSeason(match.season);
+
+        if (statCurrent == null || statOverall == null || nextEvent.MapName == null)
+        {
+            return;
+        }
+
+        bool overallUpdated = statOverall.UpdateMapName(new MapName(match.map).Name, nextEvent.MapName, match.gameMode);
+        bool currentUpdated = statCurrent.UpdateMapName(new MapName(match.map).Name, nextEvent.MapName, match.gameMode);
+
+        // Once the MapsPerSeasonTemporaryHandler catches up to the MapsPerSeasonHandler,
+        // We don't want to produce race conditions. So don't create documents and don't update ones that are up to date.
+        if (overallUpdated && currentUpdated)
+        {
+            await _w3Stats.Save(statOverall);
+            await _w3Stats.Save(statCurrent);
+        }
+    }
+}

--- a/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonTemporaryHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonTemporaryHandler.cs
@@ -9,7 +9,7 @@ namespace W3ChampionsStatisticService.W3ChampionsStats.MapsPerSeasonTemporaryHan
 
 // This handler will add mapNames to previously stored GamesPlayedOnMap objects in the MapsPerSeason collection
 // This handler could be removed after going through currently stored MatchFinishedEvents
-public class MapsPerSeasonTemporaryHandler(IW3StatsRepo w3Stats) : IReadModelHandler
+public class MapsPerSeasonTemporaryHandler(IW3StatsRepo w3Stats) : IMatchFinishedReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;
 

--- a/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MatchOnMapPerMode.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MatchOnMapPerMode.cs
@@ -16,17 +16,34 @@ public class MatchOnMapPerMode
 
     public GameMode GameMode { get; set; }
 
-    public void CountMatch(string map)
+    public void CountMatch(string map, string mapName)
     {
         var gamesOnMode = Maps.SingleOrDefault(g => g.Map == map);
         if (gamesOnMode == null)
         {
-            Maps.Add(GamesPlayedOnMap.Create(map));
+            Maps.Add(GamesPlayedOnMap.Create(map, mapName));
         }
 
         gamesOnMode = Maps.Single(g => g.Map == map);
         Maps = Maps.OrderBy(m => m.Map).ToList();
         gamesOnMode.CountMatch();
+    }
+
+    // Return true if an update was made
+    public bool UpdateMapName(string map, string mapName) {
+        var gamesOnMode = Maps.SingleOrDefault(g => g.Map == map);
+        if (gamesOnMode == null) {
+            // No record of this map
+            return false;
+        }
+
+        gamesOnMode = Maps.Single(g => g.Map == map);
+        if (gamesOnMode.MapName != null && gamesOnMode.MapName.Equals(mapName)) {
+            // MapName is already up to date
+            return false;
+        }
+        gamesOnMode.MapName = mapName;
+        return true;
     }
 
     public List<GamesPlayedOnMap> Maps { get; set; } = new List<GamesPlayedOnMap>();


### PR DESCRIPTION
Data in various collections is stored based on the map's "Map" value, which is derived from the filename. We can retrieve a mapping from the map file name to the actual map name based on the active maps stored in the matchmaking service. But that only helps us for this season.

Matches map filter for this season, using mapping from matchmaking service
![image](https://github.com/user-attachments/assets/2e02f773-3258-405b-9401-1bbc4a5dbdf2)

Matches map filter for season 19, no mapping can be done easily
![image](https://github.com/user-attachments/assets/d303089b-bd45-4fdd-bea6-e701577248bd)

This issue also affects the matchup statistics, when the maps played are from older seasons.

![image](https://github.com/user-attachments/assets/2ac5c5a2-605c-4427-b915-e532c1496c90)

Looking at the DB dumps, it seems that the proper map name has usually been provided in MatchFinishedEvent documents, under match.mapName. I propose this temporary handler, which will go through all historical MatchFinishedEvent documents and provide a mapName on GamesPerSeason objects in the MapsPerSeasonCollection. The temporary handler could then be deleted, as MapsPerSeasonHandler would store map names from now on.

Before the new handler is run
![Screenshot 2024-10-31 002827](https://github.com/user-attachments/assets/6b8efb15-d8fd-4477-a8a8-fe6e07aeb358)

After the handler is run
![Screenshot 2024-10-31 004356](https://github.com/user-attachments/assets/bbf91f5b-da23-460b-98ed-44b9d1253469)

This will enable us to provide a list of the map names in each season, for match filters. It will also allow us to provide a mapping of file name -> actual map name for each season, to help present data stored in other collections such as the matchup per map statistics.