### PR TITLE
Cache /api/matches/search

### DIFF
--- a/W3ChampionsStatisticService/Cache/ICachedDataProvider.cs
+++ b/W3ChampionsStatisticService/Cache/ICachedDataProvider.cs
@@ -5,5 +5,5 @@ namespace W3ChampionsStatisticService.Cache;
 
 public interface ICachedDataProvider<T>
 {
-    Task<T> GetCachedOrRequestAsync(Func<Task<T>> requestDataCallbackAsync, string key);
+    Task<T> GetCachedOrRequestAsync(Func<Task<T>> requestDataCallbackAsync, string key, TimeSpan? customExpiration = null);
 }

--- a/W3ChampionsStatisticService/Cache/InMemoryCacheData.cs
+++ b/W3ChampionsStatisticService/Cache/InMemoryCacheData.cs
@@ -26,13 +26,6 @@ public class InMemoryCachedDataProvider<T> : ICachedDataProvider<T> where T : cl
         string key = null,
         TimeSpan? customExpiration = null)
     {
-        if (_memoryCache.TryGetValue(typeof(T).FullName + key, out T cachedValue))
-        {
-            Console.WriteLine($"Cache HIT for key: {key}");
-        } else {
-            Console.WriteLine($"Cache MISS for key: {key}");
-        }
-        
         if (_cacheOptions.LockDuringFetch)
         {
             await _semaphoreSlim.WaitAsync();

--- a/W3ChampionsStatisticService/Cache/InMemoryCacheData.cs
+++ b/W3ChampionsStatisticService/Cache/InMemoryCacheData.cs
@@ -36,7 +36,7 @@ public class InMemoryCachedDataProvider<T> : ICachedDataProvider<T> where T : cl
             return await _memoryCache.GetOrCreateAsync(typeof(T).FullName + key, async cacheEntry =>
             {
                 var expiration = customExpiration ?? _cacheOptions.CacheDuration;
-                
+
                 if (expiration.HasValue)
                 {
                     cacheEntry.SetAbsoluteExpiration(expiration.Value);

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -4,15 +4,17 @@ using MongoDB.Bson;
 using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.Ports;
 using W3C.Contracts.GameObjects;
+using W3ChampionsStatisticService.Services;
 
 namespace W3ChampionsStatisticService.Matches;
 
 [ApiController]
 [Route("api/matches")]
-public class MatchesController(IMatchRepository matchRepository, MatchQueryHandler matchQueryHandler) : ControllerBase
+public class MatchesController(IMatchRepository matchRepository, MatchQueryHandler matchQueryHandler, MatchService matchService) : ControllerBase
 {
     private readonly IMatchRepository _matchRepository = matchRepository;
     private readonly MatchQueryHandler _matchQueryHandler = matchQueryHandler;
+    private readonly MatchService _matchService = matchService;
 
     [HttpGet("")]
     public async Task<IActionResult> GetMatches(
@@ -67,8 +69,9 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
         int pageSize = 100)
     {
         if (pageSize > 100) pageSize = 100;
-        var matches = await _matchRepository.LoadFor(playerId, opponentId, gateWay, gameMode, playerRace, opponentRace, pageSize, offset, season);
-        var count = await _matchRepository.CountFor(playerId, opponentId, gateWay, gameMode, playerRace, opponentRace, season);
+        
+        var matches = matchService.GetMatchesPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace, pageSize, offset);
+        var count = matchService.GetMatchCountPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace);
         return Ok(new { matches, count });
     }
 

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -69,7 +69,7 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
         int pageSize = 100)
     {
         if (pageSize > 100) pageSize = 100;
-        
+
         var matches = await matchService.GetMatchesPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace, pageSize, offset);
         var count = await matchService.GetMatchCountPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace);
         return Ok(new { matches, count });

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -70,8 +70,8 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
     {
         if (pageSize > 100) pageSize = 100;
         
-        var matches = matchService.GetMatchesPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace, pageSize, offset);
-        var count = matchService.GetMatchCountPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace);
+        var matches = await matchService.GetMatchesPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace, pageSize, offset);
+        var count = await matchService.GetMatchCountPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace);
         return Ok(new { matches, count });
     }
 

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -70,7 +70,7 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
     {
         if (pageSize > 100) pageSize = 100;
 
-        var matches = await matchService.GetMatchesPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace, pageSize, offset);
+        var matches = await matchService.GetMatchesPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace, offset, pageSize);
         var count = await matchService.GetMatchCountPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace);
         return Ok(new { matches, count });
     }

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -163,6 +163,7 @@ builder.Services.AddSingleton<ChatServiceClient>();
 builder.Services.AddTransient<IFriendRepository, FriendRepository>();
 builder.Services.AddTransient<PlayerStatisticsService>();
 builder.Services.AddTransient<PlayerService>();
+builder.Services.AddTransient<MatchService>();
 builder.Services.AddTransient<IPermissionsRepository, PermissionsRepository>();
 builder.Services.AddTransient<ILogsRepository, LogsRepository>();
 

--- a/W3ChampionsStatisticService/Services/MatchService.cs
+++ b/W3ChampionsStatisticService/Services/MatchService.cs
@@ -50,7 +50,7 @@ public class MatchService(
                 opponentRace,
                 pageSize,
                 offset,
-                season), cacheKeyMatches, TimeSpan.FromSeconds(15));
+                season), cacheKeyMatches, TimeSpan.FromSeconds(5));
         return matches;
     }
 
@@ -72,7 +72,7 @@ public class MatchService(
             {
                 Value = await _matchRepository.CountFor(playerId, opponentId, gateWay, gameMode, playerRace,
                     opponentRace, season)
-            }, cacheKeyCount, TimeSpan.FromSeconds(15));
+            }, cacheKeyCount, TimeSpan.FromSeconds(5));
         return count.Value;
     }
 }

--- a/W3ChampionsStatisticService/Services/MatchService.cs
+++ b/W3ChampionsStatisticService/Services/MatchService.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading.Tasks;
+using W3ChampionsStatisticService.Cache;
+using System.Collections.Generic;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.Matches;
+using W3ChampionsStatisticService.Ports;
+
+namespace W3ChampionsStatisticService.Services;
+
+// ICachedDataProvider can't cache primitives so we wrap long
+public class CachedLong {
+    public long Value { get; set; }
+}
+
+// Calls MatchRepository and caches results
+public class MatchService(
+    IMatchRepository matchRepository,
+    ICachedDataProvider<List<Matchup>> cachedMatchesProvider,
+    ICachedDataProvider<CachedLong> cachedMatchCountProvider) {
+    private readonly IMatchRepository _matchRepository = matchRepository;
+    private readonly ICachedDataProvider<List<Matchup>> _cachedMatchesProvider = cachedMatchesProvider;
+    private readonly ICachedDataProvider<CachedLong> _cachedMatchCountProvider = cachedMatchCountProvider;
+
+    public async Task<List<Matchup>> GetMatchesPerPlayer(
+        string playerId,
+        int season,
+        string opponentId,
+        GameMode gameMode,
+        GateWay gateWay,
+        Race playerRace,
+        Race opponentRace,
+        int offset,
+        int pageSize) {
+        // Generate a unique cache key based on the request parameters
+        string cacheKeyMatches =
+            $"matches_{playerId}_{season}_{opponentId}_{gameMode}_{gateWay}_{playerRace}_{opponentRace}_{offset}_{pageSize}";
+
+        var matches = await _cachedMatchesProvider.GetCachedOrRequestAsync(
+            async () => await _matchRepository.LoadFor(
+                playerId,
+                opponentId,
+                gateWay,
+                gameMode,
+                playerRace,
+                opponentRace,
+                pageSize,
+                offset,
+                season), cacheKeyMatches, TimeSpan.FromSeconds(15));
+        return matches;
+    }
+
+    public async Task<long> GetMatchCountPerPlayer(
+        string playerId,
+        int season,
+        string opponentId,
+        GameMode gameMode,
+        GateWay gateWay,
+        Race playerRace,
+        Race opponentRace) {
+        // Generate a unique cache key based on the request parameters
+        string cacheKeyCount =
+            $"count_{playerId}_{season}_{opponentId}_{gameMode}_{gateWay}_{playerRace}_{opponentRace}";
+
+        var count = await _cachedMatchCountProvider.GetCachedOrRequestAsync(
+            async () => new CachedLong {
+                Value = await _matchRepository.CountFor(playerId, opponentId, gateWay, gameMode, playerRace,
+                    opponentRace, season)
+            }, cacheKeyCount, TimeSpan.FromSeconds(15));
+        return count.Value;
+    }
+}

--- a/W3ChampionsStatisticService/Services/MatchService.cs
+++ b/W3ChampionsStatisticService/Services/MatchService.cs
@@ -10,7 +10,8 @@ using W3ChampionsStatisticService.Ports;
 namespace W3ChampionsStatisticService.Services;
 
 // ICachedDataProvider can't cache primitives so we wrap long
-public class CachedLong {
+public class CachedLong
+{
     public long Value { get; set; }
 }
 
@@ -18,7 +19,8 @@ public class CachedLong {
 public class MatchService(
     IMatchRepository matchRepository,
     ICachedDataProvider<List<Matchup>> cachedMatchesProvider,
-    ICachedDataProvider<CachedLong> cachedMatchCountProvider) {
+    ICachedDataProvider<CachedLong> cachedMatchCountProvider)
+{
     private readonly IMatchRepository _matchRepository = matchRepository;
     private readonly ICachedDataProvider<List<Matchup>> _cachedMatchesProvider = cachedMatchesProvider;
     private readonly ICachedDataProvider<CachedLong> _cachedMatchCountProvider = cachedMatchCountProvider;
@@ -32,7 +34,8 @@ public class MatchService(
         Race playerRace,
         Race opponentRace,
         int offset,
-        int pageSize) {
+        int pageSize)
+    {
         // Generate a unique cache key based on the request parameters
         string cacheKeyMatches =
             $"matches_{playerId}_{season}_{opponentId}_{gameMode}_{gateWay}_{playerRace}_{opponentRace}_{offset}_{pageSize}";
@@ -58,13 +61,15 @@ public class MatchService(
         GameMode gameMode,
         GateWay gateWay,
         Race playerRace,
-        Race opponentRace) {
+        Race opponentRace)
+    {
         // Generate a unique cache key based on the request parameters
         string cacheKeyCount =
             $"count_{playerId}_{season}_{opponentId}_{gameMode}_{gateWay}_{playerRace}_{opponentRace}";
 
         var count = await _cachedMatchCountProvider.GetCachedOrRequestAsync(
-            async () => new CachedLong {
+            async () => new CachedLong
+            {
                 Value = await _matchRepository.CountFor(playerId, opponentId, gateWay, gameMode, playerRace,
                     opponentRace, season)
             }, cacheKeyCount, TimeSpan.FromSeconds(15));


### PR DESCRIPTION
Recently we experienced some website slowness. /api/matches/search is heavily used and does an expensive db query.

My suggestion is to create a MatchService, similar to other services, which leverages our existing in-memory cache. This will cache the results of unique /api/matches/search requests for 15 seconds.

How do I know the caching works? I used the console logs which are removed in the second commit.

![Screenshot 2025-03-07 172157](https://github.com/user-attachments/assets/c5d9e7b1-24f3-4b7d-ade0-b17b62f354bd)
![Screenshot 2025-03-07 172223](https://github.com/user-attachments/assets/de8f897a-bd1e-44ce-bb97-9abf8ac4e3c0)
