### PR TITLE
Use readonly matchService

### DIFF
--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -70,8 +70,8 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
     {
         if (pageSize > 100) pageSize = 100;
 
-        var matches = await matchService.GetMatchesPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace, offset, pageSize);
-        var count = await matchService.GetMatchCountPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace);
+        var matches = await _matchService.GetMatchesPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace, offset, pageSize);
+        var count = await _matchService.GetMatchCountPerPlayer(playerId, season, opponentId, gameMode, gateWay, playerRace, opponentRace);
         return Ok(new { matches, count });
     }
 


### PR DESCRIPTION
matchService from the MatchesController constructor is being used, instead of the readonly property _matchService. Functionally it's the same, but _matchService should be used to follow conventions and in case matchService somehow gets re-assigned.