### PR TITLE
use Directory.Build.Props and Directory.Packages.Props

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+tab_width = 4
+indent_size = 2
+ident_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*]
+[*.csproj]
 charset = utf-8
 tab_width = 4
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,6 @@
 root = true
 
-[*.csproj]
-charset = utf-8
-tab_width = 4
-indent_size = 2
-ident_style = space
-
-[*.props]
+[*.{csproj,props}]
 charset = utf-8
 tab_width = 4
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,9 @@ charset = utf-8
 tab_width = 4
 indent_size = 2
 ident_style = space
+
+[*.props]
+charset = utf-8
+tab_width = 4
+indent_size = 2
+ident_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,4 +4,4 @@ root = true
 charset = utf-8
 tab_width = 4
 indent_size = 2
-ident_style = space
+indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,5 @@ root = true
 
 [*.{csproj,props}]
 charset = utf-8
-tab_width = 4
 indent_size = 2
 indent_style = space

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-	<TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-	</PropertyGroup>
+  <PropertyGroup>
+	<TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,28 +1,28 @@
 <Project>
-	<PropertyGroup>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageVersion Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
-		<PackageVersion Include="AutoFixture" Version="4.13.0" />
-		<PackageVersion Include="AWSSDK.S3" Version="3.7.205.12" />
-		<PackageVersion Include="FluentAssertions" Version="6.7.0" />
-		<PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
-		<PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-		<PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-		<PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-		<PackageVersion Include="MongoDB.Driver" Version="2.25.0" />
-		<PackageVersion Include="Moq" Version="4.14.5" />
-		<PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageVersion Include="nunit" Version="3.13.3" />
-		<PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
-		<PackageVersion Include="prometheus-net.AspNetCore" Version="6.0.0" />
-		<PackageVersion Include="Serilog" Version="2.12.0" />
-		<PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
-		<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
-		<PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
-		<PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
-		<PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
-	</ItemGroup>
+  <PropertyGroup>
+	<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+	<PackageVersion Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
+	<PackageVersion Include="AutoFixture" Version="4.13.0" />
+	<PackageVersion Include="AWSSDK.S3" Version="3.7.205.12" />
+	<PackageVersion Include="FluentAssertions" Version="6.7.0" />
+	<PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
+	<PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+	<PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
+	<PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
+	<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+	<PackageVersion Include="MongoDB.Driver" Version="2.25.0" />
+	<PackageVersion Include="Moq" Version="4.14.5" />
+	<PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+	<PackageVersion Include="nunit" Version="3.13.3" />
+	<PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
+	<PackageVersion Include="prometheus-net.AspNetCore" Version="6.0.0" />
+	<PackageVersion Include="Serilog" Version="2.12.0" />
+	<PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
+	<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
+	<PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
+	<PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
+	<PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
+  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,28 +1,28 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
-    <PackageVersion Include="AutoFixture" Version="4.13.0" />
-    <PackageVersion Include="AWSSDK.S3" Version="3.7.205.12" />
-    <PackageVersion Include="FluentAssertions" Version="6.7.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.25.0" />
-    <PackageVersion Include="Moq" Version="4.14.5" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="nunit" Version="3.13.3" />
-	<PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageVersion Include="prometheus-net.AspNetCore" Version="6.0.0" />
-    <PackageVersion Include="Serilog" Version="2.12.0" />
-    <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
-  </ItemGroup>
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageVersion Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
+		<PackageVersion Include="AutoFixture" Version="4.13.0" />
+		<PackageVersion Include="AWSSDK.S3" Version="3.7.205.12" />
+		<PackageVersion Include="FluentAssertions" Version="6.7.0" />
+		<PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
+		<PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+		<PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
+		<PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+		<PackageVersion Include="MongoDB.Driver" Version="2.25.0" />
+		<PackageVersion Include="Moq" Version="4.14.5" />
+		<PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageVersion Include="nunit" Version="3.13.3" />
+		<PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
+		<PackageVersion Include="prometheus-net.AspNetCore" Version="6.0.0" />
+		<PackageVersion Include="Serilog" Version="2.12.0" />
+		<PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
+		<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
+		<PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
+		<PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
+		<PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
+	</ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,28 +1,28 @@
 <Project>
   <PropertyGroup>
-	<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-	<PackageVersion Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
-	<PackageVersion Include="AutoFixture" Version="4.13.0" />
-	<PackageVersion Include="AWSSDK.S3" Version="3.7.205.12" />
-	<PackageVersion Include="FluentAssertions" Version="6.7.0" />
-	<PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
-	<PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-	<PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-	<PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
-	<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-	<PackageVersion Include="MongoDB.Driver" Version="2.25.0" />
-	<PackageVersion Include="Moq" Version="4.14.5" />
-	<PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-	<PackageVersion Include="nunit" Version="3.13.3" />
-	<PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
-	<PackageVersion Include="prometheus-net.AspNetCore" Version="6.0.0" />
-	<PackageVersion Include="Serilog" Version="2.12.0" />
-	<PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
-	<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
-	<PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
-	<PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
-	<PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
+    <PackageVersion Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
+    <PackageVersion Include="AutoFixture" Version="4.13.0" />
+    <PackageVersion Include="AWSSDK.S3" Version="3.7.205.12" />
+    <PackageVersion Include="FluentAssertions" Version="6.7.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.25.0" />
+    <PackageVersion Include="Moq" Version="4.14.5" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="nunit" Version="3.13.3" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageVersion Include="prometheus-net.AspNetCore" Version="6.0.0" />
+    <PackageVersion Include="Serilog" Version="2.12.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,28 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
+    <PackageVersion Include="AutoFixture" Version="4.13.0" />
+    <PackageVersion Include="AWSSDK.S3" Version="3.7.205.12" />
+    <PackageVersion Include="FluentAssertions" Version="6.7.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.25.0" />
+    <PackageVersion Include="Moq" Version="4.14.5" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="nunit" Version="3.13.3" />
+	<PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageVersion Include="prometheus-net.AspNetCore" Version="6.0.0" />
+    <PackageVersion Include="Serilog" Version="2.12.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
+  </ItemGroup>
+</Project>

--- a/W3C.Contracts/W3C.Contracts.csproj
+++ b/W3C.Contracts/W3C.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" />
-	</ItemGroup>
+  <ItemGroup>
+	<PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
 
 </Project>

--- a/W3C.Contracts/W3C.Contracts.csproj
+++ b/W3C.Contracts/W3C.Contracts.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" />
+	</ItemGroup>
 
 </Project>

--- a/W3C.Contracts/W3C.Contracts.csproj
+++ b/W3C.Contracts/W3C.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-	<PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/W3C.Domain/W3C.Domain.csproj
+++ b/W3C.Domain/W3C.Domain.csproj
@@ -1,14 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Http" />
-		<PackageReference Include="MongoDB.Driver" />
-		<PackageReference Include="Serilog" />
-		<PackageReference Include="Serilog.Sinks.File" />
-	</ItemGroup>
+  <ItemGroup>
+	<PackageReference Include="Microsoft.Extensions.Http" />
+	<PackageReference Include="MongoDB.Driver" />
+	<PackageReference Include="Serilog" />
+	<PackageReference Include="Serilog.Sinks.File" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\W3C.Contracts\W3C.Contracts.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+	<ProjectReference Include="..\W3C.Contracts\W3C.Contracts.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/W3C.Domain/W3C.Domain.csproj
+++ b/W3C.Domain/W3C.Domain.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
-
+	
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Http" />
+	  <PackageReference Include="MongoDB.Driver" />
+	  <PackageReference Include="Serilog" />
+	  <PackageReference Include="Serilog.Sinks.File" />
   </ItemGroup>
 
   <ItemGroup>

--- a/W3C.Domain/W3C.Domain.csproj
+++ b/W3C.Domain/W3C.Domain.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.Extensions.Http" />
-	<PackageReference Include="MongoDB.Driver" />
-	<PackageReference Include="Serilog" />
-	<PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="MongoDB.Driver" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Sinks.File" />
   </ItemGroup>
 
   <ItemGroup>
-	<ProjectReference Include="..\W3C.Contracts\W3C.Contracts.csproj" />
+    <ProjectReference Include="..\W3C.Contracts\W3C.Contracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/W3C.Domain/W3C.Domain.csproj
+++ b/W3C.Domain/W3C.Domain.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	
-  <ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Http" />
-	  <PackageReference Include="MongoDB.Driver" />
-	  <PackageReference Include="Serilog" />
-	  <PackageReference Include="Serilog.Sinks.File" />
-  </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\W3C.Contracts\W3C.Contracts.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Http" />
+		<PackageReference Include="MongoDB.Driver" />
+		<PackageReference Include="Serilog" />
+		<PackageReference Include="Serilog.Sinks.File" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\W3C.Contracts\W3C.Contracts.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/W3ChampionsStatisticService.sln
+++ b/W3ChampionsStatisticService.sln
@@ -5,11 +5,13 @@ VisualStudioVersion = 17.1.32228.430
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "W3ChampionsStatisticService", "W3ChampionsStatisticService\W3ChampionsStatisticService.csproj", "{7D9D3DC6-13DB-4B6E-974A-89050D12D2EB}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{AD706C47-31D2-4B0F-B459-BFF80BF0A5A1}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AD706C47-31D2-4B0F-B459-BFF80BF0A5A1}"
 	ProjectSection(SolutionItems) = preProject
 		.dockerignore = .dockerignore
 		.gitignore = .gitignore
 		azure-pipelines.yml = azure-pipelines.yml
+		Directory.Build.props = Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
 		docker-compose.token.yml = docker-compose.token.yml
 		Dockerfile = Dockerfile
 		README.md = README.md

--- a/W3ChampionsStatisticService.sln
+++ b/W3ChampionsStatisticService.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AD706C47-31D2-4B0F-B459-BFF80BF0A5A1}"
 	ProjectSection(SolutionItems) = preProject
 		.dockerignore = .dockerignore
+		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		azure-pipelines.yml = azure-pipelines.yml
 		Directory.Build.props = Directory.Build.props

--- a/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
+++ b/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
@@ -1,25 +1,25 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-	<ItemGroup>
-		<PackageReference Include="Aliyun.OSS.SDK.NetCore" />
-		<PackageReference Include="AWSSDK.S3" />
-		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
-		<PackageReference Include="Microsoft.AspNetCore.Http" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" />
-		<PackageReference Include="MongoDB.Driver" />
-		<PackageReference Include="prometheus-net.AspNetCore" />
-		<PackageReference Include="Serilog" />
-		<PackageReference Include="Serilog.Sinks.File" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
-	</ItemGroup>
-	<ItemGroup>
-		<Content Update="countries.json">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</Content>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\W3C.Domain\W3C.Domain.csproj" />
-	</ItemGroup>
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <ItemGroup>
+	<PackageReference Include="Aliyun.OSS.SDK.NetCore" />
+	<PackageReference Include="AWSSDK.S3" />
+	<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+	<PackageReference Include="Microsoft.AspNetCore.Http" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" />
+	<PackageReference Include="MongoDB.Driver" />
+	<PackageReference Include="prometheus-net.AspNetCore" />
+	<PackageReference Include="Serilog" />
+	<PackageReference Include="Serilog.Sinks.File" />
+	<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+	<PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
+	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
+	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
+  </ItemGroup>
+  <ItemGroup>
+	<Content Update="countries.json">
+	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	</Content>
+  </ItemGroup>
+  <ItemGroup>
+	<ProjectReference Include="..\W3C.Domain\W3C.Domain.csproj" />
+  </ItemGroup>
 </Project>

--- a/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
+++ b/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
@@ -1,21 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.205.12" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
-    <PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
+    <PackageReference Include="Aliyun.OSS.SDK.NetCore" />
+    <PackageReference Include="AWSSDK.S3" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" />
+    <PackageReference Include="MongoDB.Driver" />
+    <PackageReference Include="prometheus-net.AspNetCore" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="countries.json">

--- a/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
+++ b/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-  <ItemGroup>
-    <PackageReference Include="Aliyun.OSS.SDK.NetCore" />
-    <PackageReference Include="AWSSDK.S3" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" />
-    <PackageReference Include="MongoDB.Driver" />
-    <PackageReference Include="prometheus-net.AspNetCore" />
-    <PackageReference Include="Serilog" />
-    <PackageReference Include="Serilog.Sinks.File" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Update="countries.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\W3C.Domain\W3C.Domain.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Aliyun.OSS.SDK.NetCore" />
+		<PackageReference Include="AWSSDK.S3" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+		<PackageReference Include="Microsoft.AspNetCore.Http" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" />
+		<PackageReference Include="MongoDB.Driver" />
+		<PackageReference Include="prometheus-net.AspNetCore" />
+		<PackageReference Include="Serilog" />
+		<PackageReference Include="Serilog.Sinks.File" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
+	</ItemGroup>
+	<ItemGroup>
+		<Content Update="countries.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\W3C.Domain\W3C.Domain.csproj" />
+	</ItemGroup>
 </Project>

--- a/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
+++ b/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
@@ -1,25 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <ItemGroup>
-	<PackageReference Include="Aliyun.OSS.SDK.NetCore" />
-	<PackageReference Include="AWSSDK.S3" />
-	<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
-	<PackageReference Include="Microsoft.AspNetCore.Http" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" />
-	<PackageReference Include="MongoDB.Driver" />
-	<PackageReference Include="prometheus-net.AspNetCore" />
-	<PackageReference Include="Serilog" />
-	<PackageReference Include="Serilog.Sinks.File" />
-	<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
-	<PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
-	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
-	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
+    <PackageReference Include="Aliyun.OSS.SDK.NetCore" />
+    <PackageReference Include="AWSSDK.S3" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" />
+    <PackageReference Include="MongoDB.Driver" />
+    <PackageReference Include="prometheus-net.AspNetCore" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
   </ItemGroup>
   <ItemGroup>
-	<Content Update="countries.json">
-	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	</Content>
+    <Content Update="countries.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
-	<ProjectReference Include="..\W3C.Domain\W3C.Domain.csproj" />
+    <ProjectReference Include="..\W3C.Domain\W3C.Domain.csproj" />
   </ItemGroup>
 </Project>

--- a/WC3ChampionsStatisticService.UnitTests/WC3ChampionsStatisticService.Tests.csproj
+++ b/WC3ChampionsStatisticService.UnitTests/WC3ChampionsStatisticService.Tests.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+	<PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-    <ItemGroup>
+	<ItemGroup>
 		<PackageReference Include="AutoFixture" />
-        <PackageReference Include="FluentAssertions" />
-        <PackageReference Include="Moq" />
-        <PackageReference Include="nunit" />
+		<PackageReference Include="FluentAssertions" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="nunit" />
 		<PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    </ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+	</ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\W3C.Domain\W3C.Domain.csproj" />
-      <ProjectReference Include="..\W3ChampionsStatisticService\W3ChampionsStatisticService.csproj" />
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\W3C.Domain\W3C.Domain.csproj" />
+		<ProjectReference Include="..\W3ChampionsStatisticService\W3ChampionsStatisticService.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/WC3ChampionsStatisticService.UnitTests/WC3ChampionsStatisticService.Tests.csproj
+++ b/WC3ChampionsStatisticService.UnitTests/WC3ChampionsStatisticService.Tests.csproj
@@ -1,21 +1,21 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
+  <PropertyGroup>
+	<IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="AutoFixture" />
-		<PackageReference Include="FluentAssertions" />
-		<PackageReference Include="Moq" />
-		<PackageReference Include="nunit" />
-		<PackageReference Include="NUnit3TestAdapter" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" />
-	</ItemGroup>
+  <ItemGroup>
+	<PackageReference Include="AutoFixture" />
+	<PackageReference Include="FluentAssertions" />
+	<PackageReference Include="Moq" />
+	<PackageReference Include="nunit" />
+	<PackageReference Include="NUnit3TestAdapter" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\W3C.Domain\W3C.Domain.csproj" />
-		<ProjectReference Include="..\W3ChampionsStatisticService\W3ChampionsStatisticService.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+	<ProjectReference Include="..\W3C.Domain\W3C.Domain.csproj" />
+	<ProjectReference Include="..\W3ChampionsStatisticService\W3ChampionsStatisticService.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/WC3ChampionsStatisticService.UnitTests/WC3ChampionsStatisticService.Tests.csproj
+++ b/WC3ChampionsStatisticService.UnitTests/WC3ChampionsStatisticService.Tests.csproj
@@ -1,18 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" Version="4.13.0" />
-        <PackageReference Include="FluentAssertions" Version="6.7.0" />
-        <PackageReference Include="Moq" Version="4.14.5" />
-        <PackageReference Include="nunit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+		<PackageReference Include="AutoFixture" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="nunit" />
+		<PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
     </ItemGroup>
 
     <ItemGroup>

--- a/WC3ChampionsStatisticService.UnitTests/WC3ChampionsStatisticService.Tests.csproj
+++ b/WC3ChampionsStatisticService.UnitTests/WC3ChampionsStatisticService.Tests.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<IsPackable>false</IsPackable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="AutoFixture" />
-	<PackageReference Include="FluentAssertions" />
-	<PackageReference Include="Moq" />
-	<PackageReference Include="nunit" />
-	<PackageReference Include="NUnit3TestAdapter" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="AutoFixture" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="nunit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
 
   <ItemGroup>
-	<ProjectReference Include="..\W3C.Domain\W3C.Domain.csproj" />
-	<ProjectReference Include="..\W3ChampionsStatisticService\W3ChampionsStatisticService.csproj" />
+    <ProjectReference Include="..\W3C.Domain\W3C.Domain.csproj" />
+    <ProjectReference Include="..\W3ChampionsStatisticService\W3ChampionsStatisticService.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR introduces two new configuration files to streamline project management:

Directory.Build.props: Centralized common build settings (such as version numbers and build options) for all projects in the directory and subdirectories, ensuring consistency across the solution.

Directory.Packages.props: Introduced to define consistent NuGet package versions across multiple projects, preventing version mismatches and making dependency management easier.

These changes simplify project maintenance, reduce duplication of settings across individual project files and prevents package version conflicts.