### PR TITLE
Expand sort and filter for matches and ongoing endpoints

### DIFF
--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -15,11 +15,19 @@ public interface IMatchRepository
         int season,
         GameMode gameMode,
         int offset = 0,
-        int pageSize = 100);
+        int pageSize = 100,
+        string map = "Overall",
+        int minMmr = 0,
+        int maxMmr = 3000,
+        string sort = "endTime",
+        string sortDirection = "desc");
 
     Task<long> Count(
         int season,
-        GameMode gameMode);
+        GameMode gameMode,
+        string map = "Overall",
+        int minMmr = 0,
+        int maxMmr = 3000);
 
     Task Insert(Matchup matchup);
 
@@ -57,7 +65,8 @@ public interface IMatchRepository
         string map = "Overall",
         int minMmr = 0,
         int maxMmr = 3000,
-        string sort = "startTimeDescending");
+        string sort = "startTime",
+        string sortDirection = "asc");
 
     Task<long> CountOnGoingMatches(
         GameMode gameMode = GameMode.Undefined,


### PR DESCRIPTION
## Current

![image](https://github.com/user-attachments/assets/bf725eb7-595c-4a20-a1c9-8f45bf3d18b5)

![image](https://github.com/user-attachments/assets/7cca911b-eed0-4278-b417-5d7d57df1cb8)
map doesn't seem to work here and filled with a lot of noise
![image](https://github.com/user-attachments/assets/4157cb67-346e-4460-843a-a9b82e1d7a0d)


## Updated
![image](https://github.com/user-attachments/assets/c2226cf5-83db-4b47-bfc0-503f42646e3a)

![image](https://github.com/user-attachments/assets/7e603b00-e801-43ba-afaf-66463a49e32d)

Added sort order in addition to column
- starttime and mmr for ongoing
- endtime and mmr for finished

Also cleaned up the map list to only show maps that have a valid map name (handled by mmr service I think, this was also improved in a recent PR that hasn't been merged yet - should work for newer seasons at least)
![image](https://github.com/user-attachments/assets/db7f9e51-f610-43b9-ba49-a083d95354ef)

Now uses the mapName property to display in ui as well as filtering in backend

This makes it possible to find finished games on a given map
![image](https://github.com/user-attachments/assets/73fdafca-7557-498d-9b4b-a78ff108fbe3)

Or just recent high lvl games with the mmr descending sort
![image](https://github.com/user-attachments/assets/3174836e-c376-436d-8b73-eb8e595af832)
