### PR TITLE
Increase player global search page size limit to 100

### DIFF
--- a/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
@@ -36,7 +36,7 @@ public class PlayersController(
     [HttpGet("global-search")]
     public async Task<IActionResult> GlobalSearchPlayer(string search, string lastRelevanceId = "", int pageSize = 20)
     {
-        if (pageSize > 20) pageSize = 20;
+        if (pageSize > 100) pageSize = 100;
         var players = await _playerService.GlobalSearchForPlayer(search, lastRelevanceId, pageSize);
         return Ok(players);
     }


### PR DESCRIPTION
I'm looking to use this API in `launcher-e`, but since infinite scroll will probably be difficult, I'd rather have a higher page size limit. I think the cap of 20 is kinda low, I think it should be okay to get up to 100 results in one call if the caller wants it. Default remains at 20, only changing the `&pageSize=` allowed maximum. Planning to use 50 in `launcher-e`.