### PR TITLE
Add Hero data and filtering to Matchup

### DIFF
--- a/W3C.Domain/MatchmakingService/MatchEventDtos.cs
+++ b/W3C.Domain/MatchmakingService/MatchEventDtos.cs
@@ -200,6 +200,15 @@ public class Hero
     }
 
     public int level { get; set; }
+
+    // Only used for accessing icon field during Matchup creation without having parsing.
+    // FIXME: Remove default parsing of icon, atm other things depend on it existing
+    [JsonIgnore]
+    [BsonIgnore]
+    public string iconPath
+    {
+        get { return _icon; }
+    }
 }
 
 [BsonIgnoreExtraElements]

--- a/W3ChampionsStatisticService/Hero/Hero.cs
+++ b/W3ChampionsStatisticService/Hero/Hero.cs
@@ -17,24 +17,17 @@ namespace W3ChampionsStatisticService.Heroes;
 public class Hero
 {
     [BsonRepresentation(BsonType.Int32)]
-    public HeroType Id { get; set; } = HeroType.Unknown;
+    public HeroType Id { get; set; }
 
     [BsonIgnore()]
-    public string Name
-    {
-        // Front End uses lowercase for translation keys
-        get { return Enum.GetName(Id).ToLower(); }
-    }
+    public string Name => Enum.GetName(Id)?.ToLower(); // Frontend uses lowercase for translation keys
 
     /// <summary>
     /// For backwards compatibility to not break the frontend
     /// </summary>
     [BsonIgnore()]
     [JsonPropertyName("icon")]
-    public string Icon
-    {
-        get { return Name; }
-    }
+    public string Icon => Name;
 
     public int Level { get; set; }
 

--- a/W3ChampionsStatisticService/Hero/Hero.cs
+++ b/W3ChampionsStatisticService/Hero/Hero.cs
@@ -1,0 +1,153 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json.Serialization;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using Serilog;
+
+namespace W3ChampionsStatisticService.Heroes;
+
+/// <summary>
+/// Used for MongoDB collection for Web Backend data.<br/>
+/// This is the processed value from the MatchmakingService Hero provided in
+/// the MatchFinishedEvent data.
+/// </summary>
+[BsonIgnoreExtraElements]
+public class Hero
+{
+    [BsonRepresentation(BsonType.Int32)]
+    public HeroType Id { get; set; } = HeroType.Unknown;
+
+    [BsonIgnore()]
+    public string Name
+    {
+        // Front End uses lowercase for translation keys
+        get { return Enum.GetName(Id).ToLower(); }
+    }
+
+    /// <summary>
+    /// For backwards compatibility to not break the frontend
+    /// </summary>
+    [BsonIgnore()]
+    [JsonPropertyName("icon")]
+    public string Icon
+    {
+        get { return Name; }
+    }
+
+    public int Level { get; set; }
+
+    public Hero(W3C.Domain.MatchmakingService.Hero heroData)
+    {
+        Id = ParseHeroIcon(heroData.iconPath);
+        Level = heroData.level;
+    }
+
+    /// <summary>
+    /// Assumes that all icon values are file paths that can be parsed
+    /// and that the hero name is in file name. <br/>
+    ///
+    /// Non-custom game icons are in the format.
+    /// <code>
+    /// UI/Glues/ScoreScreen/scorescreen-hero-{heroName}.blp
+    ///
+    /// WebUI/ScoreScreen/HeroIcons/scorescreen-hero-{heroName}.png
+    /// </code>
+    ///
+    /// <returns>
+    /// <see cref="HeroType"/> matching the hero name parsed from the icon path, or
+    /// <see cref="HeroType.Unknown" /> if parsing failed.
+    /// </returns>
+    /// </summary>
+    private HeroType ParseHeroIcon(string iconPath)
+    {
+        var iconFileName = Path.GetFileNameWithoutExtension(iconPath);
+        var heroName = iconFileName.Split("-").Last();
+        if (Enum.TryParse(typeof(HeroType), heroName, true, out var parsedHeroId))
+        {
+            return (HeroType)parsedHeroId;
+        }
+        else if (Enum.TryParse(typeof(ReforgedHeroType), heroName, true, out var parsedReforgedId))
+        {
+            return MapReforged((ReforgedHeroType)parsedReforgedId);
+        }
+        else
+        {
+            // TODO: Add custom game mapping
+            Log.Warning("Failed to parse {@iconPath} to a HeroId.", iconPath);
+            return HeroType.Unknown;
+        }
+    }
+
+    /// <summary>
+    /// Maps Reforged heroes to the base heroes.
+    /// </summary>
+    public HeroType MapReforged(ReforgedHeroType reforgedHero)
+    {
+        switch (reforgedHero)
+        {
+            case ReforgedHeroType.JainaSea:
+                return HeroType.Archmage;
+            case ReforgedHeroType.ThrallChampion:
+                return HeroType.Farseer;
+            case ReforgedHeroType.FallenKingArthas:
+                return HeroType.DeathKnight;
+            case ReforgedHeroType.CenariusNightmare:
+                return HeroType.KeeperOfTheGrove;
+            default:
+                return HeroType.Unknown;
+        }
+    }
+}
+
+/// <summary>
+/// KeyValue type used for the frontend to provide filtering, giving the enum value and string name.
+/// The enum value is used in APIs, the string name is used in the frontend for icons, translations, etc.
+/// </summary>
+public class HeroFilter
+{
+    public HeroType Type { get; set; }
+    public string Name { get; set; }
+}
+
+public enum ReforgedHeroType
+{
+    JainaSea,
+    ThrallChampion,
+    FallenKingArthas,
+    CenariusNightmare,
+}
+
+/// <summary>
+/// Enum of heroes, value used as id
+/// </summary>
+public enum HeroType
+{
+    Unknown = -1,
+    AllFilter,
+    Archmage,
+    Alchemist,
+    AvatarOfFlame,
+    BansheeRanger,
+    Beastmaster,
+    Blademaster,
+    CryptLord,
+    DeathKnight,
+    DemonHunter,
+    DreadLord,
+    Farseer,
+    KeeperOfTheGrove,
+    Lich,
+    MountainKing,
+    Paladin,
+    PandarenBrewmaster,
+    PitLord,
+    PriestessOfTheMoon,
+    SeaWitch,
+    ShadowHunter,
+    Sorceror,
+    TaurenChieftain,
+    Tinker,
+    Warden,
+}

--- a/W3ChampionsStatisticService/Hero/HeroController.cs
+++ b/W3ChampionsStatisticService/Hero/HeroController.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+
+namespace W3ChampionsStatisticService.Heroes;
+
+[ApiController]
+[Route("api/hero")]
+public class HeroController() : ControllerBase
+{
+    [HttpGet("filters")]
+    public IActionResult GetHeroFilters()
+    {
+        var heroValues = Enum.GetValues(typeof(HeroType)).Cast<HeroType>();
+        var result = heroValues
+            .Where(hero => hero != HeroType.Unknown)
+            .Select(hero => new HeroFilter { Type = hero, Name = Enum.GetName(hero)?.ToLower() })
+            .OrderBy(hero => hero.Type);
+
+        return Ok(result);
+    }
+}

--- a/W3ChampionsStatisticService/Hero/HeroController.cs
+++ b/W3ChampionsStatisticService/Hero/HeroController.cs
@@ -7,7 +7,7 @@ namespace W3ChampionsStatisticService.Heroes;
 // Cache for 7 days, this isn't likely to change.
 [ApiController]
 [Route("api/hero")]
-[ResponseCache(Duration = 60 * 60 * 24 * 7)]
+[ResponseCache(Duration = 60 * 60 * 24 * 7, VaryByHeader = "HeroFilterVersion")]
 public class HeroController() : ControllerBase
 {
     [HttpGet("filters")]
@@ -15,8 +15,8 @@ public class HeroController() : ControllerBase
     {
         var heroValues = Enum.GetValues(typeof(HeroType)).Cast<HeroType>();
         var result = heroValues
-            .Where(hero => hero != HeroType.Unknown)
-            .Select(hero => new HeroFilter { Type = hero, Name = Enum.GetName(hero)?.ToLower() })
+            .Where(hero => (int)hero >= 0 && (int)hero < 100) // Non-classic hero ids start from 100, unknown is -1
+            .Select(hero => new HeroFilter(hero))
             .OrderBy(hero => hero.Type);
 
         return Ok(result);

--- a/W3ChampionsStatisticService/Hero/HeroController.cs
+++ b/W3ChampionsStatisticService/Hero/HeroController.cs
@@ -4,8 +4,10 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace W3ChampionsStatisticService.Heroes;
 
+// Cache for 7 days, this isn't likely to change.
 [ApiController]
 [Route("api/hero")]
+[ResponseCache(Duration = 60 * 60 * 24 * 7)]
 public class HeroController() : ControllerBase
 {
     [HttpGet("filters")]

--- a/W3ChampionsStatisticService/Matches/MatchRepository.cs
+++ b/W3ChampionsStatisticService/Matches/MatchRepository.cs
@@ -188,7 +188,7 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
 
         if (hero != HeroType.AllFilter && hero != HeroType.Unknown)
         {
-            var heroFilter = builder.Where(m => m.Teams.Any(t => t.Players.Any(p => p.Heroes.Any(h => h.Id == hero))));
+            var heroFilter = builder.Where(m => m.Teams.Any(t => t.Players.Any(p => p.Heroes.Count > 0 && p.Heroes[0].Id == hero)));
             filter &= heroFilter;
         }
 

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using MongoDB.Bson;
 using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.Heroes;
 using W3ChampionsStatisticService.Ports;
 using W3C.Contracts.GameObjects;
 using W3ChampionsStatisticService.Services;
@@ -21,7 +22,9 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
         int offset = 0,
         int pageSize = 100,
         GameMode gameMode = GameMode.Undefined,
-        int season = -1)
+        int season = -1,
+        HeroType hero = HeroType.AllFilter
+    )
     {
         if (season < 0)
         {
@@ -29,8 +32,8 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
             season = lastSeason.Id;
         }
         if (pageSize > 100) pageSize = 100;
-        var matches = await _matchRepository.Load(season, gameMode, offset, pageSize);
-        var count = await _matchRepository.Count(season, gameMode);
+        var matches = await _matchRepository.Load(season, gameMode, offset, pageSize, hero);
+        var count = await _matchRepository.Count(season, gameMode, hero);
         return Ok(new { matches, count });
     }
 

--- a/W3ChampionsStatisticService/Matches/Matchup.cs
+++ b/W3ChampionsStatisticService/Matches/Matchup.cs
@@ -183,7 +183,7 @@ public class Matchup
 
     protected static void SetPlayerHeroes(Matchup matchup, Result matchResult)
     {
-        if (matchResult.players.Count == 0)
+        if (matchResult?.players == null || matchResult.players?.Count == 0)
         {
             return;
         }
@@ -193,7 +193,7 @@ public class Matchup
             foreach (var player in team.Players)
             {
                 player.Heroes = matchResult
-                    .players.FirstOrDefault(p => p.battleTag == player.BattleTag)?
+                    .players?.FirstOrDefault(p => p.battleTag == player.BattleTag)?
                     .heroes?.Select(resultHero => new Heroes.Hero(resultHero))
                     .ToList();
             }

--- a/W3ChampionsStatisticService/Matches/Matchup.cs
+++ b/W3ChampionsStatisticService/Matches/Matchup.cs
@@ -183,13 +183,18 @@ public class Matchup
 
     protected static void SetPlayerHeroes(Matchup matchup, Result matchResult)
     {
+        if (matchResult.players.Count == 0)
+        {
+            return;
+        }
+        
         foreach (var team in matchup.Teams)
         {
             foreach (var player in team.Players)
             {
                 player.Heroes = matchResult
-                    .players.First(p => p.battleTag == player.BattleTag)
-                    .heroes.Select(resultHero => new Heroes.Hero(resultHero))
+                    .players.FirstOrDefault(p => p.battleTag == player.BattleTag)?
+                    .heroes?.Select(resultHero => new Heroes.Hero(resultHero))
                     .ToList();
             }
         }

--- a/W3ChampionsStatisticService/Matches/Matchup.cs
+++ b/W3ChampionsStatisticService/Matches/Matchup.cs
@@ -11,6 +11,7 @@ using W3C.Domain.GameModes;
 
 namespace W3ChampionsStatisticService.Matches;
 
+[MongoDB.Bson.Serialization.Attributes.BsonIgnoreExtraElements]
 public class Matchup
 {
     public string Map { get; set; }
@@ -117,6 +118,7 @@ public class Matchup
         }
 
         SetTeamPlayers(result);
+        SetPlayerHeroes(result, matchFinishedEvent.result);
 
         return result;
     }
@@ -177,6 +179,20 @@ public class Matchup
         }
 
         return teams;
+    }
+
+    protected static void SetPlayerHeroes(Matchup matchup, Result matchResult)
+    {
+        foreach (var team in matchup.Teams)
+        {
+            foreach (var player in team.Players)
+            {
+                player.Heroes = matchResult
+                    .players.First(p => p.battleTag == player.BattleTag)
+                    .heroes.Select(resultHero => new Heroes.Hero(resultHero))
+                    .ToList();
+            }
+        }
     }
 
     protected static void SetTeamPlayers(Matchup result)

--- a/W3ChampionsStatisticService/Matches/PlayerOverviewMatches.cs
+++ b/W3ChampionsStatisticService/Matches/PlayerOverviewMatches.cs
@@ -1,4 +1,6 @@
-﻿using W3C.Contracts.GameObjects;
+﻿using System.Collections.Generic;
+using W3C.Contracts.GameObjects;
+using W3ChampionsStatisticService.Heroes;
 
 namespace W3ChampionsStatisticService.Matches;
 
@@ -17,4 +19,5 @@ public class PlayerOverviewMatches
     public string CountryCode { get; set; }
     public string Country { get; set; }
     public string Twitch { get; set; }
+    public IList<Hero> Heroes { get; set; }
 }

--- a/W3ChampionsStatisticService/Matches/PlayerScore.cs
+++ b/W3ChampionsStatisticService/Matches/PlayerScore.cs
@@ -3,16 +3,11 @@ using W3C.Domain.MatchmakingService;
 
 namespace W3ChampionsStatisticService.Matches;
 
-public class PlayerScore(string battleTag,
-    UnitScore unitScore,
-    List<Hero> heroes,
-    HeroScore heroScore,
-    ResourceScore resourceScore,
-    int teamIndex)
+public class PlayerScore(string battleTag, UnitScore unitScore, List<Heroes.Hero> heroes, HeroScore heroScore, ResourceScore resourceScore, int teamIndex)
 {
     public string BattleTag { get; } = battleTag;
     public UnitScore UnitScore { get; } = unitScore;
-    public List<Hero> Heroes { get; } = heroes;
+    public List<Heroes.Hero> Heroes { get; } = heroes;
     public HeroScore HeroScore { get; } = heroScore;
     public ResourceScore ResourceScore { get; } = resourceScore;
     public int TeamIndex { get; } = teamIndex;

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -1,5 +1,7 @@
 ﻿using MongoDB.Bson;
+﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
@@ -67,6 +69,8 @@ public interface IMatchRepository
 
     Task<int> GetFloIdFromId(string gameId);
     Task<Season> LoadLastSeason();
+
+    Task<DateTimeOffset?> AddPlayerHeroes(DateTimeOffset startTime, int pageSize);
 }
 
 public class MatchupDetail

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.MatchmakingService;
+using W3ChampionsStatisticService.Heroes;
 using W3ChampionsStatisticService.Ladder;
 using W3ChampionsStatisticService.Matches;
 
@@ -11,11 +12,7 @@ namespace W3ChampionsStatisticService.Ports;
 
 public interface IMatchRepository
 {
-    Task<List<Matchup>> Load(
-        int season,
-        GameMode gameMode,
-        int offset = 0,
-        int pageSize = 100);
+    Task<List<Matchup>> Load(int season, GameMode gameMode, int offset = 0, int pageSize = 100, HeroType hero = HeroType.AllFilter);
 
     Task<long> Count(
         int season,

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -18,7 +18,8 @@ public interface IMatchRepository
 
     Task<long> Count(
         int season,
-        GameMode gameMode);
+        GameMode gameMode,
+        HeroType hero = HeroType.AllFilter);
 
     Task Insert(Matchup matchup);
 

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -24,6 +24,7 @@ using W3ChampionsStatisticService.Admin.Permissions;
 using W3ChampionsStatisticService.Cache;
 using W3ChampionsStatisticService.Clans;
 using W3ChampionsStatisticService.Friends;
+using W3ChampionsStatisticService.Heroes;
 using W3ChampionsStatisticService.Hubs;
 using W3ChampionsStatisticService.Ladder;
 using W3ChampionsStatisticService.Matches;
@@ -230,6 +231,15 @@ if (runBackfill == "true")
 var app = builder.Build();
 
 app.UseForwardedHeaders(new ForwardedHeadersOptions { ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto });
+
+app.Use(
+    (context, next) =>
+    {
+        // Sets header for api/heroes/filter cache response Vary header
+        context.Response.Headers["HeroFilterVersion"] = HeroFilter.AllowedHeroTypes.GetHashCode().ToString();
+        return next.Invoke();
+    }
+);
 
 app.UseRouting();
 

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -219,12 +219,17 @@ if (startHandlers == "true")
     builder.Services.AddUnversionedReadModelService<LeagueSyncHandler>();
 }
 
+var runBackfill = System.Environment.GetEnvironmentVariable("RUN_BACKFILL");
+
+if (runBackfill == "true")
+{
+    // Not a read model service but uses the same functionality to do async background processing to backfill data.
+    builder.Services.AddUnversionedReadModelService<MatchupHeroBackfillService>();
+}
+
 var app = builder.Build();
 
-app.UseForwardedHeaders(new ForwardedHeadersOptions
-{
-    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
-});
+app.UseForwardedHeaders(new ForwardedHeadersOptions { ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto });
 
 app.UseRouting();
 

--- a/W3ChampionsStatisticService/ReadModelBase/BsonExtensions.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/BsonExtensions.cs
@@ -15,9 +15,13 @@ public static class BsonExtensions
             cm.SetIsRootClass(true);
 
             var featureType = typeof(ClanState);
-            featureType.Assembly.GetTypes()
-                .Where(type => featureType.IsAssignableFrom(type)).ToList()
-                .ForEach(type => cm.AddKnownType(type));
+            featureType.Assembly.GetTypes().Where(type => featureType.IsAssignableFrom(type)).ToList().ForEach(type => cm.AddKnownType(type));
+        });
+
+        BsonClassMap.RegisterClassMap<Heroes.Hero>(heroMapper =>
+        {
+            heroMapper.AutoMap();
+            heroMapper.MapCreator(hero => new Heroes.Hero(hero.Id, hero.Level));
         });
 
         return services;

--- a/W3ChampionsStatisticService/Services/MatchupHeroBackfillService.cs
+++ b/W3ChampionsStatisticService/Services/MatchupHeroBackfillService.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.ReadModelBase;
+
+namespace W3ChampionsStatisticService.Services;
+
+public class MatchupHeroBackfillService : IAsyncUpdatable
+{
+    private readonly IMatchRepository matchRepository;
+    private DateTimeOffset? startTime;
+
+    public MatchupHeroBackfillService(IMatchRepository matchRepository)
+    {
+        this.matchRepository = matchRepository;
+        startTime = DateTimeOffset.Now;
+    }
+
+    public async Task Update()
+    {
+        try
+        {
+            if (!startTime.HasValue)
+            {
+                return;
+            }
+
+            DateTimeOffset? nextStartTime = await matchRepository.AddPlayerHeroes(startTime.Value, 1000);
+            if (nextStartTime == null)
+            {
+                // Nothing else to update
+                startTime = null;
+            }
+            else if (nextStartTime.Value >= startTime.Value)
+            {
+                Log.Warning("Matchup Update returned the same or more recent time. Changing time manually to prevent infinite loop.");
+                startTime = startTime.Value.AddTicks(-1);
+            }
+            else
+            {
+                startTime = nextStartTime;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error when attempting to update Matchup Player Heroes");
+        }
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
@@ -307,4 +307,9 @@ public static class TestDtoHelper
         matchFinishedEvent.match.players[1].mmr.rating = mmr2;
         return matchFinishedEvent;
     }
+
+    public static List<Hero> CreateHeroList(IList<W3ChampionsStatisticService.Heroes.HeroType> heroes)
+    {
+        return heroes.Select((hero, index) => new Hero { icon = $"{Enum.GetName(hero).ToLower()}.png", level = index + 1 }).ToList();
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Heroes/HeroTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Heroes/HeroTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using W3ChampionsStatisticService.Heroes;
 
@@ -10,22 +11,45 @@ using MM = W3C.Domain.MatchmakingService;
 [TestFixture]
 public class HeroTests
 {
+    [Test]
+    public void HeroFilters()
+    {
+        var controller = new HeroController();
+        var response = controller.GetHeroFilters() as ObjectResult;
+        var filters = ((IOrderedEnumerable<HeroFilter>)response!.Value)!.ToList();
+
+        var expectedCount = Enum.GetValues<HeroType>().Count(hero => (int)hero >= 0 && (int)hero < 100);
+
+        Assert.AreEqual(expectedCount, filters?.Count);
+
+        Assert.AreEqual(HeroSource.Unknown, Hero.ParseHeroSource(filters[0].Type));
+        Assert.AreEqual("allfilter", filters[0].Name);
+
+        foreach (var filter in filters.Skip(1))
+        {
+            Assert.AreEqual(HeroSource.Classic, Hero.ParseHeroSource(filter.Type));
+        }
+    }
+
     [TestCaseSource(nameof(HeroCases))]
     public void HeroParse(MM.Hero heroData, HeroType expectedType)
     {
         var hero = new Hero(heroData);
         Assert.AreEqual(expectedType, hero.Id);
+        Assert.AreEqual(HeroSource.Classic, hero.Source);
+        Assert.AreEqual(Enum.GetName(expectedType)!.ToLower(), hero.Name);
     }
 
     public static object[] HeroCases()
     {
-        var heroTypes = Enum.GetNames(typeof(HeroType));
+        var heroTypes = Enum.GetValues<HeroType>();
         return heroTypes
+            .Where(hero => (int)hero > 0 && (int)hero < 100) // Filter out Unknown, AllFilter and Reforged
             .Select(hero =>
-                new[]
+                new object[]
                 {
-                    new MM.Hero { icon = $"test-path/hero-{hero.ToLower()}.png", level = 1 },
-                    Enum.Parse(typeof(HeroType), hero),
+                    new MM.Hero { icon = $"test-path/hero-{Enum.GetName(hero)!.ToLower()}.png", level = 1 },
+                    hero,
                 }
             )
             .ToArray<object>();
@@ -38,5 +62,31 @@ public class HeroTests
         var hero = new Hero(invalidHeroData);
 
         Assert.AreEqual(HeroType.Unknown, hero.Id);
+        Assert.AreEqual(HeroSource.Unknown, hero.Source);
+    }
+
+    [TestCaseSource(nameof(ReforgedHeroCases))]
+    public void ReforgedHeroParse(MM.Hero heroData, HeroType expectedType, string expectedName)
+    {
+        var hero = new Hero(heroData);
+
+        Assert.AreEqual(expectedType, hero.Id);
+        Assert.AreEqual(expectedName, hero.Name);
+        Assert.AreEqual(HeroSource.Reforged, hero.Source);
+    }
+
+    public static object[] ReforgedHeroCases()
+    {
+        return Enum.GetValues<HeroType>()
+            .Where(hero => (int)hero >= 100) // Reforged hero types
+            .Select(hero =>
+                new object[]
+                {
+                    new MM.Hero { icon = $"test-path/reforged-hero-{Enum.GetName(hero)!.ToLower()}.png", level = 1 },
+                    hero,
+                    Hero.ParseHeroName(hero, HeroSource.Reforged),
+                }
+            )
+            .ToArray<object>();
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Heroes/HeroTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Heroes/HeroTest.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using W3ChampionsStatisticService.Heroes;
+
+namespace WC3ChampionsStatisticService.Tests.Heroes;
+
+using MM = W3C.Domain.MatchmakingService;
+
+[TestFixture]
+public class HeroTests
+{
+    [TestCaseSource(nameof(HeroCases))]
+    public void HeroParse(MM.Hero heroData, HeroType expectedType)
+    {
+        var hero = new Hero(heroData);
+        Assert.AreEqual(expectedType, hero.Id);
+    }
+
+    public static object[] HeroCases()
+    {
+        var heroTypes = Enum.GetNames(typeof(HeroType));
+        return heroTypes
+            .Select(hero =>
+                new[]
+                {
+                    new MM.Hero { icon = $"test-path/hero-{hero.ToLower()}.png", level = 1 },
+                    Enum.Parse(typeof(HeroType), hero),
+                }
+            )
+            .ToArray<object>();
+    }
+
+    [Test]
+    public void InvalidHeroParse()
+    {
+        var invalidHeroData = new MM.Hero { icon = "test-path/hero-invalid.png", level = 1 };
+        var hero = new Hero(invalidHeroData);
+
+        Assert.AreEqual(HeroType.Unknown, hero.Id);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
@@ -42,8 +42,8 @@ public class MatchupDetailTests : IntegrationTestBase
         var result = await matchRepository.LoadDetails(matchFinishedEvent.Id);
 
         Assert.AreEqual("nmhcCLaRc7", result.Match.MatchId);
-        Assert.AreEqual("Archmage", result.PlayerScores[0].Heroes[0].icon);
-        Assert.AreEqual("Warden", result.PlayerScores[1].Heroes[0].icon);
+        Assert.AreEqual("Archmage", result.PlayerScores[0].Heroes[0].Icon);
+        Assert.AreEqual("Warden", result.PlayerScores[1].Heroes[0].Icon);
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
@@ -30,8 +30,8 @@ public class MatchupDetailTests : IntegrationTestBase
         var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent.match.id = "nmhcCLaRc7";
         matchFinishedEvent.Id = ObjectId.GenerateNewId();
-        matchFinishedEvent.result.players[0].heroes[0].icon = "Archmage";
-        matchFinishedEvent.result.players[1].heroes[0].icon = "Warden";
+        matchFinishedEvent.result.players[0].heroes[0].icon = "archmage";
+        matchFinishedEvent.result.players[1].heroes[0].icon = "warden";
 
         await InsertMatchEvent(matchFinishedEvent);
 
@@ -42,8 +42,8 @@ public class MatchupDetailTests : IntegrationTestBase
         var result = await matchRepository.LoadDetails(matchFinishedEvent.Id);
 
         Assert.AreEqual("nmhcCLaRc7", result.Match.MatchId);
-        Assert.AreEqual("Archmage", result.PlayerScores[0].Heroes[0].Icon);
-        Assert.AreEqual("Warden", result.PlayerScores[1].Heroes[0].Icon);
+        Assert.AreEqual("archmage", result.PlayerScores[0].Heroes[0].Icon);
+        Assert.AreEqual("warden", result.PlayerScores[1].Heroes[0].Icon);
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -404,7 +404,7 @@ public class MatchupRepoTests : IntegrationTestBase
 
         var result = await matchRepository.LoadDetails(matchFinishedEvent1.Id);
 
-        Assert.AreEqual("archmage", result.PlayerScores[0].Heroes[0].icon);
+        Assert.AreEqual("archmage", result.PlayerScores[0].Heroes[0].Icon);
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupTests.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.Heroes;
 using W3ChampionsStatisticService.Matches;
 
 namespace WC3ChampionsStatisticService.Tests.Matchups;
@@ -100,5 +102,23 @@ public class MatchupTests
         fakeEvent.match.gameMode = GameMode.GM_1v1;
         var matchup = Matchup.Create(fakeEvent);
         Assert.AreEqual(GameMode.GM_1v1, matchup.GameMode);
+    }
+
+    [Test]
+    public void MapResult_Heroes()
+    {
+        var fakeEvent = TestDtoHelper.CreateFakeEvent();
+        fakeEvent.result.players[0].heroes = TestDtoHelper.CreateHeroList(new List<HeroType> { HeroType.Archmage });
+        fakeEvent.result.players[1].heroes = TestDtoHelper.CreateHeroList(new List<HeroType> { HeroType.Farseer, HeroType.Blademaster });
+
+        var matchup = Matchup.Create(fakeEvent);
+        var firstPlayer = matchup.Teams[0].Players[0];
+        Assert.AreEqual(1, firstPlayer.Heroes.Count);
+        Assert.AreEqual(HeroType.Archmage, firstPlayer.Heroes[0].Id);
+
+        var secondPlayer = matchup.Teams[1].Players[0];
+        Assert.AreEqual(2, secondPlayer.Heroes.Count);
+        Assert.AreEqual(HeroType.Farseer, secondPlayer.Heroes[0]);
+        Assert.AreEqual(HeroType.Blademaster, secondPlayer.Heroes[1]);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupTests.cs
@@ -118,7 +118,7 @@ public class MatchupTests
 
         var secondPlayer = matchup.Teams[1].Players[0];
         Assert.AreEqual(2, secondPlayer.Heroes.Count);
-        Assert.AreEqual(HeroType.Farseer, secondPlayer.Heroes[0]);
-        Assert.AreEqual(HeroType.Blademaster, secondPlayer.Heroes[1]);
+        Assert.AreEqual(HeroType.Farseer, secondPlayer.Heroes[0].Id);
+        Assert.AreEqual(HeroType.Blademaster, secondPlayer.Heroes[1].Id);
     }
 }


### PR DESCRIPTION
- Add new `Hero` class that specifically for backend to separate from the MM MatchFinishedEvent hero class. This also parses the `icon` path differently. The parsing can be expanded to support custom games later if we want
- Add new `HeroType` enum that's used as an ID for heroes instead of using strings. The enum value is saved in the `Matchup` document and is used for querying and filtering.
- Add hero data for players in `Matchup`. This only adds the enum value as an id, and the level. Strings are handled in the backend/frontend as needed.
- Add backfill service to gradually update historical matchup data to add hero data. This runs as a background task updating in batches of 1000 with a 5 second delay between each batch (set for all `ReadModelHandler` background tasks). Is enabled by setting the `RUN_BACKFILL=true` environment variable.
- Updates `api/matches` to accept hero ids for filtering. 
- Updates `PlayerScore` and `PlayerOverviewMatches` to use new `Hero` class for consistency.

A new index needs to be added to `Matchup.Teams.Players.Heroes._id` otherwise filtering is going to be very slow.