### PR TITLE
Matchup: Add finished match player heroes to matchup response data

### DIFF
--- a/W3ChampionsStatisticService/Matches/Matchup.cs
+++ b/W3ChampionsStatisticService/Matches/Matchup.cs
@@ -110,10 +110,8 @@ public class Matchup
 
         foreach (var team in teamGroups)
         {
-            result.Teams.Add(CreateTeam(team.Value));
-            result.Teams = result.Teams
-                .OrderByDescending(x => x.Players.Any(y => y.Won))
-                .ToList();
+            result.Teams.Add(CreateTeam(team.Value, matchFinishedEvent.result?.players));
+            result.Teams = result.Teams.OrderByDescending(x => x.Players.Any(y => y.Won)).ToList();
         }
 
         SetTeamPlayers(result);
@@ -229,14 +227,20 @@ public class Matchup
         }
     }
 
-    private static Team CreateTeam(IEnumerable<PlayerMMrChange> players)
+    private static Team CreateTeam(
+        IEnumerable<PlayerMMrChange> players,
+        List<PlayerBlizzard> playerResults
+    )
     {
         var team = new Team();
-        team.Players.AddRange(CreatePlayerArray(players));
+        team.Players.AddRange(CreatePlayerArray(players, playerResults));
         return team;
     }
 
-    private static IEnumerable<PlayerOverviewMatches> CreatePlayerArray(IEnumerable<PlayerMMrChange> players)
+    private static IEnumerable<PlayerOverviewMatches> CreatePlayerArray(
+        IEnumerable<PlayerMMrChange> players,
+        List<PlayerBlizzard> playerResults
+    )
     {
         return players.Select(w => new PlayerOverviewMatches
         {
@@ -247,7 +251,8 @@ public class Matchup
             OldMmr = (int)w.mmr.rating,
             Won = w.won,
             Race = w.race,
-            RndRace = w.rndRace
+            RndRace = w.rndRace,
+            Heroes = playerResults.Find(result => w.battleTag == result.battleTag)?.heroes,
         });
     }
 }

--- a/W3ChampionsStatisticService/Matches/PlayerOverviewMatches.cs
+++ b/W3ChampionsStatisticService/Matches/PlayerOverviewMatches.cs
@@ -1,4 +1,6 @@
-﻿using W3C.Contracts.GameObjects;
+﻿using System.Collections.Generic;
+using W3C.Contracts.GameObjects;
+using W3C.Domain.MatchmakingService;
 
 namespace W3ChampionsStatisticService.Matches;
 
@@ -17,4 +19,5 @@ public class PlayerOverviewMatches
     public string CountryCode { get; set; }
     public string Country { get; set; }
     public string Twitch { get; set; }
+    public List<Hero> Heroes { get; set; }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupTests.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using W3C.Contracts.Matchmaking;
+using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Matches;
 
 namespace WC3ChampionsStatisticService.Tests.Matchups;
@@ -100,5 +102,35 @@ public class MatchupTests
         fakeEvent.match.gameMode = GameMode.GM_1v1;
         var matchup = Matchup.Create(fakeEvent);
         Assert.AreEqual(GameMode.GM_1v1, matchup.GameMode);
+    }
+
+    [Test]
+    public void MapMatch_Heroes()
+    {
+        var fakeEvent = TestDtoHelper.CreateFakeEvent();
+        fakeEvent.result.players[0].heroes =
+        [
+            new Hero { icon = "UI/Glues/ScoreScreen/scorescreen-hero-keeperofthegrove.blp", level = 4 },
+            new Hero { icon = "UI/Glues/ScoreScreen/scorescreen-hero-alchemist.blp", level  = 2 },
+            new Hero { icon = "UI/Glues/ScoreScreen/scorescreen-hero-priestessofthemoon.blp", level = 1 }
+        ];
+        fakeEvent.result.players[1].heroes =
+        [
+            new Hero { icon = "UI/Glues/ScoreScreen/scorescreen-hero-pitlord.blp", level = 3 },
+        ];
+        var matchup = Matchup.Create(fakeEvent);
+        
+        Assert.AreEqual(3, matchup.Teams[0].Players[0].Heroes.Count);
+        Assert.AreEqual(1, matchup.Teams[1].Players[0].Heroes.Count);
+
+        Assert.AreEqual("keeperofthegrove", matchup.Teams[0].Players[0].Heroes[0].icon);
+        Assert.AreEqual(4, matchup.Teams[0].Players[0].Heroes[0].level);
+        Assert.AreEqual("alchemist", matchup.Teams[0].Players[0].Heroes[1].icon);
+        Assert.AreEqual(2, matchup.Teams[0].Players[0].Heroes[1].level);
+        Assert.AreEqual("priestessofthemoon", matchup.Teams[0].Players[0].Heroes[2].icon);
+        Assert.AreEqual(1, matchup.Teams[0].Players[0].Heroes[2].level);
+        
+        Assert.AreEqual("pitlord", matchup.Teams[1].Players[0].Heroes[0].icon);
+        Assert.AreEqual(3, matchup.Teams[1].Players[0].Heroes[0].level);
     }
 }


### PR DESCRIPTION
Adds `Hero` info to the `Matchup` object so it can be returned to the front-end.

Implementation is a little awkward because of the various different types for player data but I wanted to make minimal changes until I get more familiar with things.