### PR TITLE
Update websockets to include friend online status

### DIFF
--- a/W3ChampionsStatisticService/Friends/FriendUser.cs
+++ b/W3ChampionsStatisticService/Friends/FriendUser.cs
@@ -6,4 +6,5 @@ public class FriendUser
 {
     public string BattleTag { get; set; }
     public ProfilePicture ProfilePicture { get; set; }
+    public bool IsOnline { get; set; }
 }

--- a/W3ChampionsStatisticService/Hubs/ConnectionMapping.cs
+++ b/W3ChampionsStatisticService/Hubs/ConnectionMapping.cs
@@ -6,10 +6,12 @@ namespace W3ChampionsStatisticService.Hubs;
 public class ConnectionMapping
 {
     private readonly Dictionary<string, WebSocketUser> _connections = new();
+    private readonly Dictionary<string, HashSet<string>> _onlineUsersByBattleTag = new();
+    private readonly object _lock = new();
 
     public List<WebSocketUser> GetUsers()
     {
-        lock (_connections)
+        lock (_lock)
         {
             return _connections.Values.Select(v => v).OrderBy(r => r.BattleTag).ToList();
         }
@@ -17,29 +19,54 @@ public class ConnectionMapping
 
     public void Add(string connectionId, WebSocketUser user)
     {
-        lock (_connections)
+        lock (_lock)
         {
             if (!_connections.ContainsKey(connectionId))
             {
                 _connections.Add(connectionId, user);
+                if (!_onlineUsersByBattleTag.ContainsKey(user.BattleTag))
+                {
+                    _onlineUsersByBattleTag[user.BattleTag] = new HashSet<string>();
+                }
+                _onlineUsersByBattleTag[user.BattleTag].Add(connectionId);
             }
         }
     }
 
     public WebSocketUser GetUser(string connectionId)
     {
-        lock (_connections)
+        lock (_lock)
         {
             _connections.TryGetValue(connectionId, out WebSocketUser user);
             return user;
         }
     }
 
+    public bool IsUserOnline(string battleTag)
+    {
+        lock (_lock)
+        {
+            return _onlineUsersByBattleTag.ContainsKey(battleTag) && _onlineUsersByBattleTag[battleTag].Count > 0;
+        }
+    }
+
     public void Remove(string connectionId)
     {
-        lock (_connections)
+        lock (_lock)
         {
-            _connections.Remove(connectionId);
+            if (_connections.TryGetValue(connectionId, out var user))
+            {
+                _connections.Remove(connectionId);
+
+                if (_onlineUsersByBattleTag.TryGetValue(user.BattleTag, out var userConnections))
+                {
+                    userConnections.Remove(connectionId);
+                    if (userConnections.Count == 0)
+                    {
+                        _onlineUsersByBattleTag.Remove(user.BattleTag);
+                    }
+                }
+            }
         }
     }
 }

--- a/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
+++ b/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
@@ -1,10 +1,10 @@
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.SignalR;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR;
 using W3ChampionsStatisticService.Friends;
 using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.Ports;
@@ -18,7 +18,8 @@ public class WebsiteBackendHub(
     IHttpContextAccessor contextAccessor,
     FriendRepository friendRepository,
     FriendRequestCache friendRequestCache,
-    IPersonalSettingsRepository personalSettingsRepository) : Hub
+    IPersonalSettingsRepository personalSettingsRepository
+) : Hub
 {
     private readonly IW3CAuthenticationService _authenticationService = authenticationService;
     private readonly ConnectionMapping _connections = connections;
@@ -37,11 +38,7 @@ public class WebsiteBackendHub(
             Context.Abort();
             return;
         }
-        WebSocketUser user = new()
-        {
-            BattleTag = w3cUserAuthentication.BattleTag,
-            ConnectionId = Context.ConnectionId,
-        };
+        WebSocketUser user = new() { BattleTag = w3cUserAuthentication.BattleTag, ConnectionId = Context.ConnectionId };
         await LoginAsAuthenticated(user);
         await base.OnConnectedAsync();
     }
@@ -55,7 +52,8 @@ public class WebsiteBackendHub(
     public async Task LoadFriendListAndRequests()
     {
         var currentUser = _connections.GetUser(Context.ConnectionId)?.BattleTag;
-        if (currentUser == null) return;
+        if (currentUser == null)
+            return;
         Friendlist friendList = await _friendRepository.LoadFriendlist(currentUser);
         List<FriendRequest> sentRequests = await _friendRequestCache.LoadSentFriendRequests(currentUser);
         List<FriendRequest> receivedRequests = await _friendRequestCache.LoadReceivedFriendRequests(currentUser);
@@ -65,7 +63,8 @@ public class WebsiteBackendHub(
     public async Task LoadFriendsWithPictures()
     {
         var currentUser = _connections.GetUser(Context.ConnectionId)?.BattleTag;
-        if (currentUser == null) return;
+        if (currentUser == null)
+            return;
         List<FriendUser> friends = await GetFriends(currentUser);
         await Clients.Caller.SendAsync(FriendResponseType.FriendsWithPictures.ToString(), friends);
     }
@@ -74,7 +73,8 @@ public class WebsiteBackendHub(
     {
         try
         {
-            PersonalSetting personalSetting = await _personalSettingsRepository.Find(req.Receiver) ?? throw new ValidationException($"Player {req.Receiver} not found.");
+            PersonalSetting personalSetting =
+                await _personalSettingsRepository.Find(req.Receiver) ?? throw new ValidationException($"Player {req.Receiver} not found.");
 
             if (req.Sender.Equals(req.Receiver, StringComparison.CurrentCultureIgnoreCase))
             {
@@ -90,7 +90,13 @@ public class WebsiteBackendHub(
             await _friendRepository.CreateFriendRequest(req);
             _friendRequestCache.Insert(req);
             sentRequests.Add(req);
-            await Clients.Caller.SendAsync(FriendResponseType.FriendResponseData.ToString(), null, sentRequests, null, $"Friend request sent to {req.Receiver}!");
+            await Clients.Caller.SendAsync(
+                FriendResponseType.FriendResponseData.ToString(),
+                null,
+                sentRequests,
+                null,
+                $"Friend request sent to {req.Receiver}!"
+            );
 
             var requestsReceivedByOtherPlayer = await _friendRequestCache.LoadReceivedFriendRequests(req.Receiver);
             await PushFriendResponseDataToPlayer(req.Receiver, null, null, requestsReceivedByOtherPlayer);
@@ -110,7 +116,13 @@ public class WebsiteBackendHub(
             _friendRequestCache.Delete(request);
 
             List<FriendRequest> sentRequests = await _friendRequestCache.LoadSentFriendRequests(req.Sender);
-            await Clients.Caller.SendAsync(FriendResponseType.FriendResponseData.ToString(), null, sentRequests, null, $"Friend request to {req.Receiver} deleted!");
+            await Clients.Caller.SendAsync(
+                FriendResponseType.FriendResponseData.ToString(),
+                null,
+                sentRequests,
+                null,
+                $"Friend request to {req.Receiver} deleted!"
+            );
 
             var requestsReceivedByOtherPlayer = await _friendRequestCache.LoadReceivedFriendRequests(req.Receiver);
             await PushFriendResponseDataToPlayer(req.Receiver, null, null, requestsReceivedByOtherPlayer);
@@ -152,7 +164,13 @@ public class WebsiteBackendHub(
 
             List<FriendRequest> sentRequests = await _friendRequestCache.LoadSentFriendRequests(req.Receiver);
             List<FriendRequest> receivedRequests = await _friendRequestCache.LoadReceivedFriendRequests(req.Receiver);
-            await Clients.Caller.SendAsync(FriendResponseType.FriendResponseData.ToString(), currentUserFriendlist, sentRequests, receivedRequests, $"Friend request from {req.Sender} accepted!");
+            await Clients.Caller.SendAsync(
+                FriendResponseType.FriendResponseData.ToString(),
+                currentUserFriendlist,
+                sentRequests,
+                receivedRequests,
+                $"Friend request from {req.Sender} accepted!"
+            );
 
             List<FriendUser> receiverFriends = await GetFriends(req.Receiver);
             await Clients.Caller.SendAsync(FriendResponseType.FriendsWithPictures.ToString(), receiverFriends);
@@ -176,7 +194,13 @@ public class WebsiteBackendHub(
             _friendRequestCache.Delete(request);
 
             List<FriendRequest> receivedRequests = await _friendRequestCache.LoadReceivedFriendRequests(req.Receiver);
-            await Clients.Caller.SendAsync(FriendResponseType.FriendResponseData.ToString(), null, null, receivedRequests, $"Friend request from {req.Sender} denied!");
+            await Clients.Caller.SendAsync(
+                FriendResponseType.FriendResponseData.ToString(),
+                null,
+                null,
+                receivedRequests,
+                $"Friend request from {req.Sender} denied!"
+            );
 
             var sentRequests = await _friendRequestCache.LoadSentFriendRequests(req.Sender);
             await PushFriendResponseDataToPlayer(req.Sender, null, sentRequests);
@@ -202,7 +226,13 @@ public class WebsiteBackendHub(
             await _friendRepository.UpsertFriendlist(currentUserFriendlist);
 
             List<FriendRequest> receivedRequests = await _friendRequestCache.LoadReceivedFriendRequests(req.Receiver);
-            await Clients.Caller.SendAsync(FriendResponseType.FriendResponseData.ToString(), currentUserFriendlist, null, receivedRequests, $"Friend requests from {req.Sender} blocked!");
+            await Clients.Caller.SendAsync(
+                FriendResponseType.FriendResponseData.ToString(),
+                currentUserFriendlist,
+                null,
+                receivedRequests,
+                $"Friend requests from {req.Sender} blocked!"
+            );
 
             var sentRequests = await _friendRequestCache.LoadSentFriendRequests(req.Sender);
             await PushFriendResponseDataToPlayer(req.Sender, null, sentRequests);
@@ -216,16 +246,24 @@ public class WebsiteBackendHub(
     public async Task UnblockFriendRequestsFromPlayer(string battleTag)
     {
         var currentUser = _connections.GetUser(Context.ConnectionId)?.BattleTag;
-        if (currentUser == null) return;
+        if (currentUser == null)
+            return;
         try
         {
             var friendList = await _friendRepository.LoadFriendlist(currentUser);
 
-            var itemToRemove = friendList.BlockedBattleTags.SingleOrDefault(bTag => bTag == battleTag) ?? throw new ValidationException("Could not find a player to unblock.");
+            var itemToRemove =
+                friendList.BlockedBattleTags.SingleOrDefault(bTag => bTag == battleTag) ?? throw new ValidationException("Could not find a player to unblock.");
             friendList.BlockedBattleTags.Remove(itemToRemove);
             await _friendRepository.UpsertFriendlist(friendList);
 
-            await Clients.Caller.SendAsync(FriendResponseType.FriendResponseData.ToString(), friendList, null, null, $"Friend requests from {battleTag} unblocked!");
+            await Clients.Caller.SendAsync(
+                FriendResponseType.FriendResponseData.ToString(),
+                friendList,
+                null,
+                null,
+                $"Friend requests from {battleTag} unblocked!"
+            );
         }
         catch (Exception ex)
         {
@@ -236,7 +274,8 @@ public class WebsiteBackendHub(
     public async Task RemoveFriend(string friend)
     {
         var currentUser = _connections.GetUser(Context.ConnectionId)?.BattleTag;
-        if (currentUser == null) return;
+        if (currentUser == null)
+            return;
         try
         {
             var currentUserFriendlist = await _friendRepository.LoadFriendlist(currentUser);
@@ -255,7 +294,13 @@ public class WebsiteBackendHub(
             }
             await _friendRepository.UpsertFriendlist(otherUserFriendlist);
 
-            await Clients.Caller.SendAsync(FriendResponseType.FriendResponseData.ToString(), currentUserFriendlist, null, null, $"Removed {friend} from friends.");
+            await Clients.Caller.SendAsync(
+                FriendResponseType.FriendResponseData.ToString(),
+                currentUserFriendlist,
+                null,
+                null,
+                $"Removed {friend} from friends."
+            );
 
             List<FriendUser> currentUserFriends = await GetFriends(currentUser);
             await Clients.Caller.SendAsync(FriendResponseType.FriendsWithPictures.ToString(), currentUserFriends);
@@ -273,7 +318,8 @@ public class WebsiteBackendHub(
     private async Task<List<FriendUser>> GetFriends(string battleTag)
     {
         Friendlist friendList = await _friendRepository.LoadFriendlist(battleTag);
-        if (friendList.Friends.Count == 0) return [];
+        if (friendList.Friends.Count == 0)
+            return [];
 
         // TODO: Uncomment after the launcher has been updated to avoid querying the db excessively after a website-backend restart/deploy.
         // List<PersonalSetting> personalSettings = await _personalSettingsRepository.LoadMany(friendList.Friends.ToArray());
@@ -283,11 +329,14 @@ public class WebsiteBackendHub(
         //     ProfilePicture = x.ProfilePicture
         // }).ToList();
 
-        List<FriendUser> friends = friendList.Friends.Select(x => new FriendUser
-        {
-            BattleTag = x,
-            ProfilePicture = ProfilePicture.Default(),
-        }).ToList();
+        List<FriendUser> friends = friendList
+            .Friends.Select(battleTag => new FriendUser
+            {
+                BattleTag = battleTag,
+                ProfilePicture = ProfilePicture.Default(),
+                IsOnline = connections.IsUserOnline(battleTag),
+            })
+            .ToList();
         return friends ?? [];
     }
 
@@ -300,14 +349,18 @@ public class WebsiteBackendHub(
     )
     {
         var player = _connections.GetUsers().FirstOrDefault(x => x.BattleTag == battleTag);
-        if (player?.ConnectionId == null) return;
-        await Clients.Client(player.ConnectionId).SendAsync(FriendResponseType.FriendResponseData.ToString(), friendList, sentRequests, receivedRequests, message);
+        if (player?.ConnectionId == null)
+            return;
+        await Clients
+            .Client(player.ConnectionId)
+            .SendAsync(FriendResponseType.FriendResponseData.ToString(), friendList, sentRequests, receivedRequests, message);
     }
 
     private async Task PushFriendsWithPicturesToPlayer(string battleTag)
     {
         var player = _connections.GetUsers().FirstOrDefault(x => x.BattleTag == battleTag);
-        if (player?.ConnectionId == null) return;
+        if (player?.ConnectionId == null)
+            return;
         List<FriendUser> friends = await GetFriends(battleTag);
         await Clients.Client(player.ConnectionId).SendAsync(FriendResponseType.FriendsWithPictures.ToString(), friends);
     }


### PR DESCRIPTION
- Update `FriendUser` to include `IsOnline` property.
- Update `ConnectionMapping` to also keep a mapping of `BattleTag, HashSet<ConnectionId>` so we don't need to search constantly to check for whether a user is online or not.
- Update `ConnectionMapping` to add `IsUserOnline()` to check whether a user is online or not.
- Update `WebsiteBackendHub#GetFriends()` to get the online status of users using the `ConnectionMapping#IsUserOnline()` from above