### PR TITLE
Introduce transaction support, rewrite cache and introduce match cleanup

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+dotnet-core 8.0.408

--- a/MONGODB_SETUP.md
+++ b/MONGODB_SETUP.md
@@ -1,0 +1,28 @@
+# MongoDB Setup for W3Champions
+
+This document describes how to set up MongoDB for W3Champions website-backend.
+
+## Transaction Support
+
+The W3Champions website-backend requires MongoDB transaction support, which is only available when MongoDB is running as a replica set (not in standalone mode).
+
+In order to do that, attach `--replSet rs0` to the launch command of the MongoDB.
+Once started, initiate the replicate set with the following command:
+```javascript
+rs.initiate()
+```
+
+### Connection String
+
+The service expects the following connection string format:
+
+- Replica Set: `mongodb://hostname:port/?replicaSet=rs0`
+
+If a replica set name is not provided in the connection string, the service will fail to start.
+
+## Troubleshooting
+
+If you encounter the error `System.NotSupportedException: Standalone servers do not support transactions`, it means:
+
+1. MongoDB is running in standalone mode
+2. You need to manually configure MongoDB as a replica set

--- a/W3C.Domain/Repositories/AsyncTransactionScope.cs
+++ b/W3C.Domain/Repositories/AsyncTransactionScope.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading.Tasks;
+
+namespace W3C.Domain.Repositories;
+
+public sealed class AsyncTransactionScope : IAsyncDisposable
+{
+    private readonly ITransactionCoordinator _transactionCoordinator;
+    private readonly Guid _transactionId;
+    private bool _completedSuccessfully = false;
+
+    private AsyncTransactionScope(ITransactionCoordinator transactionCoordinator, Guid transactionId)
+    {
+        _transactionCoordinator = transactionCoordinator;
+        _transactionId = transactionId;
+    }
+
+    public static AsyncTransactionScope Create(ITransactionCoordinator transactionCoordinator)
+    {
+        if (transactionCoordinator == null)
+        {
+            throw new ArgumentNullException(nameof(transactionCoordinator));
+        }
+        var transactionId = transactionCoordinator.InitializeTransaction();
+        return new AsyncTransactionScope(transactionCoordinator, transactionId);
+    }
+
+    public async Task Start()
+    {
+        await _transactionCoordinator.BeginTransactionAsync(_transactionId);
+    }
+
+    public void Complete()
+    {
+        if (_transactionId != _transactionCoordinator.CurrentTransactionId)
+        {
+            throw new InvalidOperationException("Transaction id mismatch: " + _transactionId + " != " + _transactionCoordinator.CurrentTransactionId);
+        }
+        if (!_transactionCoordinator.IsTransactionActive)
+        {
+            throw new InvalidOperationException("Cannot complete a transaction that is not active.");
+        }
+        _completedSuccessfully = true;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!_transactionCoordinator.IsTransactionActive)
+        {
+            return;
+        }
+
+        if (_completedSuccessfully)
+        {
+            await _transactionCoordinator.CommitTransactionAsync(_transactionId);
+        }
+        else
+        {
+            await _transactionCoordinator.AbortTransactionAsync(_transactionId);
+        }
+    }
+
+    public async Task RegisterOnSuccessHandler(Func<Task> handler, bool executeImmediatelyWithoutTransaction = true)
+    {
+        await _transactionCoordinator.RegisterOnSuccessHandler(handler, executeImmediatelyWithoutTransaction);
+    }
+}

--- a/W3C.Domain/Repositories/Contracts/IMatchEventRepository.cs
+++ b/W3C.Domain/Repositories/Contracts/IMatchEventRepository.cs
@@ -8,9 +8,12 @@ namespace W3C.Domain.Repositories;
 public interface IMatchEventRepository
 {
     Task<List<MatchFinishedEvent>> Load(string lastObjectId, int pageSize = 100);
+
+    Task<List<MatchCanceledEvent>> LoadCanceledMatches();
     Task<List<MatchStartedEvent>> LoadStartedMatches();
-    Task<bool> InsertIfNotExisting(MatchFinishedEvent matchFinishedEvent, int i = 0);
+    Task<bool> InsertIfNotExisting(MatchFinishedEvent matchFinishedEvent, int attempt = 0);
     Task<List<RankingChangedEvent>> CheckoutForRead();
     Task<List<LeagueConstellationChangedEvent>> LoadLeagueConstellationChanged();
     Task DeleteStartedEvent(ObjectId nextEventId);
+    Task DeleteCanceledEvent(ObjectId nextEventId);
 }

--- a/W3C.Domain/Repositories/ITransactionCoordinator.cs
+++ b/W3C.Domain/Repositories/ITransactionCoordinator.cs
@@ -1,0 +1,18 @@
+using MongoDB.Driver;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace W3C.Domain.Repositories;
+
+public interface ITransactionCoordinator : IDisposable
+{
+    Guid InitializeTransaction();
+    Guid CurrentTransactionId { get; }
+    Task BeginTransactionAsync(Guid transactionId, CancellationToken cancellationToken = default);
+    Task CommitTransactionAsync(Guid transactionId, CancellationToken cancellationToken = default);
+    Task AbortTransactionAsync(Guid transactionId, CancellationToken cancellationToken = default);
+    Task RegisterOnSuccessHandler(Func<Task> handler, bool executeImmediatelyWithoutTransaction = true);
+    IClientSessionHandle GetCurrentSession();
+    bool IsTransactionActive { get; }
+}

--- a/W3C.Domain/Repositories/InformationMessagesRepository.cs
+++ b/W3C.Domain/Repositories/InformationMessagesRepository.cs
@@ -21,20 +21,17 @@ public class InformationMessagesRepository : MongoDbRepositoryBase, IInformation
 
     public Task<List<LoadingScreenTip>> GetTips(int? limit = 5)
     {
-        var mongoCollection = CreateCollection<LoadingScreenTip>();
-        return mongoCollection
-            .Find(r => true)
-            .SortByDescending(m => m.Id)
-            .Limit(limit).ToListAsync();
+        // Do we really intend to allow limit to be null? And that means "give me everything"? 
+        // The nullable int is a bit confusing here - assuming null means "give me everything" for now.
+        return LoadAll(
+            sortBy: Builders<LoadingScreenTip>.Sort.Descending(m => m.Id),
+            limit: limit
+        );
     }
 
     public async Task<LoadingScreenTip> GetRandomTip()
     {
-        var mongoCollection = CreateCollection<LoadingScreenTip>();
-        return await mongoCollection
-            .AsQueryable()
-            .Sample(1)
-            .FirstOrDefaultAsync();
+        return await AsQueryable<LoadingScreenTip>().Sample(1).FirstOrDefaultAsync();
     }
 
 
@@ -50,7 +47,7 @@ public class InformationMessagesRepository : MongoDbRepositoryBase, IInformation
 
     public Task UpsertTip(LoadingScreenTip loadingScreenTip)
     {
-        return Upsert(loadingScreenTip, n => n.Id == loadingScreenTip.Id);
+        return Upsert(loadingScreenTip, Builders<LoadingScreenTip>.Filter.Eq(n => n.Id, loadingScreenTip.Id));
     }
 
     public async Task<MessageOfTheDay> GetMotd()

--- a/W3C.Domain/Repositories/MongoDbRepositoryBase.cs
+++ b/W3C.Domain/Repositories/MongoDbRepositoryBase.cs
@@ -2,8 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualBasic;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 
 namespace W3C.Domain.Repositories;
 
@@ -11,94 +14,200 @@ public class MongoDbRepositoryBase
 {
     private readonly MongoClient _mongoClient;
     private readonly string _databaseName = "W3Champions-Statistic-Service";
+    private readonly ITransactionCoordinator _transactionCoordinator;
 
-    public MongoDbRepositoryBase(MongoClient mongoClient)
+    public MongoDbRepositoryBase(MongoClient mongoClient, ITransactionCoordinator transactionCoordinator = null)
     {
-        _mongoClient = mongoClient;
+        _mongoClient = mongoClient ?? throw new ArgumentNullException(nameof(mongoClient));
+        _transactionCoordinator = transactionCoordinator;
     }
 
-    protected IMongoDatabase CreateClient()
+    private IMongoDatabase CreateClient()
     {
+        // Do not expose the client to derived classes to enforce the usage of this classes functions which are session aware!
         var database = _mongoClient.GetDatabase(_databaseName);
         return database;
     }
 
-    protected Task<T> LoadFirst<T>(Expression<Func<T, bool>> expression)
-    {
-        var mongoCollection = CreateCollection<T>();
-        return mongoCollection.FindSync(expression).FirstOrDefaultAsync();
-    }
-
     protected Task<T> LoadFirst<T>(string id) where T : IIdentifiable
     {
-        return LoadFirst<T>(x => x.Id == id);
+        return Find(Builders<T>.Filter.Eq(x => x.Id, id)).FirstOrDefaultAsync();
+    }
+
+    protected Task<T> LoadFirst<T>(FilterDefinition<T> filter)
+    {
+        return Find(filter).FirstOrDefaultAsync();
+    }
+    protected Task<List<T>> LoadAll<T>(FilterDefinition<T> filter = null, SortDefinition<T> sortBy = null, int? limit = null, int? offset = null)
+    {
+        return Find(filter, sortBy, limit, offset).ToListAsync();
+    }
+
+    protected IFindFluent<T, T> Find<T>(
+        FilterDefinition<T> filter = null, 
+        SortDefinition<T> sortBy = null, 
+        int? limit = null,
+        int? offset = null)
+    {
+        filter ??= Builders<T>.Filter.Empty;
+        var collection = CreateCollection<T>();
+        var session = _transactionCoordinator?.GetCurrentSession();
+        var findFluent = session != null
+            ? collection.Find(session, filter)
+            : collection.Find(filter);
+        
+        if (sortBy != null)
+        {
+            findFluent = findFluent.Sort(sortBy);
+        }
+        
+        findFluent = findFluent.Skip(offset);
+        findFluent = findFluent.Limit(limit);
+        
+        return findFluent;
+    }
+
+
+    protected IMongoQueryable<TDocument> AsQueryable<TDocument>(AggregateOptions aggregateOptions = null)
+    {
+
+        var mongoCollection = CreateCollection<TDocument>();
+        var session = _transactionCoordinator?.GetCurrentSession();
+        return session != null
+            ? mongoCollection.AsQueryable(session, aggregateOptions)
+            : mongoCollection.AsQueryable(aggregateOptions);
     }
 
     protected Task Insert<T>(T element)
     {
         var mongoCollection = CreateCollection<T>();
-        return mongoCollection.InsertOneAsync(element);
+        var session = _transactionCoordinator?.GetCurrentSession();
+        return session != null
+            ? mongoCollection.InsertOneAsync(session, element)
+            : mongoCollection.InsertOneAsync(element);
     }
 
-    protected async Task<List<T>> LoadAll<T>(Expression<Func<T, bool>> expression = null, int? limit = null)
+    protected Task<UpdateResult> UpdateOneAsync<T>(FilterDefinition<T> filter, UpdateDefinition<T> update, UpdateOptions options = null)
     {
-        if (expression == null) expression = l => true;
         var mongoCollection = CreateCollection<T>();
-        var elements = await mongoCollection.Find(expression).Limit(limit).ToListAsync();
-        return elements;
+        var session = _transactionCoordinator?.GetCurrentSession();
+        return session != null
+            ? mongoCollection.UpdateOneAsync(session, filter, update, options)
+            : mongoCollection.UpdateOneAsync(filter, update, options);
     }
 
-    protected Task<List<T>> LoadSince<T>(DateTimeOffset since) where T : IVersionable
+    protected Task<UpdateResult> UpdateManyAsync<T>(FilterDefinition<T> filter, UpdateDefinition<T> update, UpdateOptions options = null)
     {
-        return LoadAll<T>(m => m.LastUpdated > since);
+        var mongoCollection = CreateCollection<T>();
+        var session = _transactionCoordinator?.GetCurrentSession();
+        return session != null
+            ? mongoCollection.UpdateManyAsync(session, filter, update, options)
+            : mongoCollection.UpdateManyAsync(filter, update, options);
     }
 
-    protected IMongoCollection<T> CreateCollection<T>(string collectionName = null)
+    protected Task<TProjection> FindOneAndUpdateAsync<T, TProjection>(FilterDefinition<T> filter, UpdateDefinition<T> update, FindOneAndUpdateOptions<T, TProjection> options = null, CancellationToken cancellationToken = default)
     {
+        var mongoCollection = CreateCollection<T>();
+        var session = _transactionCoordinator?.GetCurrentSession();
+        return session != null
+            ? mongoCollection.FindOneAndUpdateAsync(session, filter, update, options, cancellationToken)
+            : mongoCollection.FindOneAndUpdateAsync(filter, update, options, cancellationToken);
+    }
+
+    protected Task<List<T>> LoadManySince<T>(DateTimeOffset since) where T : IVersionable
+    {
+        return LoadAll(filter:Builders<T>.Filter.Gt(m => m.LastUpdated, since));
+    }
+
+    private IMongoCollection<T> CreateCollection<T>(string collectionName = null)
+    {
+        // Do not expose the collection to derived classes to enforce the usage of this classes functions which are session aware!
         var mongoDatabase = CreateClient();
         var mongoCollection = mongoDatabase.GetCollection<T>((collectionName ?? typeof(T).Name));
         return mongoCollection;
     }
 
-    protected async Task Upsert<T>(T insertObject, Expression<Func<T, bool>> identityQuerry)
+    protected async Task Upsert<T>(T insertObject, FilterDefinition<T> identityQuery)
     {
-        var mongoDatabase = CreateClient();
-        var mongoCollection = mongoDatabase.GetCollection<T>(typeof(T).Name);
-        await mongoCollection.FindOneAndReplaceAsync(
-            identityQuerry,
-            insertObject,
-            new FindOneAndReplaceOptions<T> { IsUpsert = true });
+        var mongoCollection = CreateCollection<T>();
+        var session = _transactionCoordinator?.GetCurrentSession();
+        var options = new FindOneAndReplaceOptions<T> { IsUpsert = true };
+
+        if (session != null)
+        {
+            await mongoCollection.FindOneAndReplaceAsync(session, identityQuery, insertObject, options);
+        }
+        else
+        {
+            await mongoCollection.FindOneAndReplaceAsync(identityQuery, insertObject, options);
+        }
     }
 
-    protected Task UpsertTimed<T>(T insertObject, Expression<Func<T, bool>> identityQuerry) where T : IVersionable
+    protected Task UpsertTimed<T>(T insertObject, FilterDefinition<T> identityQuery) where T : IVersionable
     {
         insertObject.LastUpdated = DateTimeOffset.UtcNow;
-        return Upsert(insertObject, identityQuerry);
+        return Upsert(insertObject, identityQuery);
+    }
+
+    protected Task<long> Count<T>(FilterDefinition<T> filter, CountOptions options = null, CancellationToken cancellationToken = default)
+    {
+        var collection = CreateCollection<T>();
+        var session = _transactionCoordinator?.GetCurrentSession();
+        return session != null
+            ? collection.CountDocumentsAsync(session, filter, options, cancellationToken)
+            : collection.CountDocumentsAsync(filter, options, cancellationToken);
+    }
+
+    protected IAggregateFluent<TDocument> Aggregate<TDocument>(AggregateOptions options = null)
+    {
+        var c = CreateCollection<TDocument>();
+        var session = _transactionCoordinator?.GetCurrentSession();
+        return session != null
+            ? c.Aggregate(session, options)
+            : c.Aggregate(options);
+    }
+
+    public IAggregateFluent<TNewResult> Lookup<TResult, TForeignDocument, TNewResult>(IAggregateFluent<TResult> aggregate, Expression<Func<TResult, object>> localField, Expression<Func<TForeignDocument, object>> foreignField, Expression<Func<TNewResult, object>> @as, AggregateLookupOptions<TForeignDocument, TNewResult> options = null)
+    {
+        var foreignCollection = CreateCollection<TForeignDocument>();
+        return aggregate.Lookup(foreignCollection, localField, foreignField, @as, options);
     }
 
     protected Task Upsert<T>(T insertObject) where T : IIdentifiable
     {
-        return Upsert(insertObject, x => x.Id == insertObject.Id);
+        return Upsert(insertObject, Builders<T>.Filter.Eq(x => x.Id, insertObject.Id));
     }
 
-    protected Task UpsertMany<T>(List<T> insertObject) where T : IIdentifiable
+    protected Task UpsertMany<T>(List<T> insertObjects) where T : IIdentifiable
     {
-        if (!insertObject.Any()) return Task.CompletedTask;
+        if (!insertObjects.Any()) return Task.CompletedTask;
 
         var collection = CreateCollection<T>();
-        var bulkOps = insertObject
+        var session = _transactionCoordinator?.GetCurrentSession();
+        var bulkOps = insertObjects
             .Select(record => new ReplaceOneModel<T>(Builders<T>.Filter
-            .Where(x => x.Id == record.Id), record)
-            { IsUpsert = true })
+                .Where(x => x.Id == record.Id), record) 
+                { IsUpsert = true })
             .Cast<WriteModel<T>>().ToList();
-        return collection.BulkWriteAsync(bulkOps);
+
+        return session != null
+            ? collection.BulkWriteAsync(session, bulkOps)
+            : collection.BulkWriteAsync(bulkOps);
     }
 
     protected async Task Delete<T>(Expression<Func<T, bool>> deleteQuery)
     {
-        var mongoDatabase = CreateClient();
-        var mongoCollection = mongoDatabase.GetCollection<T>(typeof(T).Name);
-        await mongoCollection.DeleteOneAsync<T>(deleteQuery);
+        var mongoCollection = CreateCollection<T>();
+        var session = _transactionCoordinator?.GetCurrentSession();
+
+        if (session != null)
+        {
+            await mongoCollection.DeleteOneAsync(session, deleteQuery);
+        }
+        else
+        {
+            await mongoCollection.DeleteOneAsync(deleteQuery);
+        }
     }
 
     protected Task Delete<T>(string id) where T : IIdentifiable
@@ -108,12 +217,36 @@ public class MongoDbRepositoryBase
 
     protected async Task UnsetOne<T>(FieldDefinition<T> fieldName, string id) where T : IIdentifiable
     {
-        // $unset
-        var mongoDatabase = CreateClient();
-        var mongoCollection = mongoDatabase.GetCollection<T>(typeof(T).Name);
+        var mongoCollection = CreateCollection<T>();
+        var session = _transactionCoordinator?.GetCurrentSession();
         var updateDefinition = Builders<T>.Update.Unset(fieldName);
-        await mongoCollection.UpdateOneAsync(x => x.Id == id, updateDefinition);
+        var filter = Builders<T>.Filter.Eq(x => x.Id, id);
+
+        if (session != null)
+        {
+            await mongoCollection.UpdateOneAsync(session, filter, updateDefinition);
+        }
+        else
+        {
+            await mongoCollection.UpdateOneAsync(filter, updateDefinition);
+        }
     }
+
+    protected Task<BulkWriteResult<T>> BulkWriteAsync<T>(IEnumerable<WriteModel<T>> requests, BulkWriteOptions options = null)
+    {
+        var collection = CreateCollection<T>();
+        var session = _transactionCoordinator?.GetCurrentSession();
+        return session != null
+            ? collection.BulkWriteAsync(session, requests, options)
+            : collection.BulkWriteAsync(requests, options);
+    }
+
+    protected Task<string> CreateIndexOneAsync<T>(CreateIndexModel<T> model, CreateOneIndexOptions options = null, CancellationToken cancellationToken = default)
+    {
+        var collection = CreateCollection<T>();
+        return collection.Indexes.CreateOneAsync(model, options, cancellationToken);
+    }
+
 }
 
 public interface IIdentifiable

--- a/W3C.Domain/Repositories/MongoDbTransactionCoordinator.cs
+++ b/W3C.Domain/Repositories/MongoDbTransactionCoordinator.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Serilog;
+
+namespace W3C.Domain.Repositories;
+
+public class MongoDbTransactionCoordinator : ITransactionCoordinator
+{
+    private readonly IMongoClient _mongoClient;
+    private IClientSessionHandle _session => IsTransactionActive ? _sessionDictionary[_currentTransactionId.Value] : null;
+    private ConcurrentQueue<Func<Task>> _onSuccessHandlers;
+    private AsyncLocal<Guid> _currentTransactionId = new AsyncLocal<Guid>();
+    private ConcurrentDictionary<Guid, IClientSessionHandle> _sessionDictionary = new ConcurrentDictionary<Guid, IClientSessionHandle>();
+
+    public bool IsTransactionActive
+    {
+        get {
+            if (_currentTransactionId.Value == Guid.Empty) return false;
+            _sessionDictionary.TryGetValue(_currentTransactionId.Value, out var session);
+            if (session == null) return false;
+            return session.IsInTransaction;
+        }
+    }
+
+    public Guid CurrentTransactionId => _currentTransactionId.Value;
+
+    public Guid InitializeTransaction()
+    {
+        if (_currentTransactionId.Value != Guid.Empty)
+        {
+            throw new InvalidOperationException("Transaction already initialized.");
+        }
+
+        var guid = Guid.NewGuid();
+        _currentTransactionId.Value = guid;
+        return guid;
+    }
+
+    public MongoDbTransactionCoordinator(IMongoClient mongoClient)
+    {
+        _mongoClient = mongoClient ?? throw new ArgumentNullException(nameof(mongoClient));
+        _onSuccessHandlers = new ConcurrentQueue<Func<Task>>();
+    }
+
+    public async Task BeginTransactionAsync(Guid transactionId, CancellationToken cancellationToken = default)
+    {
+        if (IsTransactionActive)
+        {
+            throw new InvalidOperationException("A transaction is already in progress.");
+        }
+        if (transactionId != _currentTransactionId.Value)
+        {
+            throw new InvalidOperationException("Transaction id mismatch: " + transactionId + " != " + _currentTransactionId.Value);
+        }
+        var session = await _mongoClient.StartSessionAsync(cancellationToken: cancellationToken);
+        session.StartTransaction();
+        if (!_sessionDictionary.TryAdd(transactionId, session))
+        {
+            throw new InvalidOperationException("Failed to add session to dictionary.");
+        }
+        ClearQueue();
+    }
+
+    public async Task CommitTransactionAsync(Guid transactionId, CancellationToken cancellationToken = default)
+    {
+        if (!IsTransactionActive)
+        {
+            throw new InvalidOperationException("No active transaction to commit.");
+        }
+        await _session.CommitTransactionAsync(cancellationToken);
+        // Transaction was successfully committed, execute all onSuccess handlers
+        await ExecuteOnSuccessHandlersAsync();
+    }
+
+    public async Task AbortTransactionAsync(Guid transactionId, CancellationToken cancellationToken = default)
+    {
+        ClearQueue();
+
+        if (!IsTransactionActive)
+        {
+            // It's often safe to allow aborting a non-existent or already completed transaction.
+            // However, if strictness is desired, an exception can be thrown.
+            // For now, let's allow it to be called safely.
+            return;
+        }
+        await _session.AbortTransactionAsync(cancellationToken);
+    }
+
+    public async Task ExecuteOnSuccessHandlersAsync()
+    {
+        while (_onSuccessHandlers.TryDequeue(out var handler))
+        {
+            await handler();
+        }
+    }
+
+    private void ClearQueue()
+    {
+        while (_onSuccessHandlers.TryDequeue(out _)) { }
+    }
+
+    public Task RegisterOnSuccessHandler(Func<Task> handler, bool executeImmediatelyWithoutTransaction = true)
+    {
+        if (handler == null) throw new ArgumentNullException(nameof(handler));
+
+        if (IsTransactionActive)
+        {
+            _onSuccessHandlers.Enqueue(handler);
+            return Task.CompletedTask;
+        }
+
+        if (executeImmediatelyWithoutTransaction)
+        {
+            return handler();
+        }
+
+        throw new InvalidOperationException("No transaction is active, and immediate execution without a transaction is not allowed for this handler.");
+    }
+
+    public IClientSessionHandle GetCurrentSession()
+    {
+        return _session;
+    }
+
+    public void Dispose()
+    {
+        ClearQueue();
+        _session?.Dispose();
+        _sessionDictionary.TryRemove(_currentTransactionId.Value, out _);
+        _currentTransactionId.Value = Guid.Empty;
+    }
+}

--- a/W3ChampionsStatisticService/Admin/NewsRepository.cs
+++ b/W3ChampionsStatisticService/Admin/NewsRepository.cs
@@ -15,11 +15,10 @@ public class NewsRepository : MongoDbRepositoryBase, INewsRepository
 
     public Task<List<NewsMessage>> Get(int? limit = 5)
     {
-        var mongoCollection = CreateCollection<NewsMessage>();
-        return mongoCollection
-            .Find(r => true)
-            .SortByDescending(m => m.Id)
-            .Limit(limit).ToListAsync();
+        return LoadAll(
+            sortBy: Builders<NewsMessage>.Sort.Descending(m => m.Id),
+            limit: limit
+        );
     }
 
     public Task Save(NewsMessage newsMessage)
@@ -34,6 +33,6 @@ public class NewsRepository : MongoDbRepositoryBase, INewsRepository
 
     public Task UpsertNews(NewsMessage newsMessage)
     {
-        return Upsert(newsMessage, n => n.Id == newsMessage.Id);
+        return Upsert(newsMessage, Builders<NewsMessage>.Filter.Eq(n => n.Id, newsMessage.Id));
     }
 }

--- a/W3ChampionsStatisticService/Clans/ClanCommandHandler.cs
+++ b/W3ChampionsStatisticService/Clans/ClanCommandHandler.cs
@@ -12,10 +12,10 @@ namespace W3ChampionsStatisticService.Clans;
 public class ClanCommandHandler(
     IClanRepository clanRepository,
     IRankRepository rankRepository,
-    TrackingService trackingService)
+    ITrackingService trackingService)
 {
     private readonly IClanRepository _clanRepository = clanRepository;
-    private readonly TrackingService _trackingService = trackingService;
+    private readonly ITrackingService _trackingService = trackingService;
     private readonly IRankRepository _rankRepository = rankRepository;
 
     public async Task<Clan> CreateClan(string clanName, string clanAbbrevation, string battleTagOfFounder)
@@ -211,7 +211,7 @@ public class ClanCommandHandler(
             }
             catch (Exception e)
             {
-                _trackingService.TrackException(e, $"A League was not found for {rank.Id} RN: {rank.RankNumber} LE:{rank.League}");
+                _trackingService?.TrackException(e, $"A League was not found for {rank.Id} RN: {rank.RankNumber} LE:{rank.League}");
             }
         }
     }

--- a/W3ChampionsStatisticService/Clans/ClanRepository.cs
+++ b/W3ChampionsStatisticService/Clans/ClanRepository.cs
@@ -12,31 +12,31 @@ public class ClanRepository : MongoDbRepositoryBase, IClanRepository
 {
     public async Task TryInsertClan(Clan clan)
     {
-        var clanFoundById = await LoadFirst<Clan>(c => c.ClanId == clan.ClanId);
+        var clanFoundById = await LoadFirst(Builders<Clan>.Filter.Eq(c => c.ClanId, clan.ClanId));
         if (clanFoundById != null) throw new ValidationException($"Clan abbreviation already taken: {clan.ClanId}");
-        var clanFoundByName = await LoadFirst<Clan>(c => c.ClanName == clan.ClanName);
+        var clanFoundByName = await LoadFirst(Builders<Clan>.Filter.Eq(c => c.ClanName, clan.ClanName));
         if (clanFoundByName != null) throw new ValidationException($"Clan name already taken: {clan.ClanName}");
         await Insert(clan);
     }
 
     public Task UpsertClan(Clan clan)
     {
-        return Upsert(clan, c => c.ClanId == clan.ClanId);
+        return Upsert(clan, Builders<Clan>.Filter.Eq(c => c.ClanId, clan.ClanId));
     }
 
     public Task<Clan> LoadClan(string clanId)
     {
-        return LoadFirst<Clan>(l => l.ClanId == clanId);
+        return LoadFirst(Builders<Clan>.Filter.Eq(l => l.ClanId, clanId));
     }
 
     public Task<ClanMembership> LoadMemberShip(string battleTag)
     {
-        return LoadFirst<ClanMembership>(m => m.BattleTag == battleTag);
+        return LoadFirst(Builders<ClanMembership>.Filter.Eq(m => m.BattleTag, battleTag));
     }
 
     public Task UpsertMemberShip(ClanMembership clanMemberShip)
     {
-        return UpsertTimed(clanMemberShip, c => c.BattleTag == clanMemberShip.BattleTag);
+        return UpsertTimed(clanMemberShip, Builders<ClanMembership>.Filter.Eq(c => c.BattleTag, clanMemberShip.BattleTag));
     }
 
     public Task DeleteClan(string clanId)
@@ -46,12 +46,12 @@ public class ClanRepository : MongoDbRepositoryBase, IClanRepository
 
     public Task<List<ClanMembership>> LoadMemberShips(List<string> clanMembers)
     {
-        return LoadAll<ClanMembership>(m => clanMembers.Contains(m.BattleTag));
+        return LoadAll(Builders<ClanMembership>.Filter.In(m => m.BattleTag, clanMembers));
     }
 
     public Task<List<ClanMembership>> LoadMemberShipsSince(DateTimeOffset from)
     {
-        return LoadSince<ClanMembership>(from);
+        return LoadManySince<ClanMembership>(from);
     }
 
     public Task SaveMemberShips(List<ClanMembership> clanMembers)

--- a/W3ChampionsStatisticService/Friends/FriendRepository.cs
+++ b/W3ChampionsStatisticService/Friends/FriendRepository.cs
@@ -23,7 +23,7 @@ public class FriendRepository(MongoClient mongoClient) : MongoDbRepositoryBase(m
 
     public Task UpsertFriendlist(Friendlist friendlist)
     {
-        return Upsert(friendlist, p => p.Id == friendlist.Id);
+        return Upsert(friendlist, Builders<Friendlist>.Filter.Eq(p => p.Id, friendlist.Id));
     }
 
     public async Task<FriendRequest> CreateFriendRequest(FriendRequest request)
@@ -34,7 +34,10 @@ public class FriendRepository(MongoClient mongoClient) : MongoDbRepositoryBase(m
 
     public async Task<FriendRequest> LoadFriendRequest(string sender, string receiver)
     {
-        return await LoadFirst<FriendRequest>(r => r.Sender == sender && r.Receiver == receiver);
+        return await LoadFirst<FriendRequest>(Builders<FriendRequest>.Filter.And(
+            Builders<FriendRequest>.Filter.Eq(r => r.Sender, sender),
+            Builders<FriendRequest>.Filter.Eq(r => r.Receiver, receiver)
+        ));
     }
 
     public async Task DeleteFriendRequest(FriendRequest request)
@@ -44,20 +47,23 @@ public class FriendRepository(MongoClient mongoClient) : MongoDbRepositoryBase(m
 
     public async Task<bool> FriendRequestExists(FriendRequest request)
     {
-        var req = await LoadFirst<FriendRequest>(r => r.Sender == request.Sender && r.Receiver == request.Receiver);
+        var req = await LoadFirst(Builders<FriendRequest>.Filter.And(
+            Builders<FriendRequest>.Filter.Eq(r => r.Sender, request.Sender),
+            Builders<FriendRequest>.Filter.Eq(r => r.Receiver, request.Receiver)
+        ));
         if (req == null) return false;
         return true;
     }
 
     public async Task<List<FriendRequest>> LoadAllFriendRequestsSentByPlayer(string sender)
     {
-        var requests = await LoadAll<FriendRequest>(r => r.Sender == sender);
+        var requests = await LoadAll(Builders<FriendRequest>.Filter.Eq(r => r.Sender, sender));
         return requests;
     }
 
     public async Task<List<FriendRequest>> LoadAllFriendRequestsSentToPlayer(string receiver)
     {
-        var requests = await LoadAll<FriendRequest>(r => r.Receiver == receiver);
+        var requests = await LoadAll(Builders<FriendRequest>.Filter.Eq(r => r.Receiver, receiver));
         return requests;
     }
 }

--- a/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
+++ b/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
@@ -89,7 +89,7 @@ public class WebsiteBackendHub(
             var receiverFriendlist = await _friendRepository.LoadFriendlist(req.Receiver);
             await CanMakeFriendRequest(receiverFriendlist, req);
             await _friendRepository.CreateFriendRequest(req);
-            _friendRequestCache.Insert(req);
+            await _friendRequestCache.Insert(req);
             sentRequests.Add(req);
             await Clients.Caller.SendAsync(
                 FriendResponseType.FriendResponseData.ToString(),
@@ -114,7 +114,7 @@ public class WebsiteBackendHub(
         {
             var request = await _friendRequestCache.LoadFriendRequest(req) ?? throw new ValidationException("Could not find a friend request to delete.");
             await _friendRepository.DeleteFriendRequest(request);
-            _friendRequestCache.Delete(request);
+            await _friendRequestCache.Delete(request);
 
             List<FriendRequest> sentRequests = await _friendRequestCache.LoadSentFriendRequests(req.Sender);
             await Clients.Caller.SendAsync(
@@ -143,12 +143,12 @@ public class WebsiteBackendHub(
 
             var request = await _friendRequestCache.LoadFriendRequest(req) ?? throw new ValidationException("Could not find a friend request to accept.");
             await _friendRepository.DeleteFriendRequest(request);
-            _friendRequestCache.Delete(request);
+            await _friendRequestCache.Delete(request);
             var reciprocalRequest = await _friendRequestCache.LoadFriendRequest(new FriendRequest(req.Receiver, req.Sender));
             if (reciprocalRequest != null)
             {
                 await _friendRepository.DeleteFriendRequest(reciprocalRequest);
-                _friendRequestCache.Delete(reciprocalRequest);
+                await _friendRequestCache.Delete(reciprocalRequest);
             }
 
             if (!currentUserFriendlist.Friends.Contains(req.Sender))
@@ -192,7 +192,7 @@ public class WebsiteBackendHub(
         {
             var request = await _friendRequestCache.LoadFriendRequest(req) ?? throw new ValidationException("Could not find a friend request to deny.");
             await _friendRepository.DeleteFriendRequest(request);
-            _friendRequestCache.Delete(request);
+            await _friendRequestCache.Delete(request);
 
             List<FriendRequest> receivedRequests = await _friendRequestCache.LoadReceivedFriendRequests(req.Receiver);
             await Clients.Caller.SendAsync(
@@ -221,7 +221,7 @@ public class WebsiteBackendHub(
 
             var request = await _friendRequestCache.LoadFriendRequest(req) ?? throw new ValidationException("Could not find a friend request to block.");
             await _friendRepository.DeleteFriendRequest(request);
-            _friendRequestCache.Delete(request);
+            await _friendRequestCache.Delete(request);
 
             currentUserFriendlist.BlockedBattleTags.Add(req.Sender);
             await _friendRepository.UpsertFriendlist(currentUserFriendlist);

--- a/W3ChampionsStatisticService/Ladder/PlayOverviewHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/PlayOverviewHandler.cs
@@ -7,7 +7,7 @@ using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Contracts.Matchmaking;
-
+using Serilog;
 namespace W3ChampionsStatisticService.Ladder;
 
 public class PlayOverviewHandler(IPlayerRepository playerRepository) : IReadModelHandler
@@ -21,7 +21,7 @@ public class PlayOverviewHandler(IPlayerRepository playerRepository) : IReadMode
 
         if (winners.Count == 0 || losers.Count == 0)
         {
-            // We should log the bad event here
+            Log.Error("No winners or losers when processing MatchFinishedEvent for {MatchId} in PlayOverviewHandler", nextEvent.match.id);
             return;
         }
 
@@ -29,6 +29,7 @@ public class PlayOverviewHandler(IPlayerRepository playerRepository) : IReadMode
                 || nextEvent.match.gameMode == GameMode.GM_2v2_AT)
             && winners.Count != 2 && losers.Count != 2)
         {
+            Log.Error("Invalid number of winners or losers when processing 2v2 MatchFinishedEvent for {MatchId} in PlayOverviewHandler", nextEvent.match.id);
             return;
         }
 

--- a/W3ChampionsStatisticService/Matches/CanceledMatchesHandler.cs
+++ b/W3ChampionsStatisticService/Matches/CanceledMatchesHandler.cs
@@ -1,0 +1,75 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using W3C.Domain.Repositories;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.ReadModelBase;
+using W3ChampionsStatisticService.Services;
+using W3C.Contracts.Matchmaking;
+using Serilog;
+using System.Transactions;
+using System;
+
+namespace W3ChampionsStatisticService.Matches;
+
+public class CanceledMatchesHandler(
+    IMatchEventRepository eventRepository,
+    IMatchRepository matchRepository,
+    ITransactionCoordinator transactionCoordinator,
+    ITrackingService trackingService) : IAsyncUpdatable
+{
+    private readonly IMatchEventRepository _eventRepository = eventRepository;
+    private readonly IMatchRepository _matchRepository = matchRepository;
+    private readonly ITransactionCoordinator _transactionCoordinator = transactionCoordinator;
+    private readonly ITrackingService _trackingService = trackingService;
+
+    public async Task Update()
+    {
+        var nextEvents = await _eventRepository.LoadCanceledMatches();
+
+        while (nextEvents.Count != 0)
+        {
+            foreach (var nextEvent in nextEvents)
+            {
+                try
+                {
+                    await using (var transaction = AsyncTransactionScope.Create(_transactionCoordinator))
+                    {
+                        await transaction.Start();
+                        if (nextEvent.match.gameMode != GameMode.CUSTOM)
+                        {
+                            var ongoingMatch = await _matchRepository.LoadDetailsByOngoingMatchId(nextEvent.match.id);
+
+                            if (ongoingMatch == null)
+                            {
+                                Log.Warning($"Canceled match {nextEvent.match.id} not found");
+                            }
+                            else
+                            {
+                                if (ongoingMatch.Match != null)
+                                {
+                                    Log.Information($"Canceling ongoing match {ongoingMatch.Match.Id}");
+                                    await _matchRepository.DeleteOnGoingMatch(ongoingMatch.Match);
+                                }
+                                else
+                                {
+                                    Log.Warning($"Canceled match detail had null Match property for {nextEvent.match.id}");
+                                    await _matchRepository.DeleteOnGoingMatch(new Matchup { MatchId = nextEvent.match.id });
+                                }
+                            }
+                        }
+
+                        await _eventRepository.DeleteCanceledEvent(nextEvent.Id);
+                        transaction.Complete();
+                    }
+                }
+                catch (Exception e)
+                {
+                    _trackingService?.TrackException(e, $"CanceledMatchesHandler died on event {nextEvent.Id}");
+                    throw;
+                }
+            }
+
+            nextEvents = await _eventRepository.LoadCanceledMatches();
+        }
+    }
+}

--- a/W3ChampionsStatisticService/Matches/MatchReadModelHandler.cs
+++ b/W3ChampionsStatisticService/Matches/MatchReadModelHandler.cs
@@ -19,12 +19,12 @@ public class MatchReadModelHandler(IMatchRepository matchRepository) : IReadMode
             var matchup = Matchup.Create(nextEvent);
 
             await _matchRepository.Insert(matchup);
-            await _matchRepository.DeleteOnGoingMatch(matchup.MatchId);
+            await _matchRepository.DeleteOnGoingMatch(matchup);
         }
         catch (Exception e)
         {
-            Console.WriteLine(e);
-            Log.Error($"Error handling MatchFinishedEvent: {e.Message}");
+            Log.Error($"Error handling MatchFinishedEvent of Match {nextEvent.match.id} for MatchReadModel: {e.Message}");
+            throw; // Rethrow or we will lose this event!
         }
     }
 }

--- a/W3ChampionsStatisticService/Matches/OngoingMatchesHandler.cs
+++ b/W3ChampionsStatisticService/Matches/OngoingMatchesHandler.cs
@@ -4,17 +4,24 @@ using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Contracts.Matchmaking;
+using Serilog;
+using W3ChampionsStatisticService.Services;
+using System;
 
 namespace W3ChampionsStatisticService.Matches;
 
 public class OngoingMatchesHandler(
     IMatchEventRepository eventRepository,
     IMatchRepository matchRepository,
-    IPersonalSettingsRepository personalSettingsRepository) : IAsyncUpdatable
+    IPersonalSettingsRepository personalSettingsRepository,
+    ITransactionCoordinator transactionCoordinator,
+    ITrackingService trackingService) : IAsyncUpdatable
 {
     private readonly IMatchEventRepository _eventRepository = eventRepository;
     private readonly IMatchRepository _matchRepository = matchRepository;
     private readonly IPersonalSettingsRepository _personalSettingsRepository = personalSettingsRepository;
+    private readonly ITransactionCoordinator _transactionCoordinator = transactionCoordinator;
+    private readonly ITrackingService _trackingService = trackingService;
 
     public async Task Update()
     {
@@ -24,30 +31,44 @@ public class OngoingMatchesHandler(
         {
             foreach (var nextEvent in nextEvents)
             {
-                if (nextEvent.match.gameMode != GameMode.CUSTOM)
+                try
                 {
-                    var matchup = OnGoingMatchup.Create(nextEvent);
-
-                    foreach (var team in matchup.Teams)
-                        foreach (var player in team.Players)
+                    await using (var transaction = AsyncTransactionScope.Create(_transactionCoordinator))
+                    {
+                        await transaction.Start();
+                        if (nextEvent.match.gameMode != GameMode.CUSTOM)
                         {
-                            var foundMatchForPlayer = await _matchRepository.LoadOnGoingMatchForPlayer(player.BattleTag);
-                            if (foundMatchForPlayer != null)
-                            {
-                                await _matchRepository.DeleteOnGoingMatch(foundMatchForPlayer.MatchId);
-                            }
+                            var matchup = OnGoingMatchup.Create(nextEvent);
 
-                            var personalSettings = await _personalSettingsRepository.LoadOrCreate(player.BattleTag);
-                            if (personalSettings != null)
-                            {
-                                player.CountryCode = personalSettings.CountryCode;
-                            }
+                            foreach (var team in matchup.Teams)
+                                foreach (var player in team.Players)
+                                {
+                                    var foundMatchForPlayer = await _matchRepository.LoadOnGoingMatchForPlayer(player.BattleTag);
+                                    if (foundMatchForPlayer != null)
+                                    {
+                                        Log.Warning("Deleting stale ongoing match {MatchId} for player {Player} as new match {NewMatchId} is starting", foundMatchForPlayer.MatchId, player.BattleTag, nextEvent.match.id);
+                                        await _matchRepository.DeleteOnGoingMatch(foundMatchForPlayer);
+                                    }
+
+                                    var personalSettings = await _personalSettingsRepository.LoadOrCreate(player.BattleTag);
+                                    if (personalSettings != null)
+                                    {
+                                        player.CountryCode = personalSettings.CountryCode;
+                                    }
+                                }
+
+                            await _matchRepository.InsertOnGoingMatch(matchup);
                         }
 
-                    await _matchRepository.InsertOnGoingMatch(matchup);
+                        await _eventRepository.DeleteStartedEvent(nextEvent.Id);
+                        transaction.Complete();
+                    }
                 }
-
-                await _eventRepository.DeleteStartedEvent(nextEvent.Id);
+                catch (Exception e)
+                {
+                    _trackingService?.TrackException(e, $"OngoingMatchesHandler died on event {nextEvent.Id}");
+                    throw;
+                }
             }
 
             nextEvents = await _eventRepository.LoadStartedMatches();

--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/GameModeStatQueryHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/GameModeStatQueryHandler.cs
@@ -13,12 +13,12 @@ namespace W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
 public class GameModeStatQueryHandler(
     IPlayerRepository playerRepository,
     PlayerService playerService,
-    TrackingService trackingService,
+    ITrackingService trackingService,
     IRankRepository rankRepository)
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;
     private readonly PlayerService _playerService = playerService;
-    private readonly TrackingService _trackingService = trackingService;
+    private readonly ITrackingService _trackingService = trackingService;
     private readonly IRankRepository _rankRepository = rankRepository;
 
     public async Task<List<PlayerGameModeStatPerGateway>> LoadPlayerStatsWithRanks(

--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGatewayHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGatewayHandler.cs
@@ -7,6 +7,7 @@ using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Contracts.Matchmaking;
+using Serilog;
 
 namespace W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
 
@@ -31,13 +32,14 @@ public class PlayerGameModeStatPerGatewayHandler : IReadModelHandler
 
         if (winners.Count == 0 || losers.Count == 0)
         {
-            // We should log the bad event here
+            Log.Error("No winners or losers when processing MatchFinishedEvent for {MatchId} in PlayerGameModeStatPerGatewayHandler", nextEvent.match.id);
             return;
         }
 
         if ((nextEvent.match.gameMode == GameMode.GM_2v2 || nextEvent.match.gameMode == GameMode.GM_2v2_AT)
             && winners.Count != 2 && losers.Count != 2)
         {
+            Log.Error("Invalid number of winners or losers when processing MatchFinishedEvent for {MatchId} in PlayerGameModeStatPerGatewayHandler", nextEvent.match.id);
             return;
         }
 

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -47,7 +47,7 @@ public interface IMatchRepository
     Task InsertOnGoingMatch(OnGoingMatchup matchup);
     Task<OnGoingMatchup> LoadOnGoingMatchForPlayer(string playerId);
     Task<OnGoingMatchup> TryLoadOnGoingMatchForPlayer(string playerId);
-    Task DeleteOnGoingMatch(string matchId);
+    Task DeleteOnGoingMatch(Matchup matchup);
 
     Task<List<OnGoingMatchup>> LoadOnGoingMatches(
         GameMode gameMode = GameMode.Undefined,

--- a/W3ChampionsStatisticService/ReadModelBase/AsyncServiceBase.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/AsyncServiceBase.cs
@@ -40,8 +40,8 @@ public class AsyncServiceBase<T>(IServiceScopeFactory serviceScopeFactory) : IHo
                 }
                 catch (Exception e)
                 {
-                    var telemetryClient = scope.ServiceProvider.GetService<TrackingService>();
-                    telemetryClient.TrackException(e, "Some Readmodelhandler is dying");
+                    var telemetryClient = scope.ServiceProvider.GetService<ITrackingService>();
+                    telemetryClient?.TrackException(e, "Some Readmodelhandler is dying");
                     Log.Error($"Some Readmodelhandler is dying: {e.Message}");
                 }
 

--- a/W3ChampionsStatisticService/ReadModelBase/ReadModelHandler.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/ReadModelHandler.cs
@@ -12,18 +12,21 @@ public class ReadModelHandler<T> : IAsyncUpdatable where T : IReadModelHandler
     private readonly IMatchEventRepository _eventRepository;
     private readonly IVersionRepository _versionRepository;
     private readonly T _innerHandler;
-    private readonly TrackingService _trackingService;
+    private readonly ITrackingService _trackingService;
+    private readonly ITransactionCoordinator _transactionCoordinator;
 
     public ReadModelHandler(
         IMatchEventRepository eventRepository,
         IVersionRepository versionRepository,
         T innerHandler,
-        TrackingService trackingService = null)
+        ITransactionCoordinator transactionCoordinator,
+        ITrackingService trackingService = null)
     {
         _eventRepository = eventRepository;
         _versionRepository = versionRepository;
         _innerHandler = innerHandler;
         _trackingService = trackingService;
+        _transactionCoordinator = transactionCoordinator ?? throw new ArgumentNullException(nameof(transactionCoordinator));
     }
 
     public async Task Update()
@@ -31,31 +34,35 @@ public class ReadModelHandler<T> : IAsyncUpdatable where T : IReadModelHandler
         var lastVersion = await _versionRepository.GetLastVersion<T>();
         var nextEvents = await _eventRepository.Load(lastVersion.Version, 1000);
 
-        while (nextEvents.Any())
+        while (nextEvents.Count != 0)
         {
             foreach (var nextEvent in nextEvents)
             {
+                if (lastVersion.IsStopped) return;
                 try
                 {
-                    if (lastVersion.IsStopped) return;
-
-                    if (nextEvent.match.season > lastVersion.Season)
+                    await using (var transaction = AsyncTransactionScope.Create(_transactionCoordinator))
                     {
-                        await _versionRepository.SaveLastVersion<T>(lastVersion.Version, nextEvent.match.season);
-                        lastVersion = await _versionRepository.GetLastVersion<T>();
-                    }
+                        await transaction.Start();
+                        if (nextEvent.match.season > lastVersion.Season)
+                        {
+                            await _versionRepository.SaveLastVersion<T>(lastVersion.Version, nextEvent.match.season);
+                            lastVersion = await _versionRepository.GetLastVersion<T>();
+                        }
 
-                    // Skip the cancel events for now
-                    if (nextEvent.match.state != 3 && nextEvent.match.season == lastVersion.Season)
-                    {
-                        await _innerHandler.Update(nextEvent);
-                    }
+                        // Skip the cancel events for now
+                        if (nextEvent.match.state != 3 && nextEvent.match.season == lastVersion.Season)
+                        {
+                            await _innerHandler.Update(nextEvent);
+                        }
 
-                    await _versionRepository.SaveLastVersion<T>(nextEvent.Id.ToString(), lastVersion.Season);
+                        await _versionRepository.SaveLastVersion<T>(nextEvent.Id.ToString(), lastVersion.Season);
+                        transaction.Complete();
+                    }
                 }
                 catch (Exception e)
                 {
-                    _trackingService.TrackException(e, $"ReadmodelHandler: {typeof(T).Name} died on event{nextEvent.Id}");
+                    _trackingService?.TrackException(e, $"ReadmodelHandler: {typeof(T).Name} died on event{nextEvent.Id}");
                     throw;
                 }
             }

--- a/W3ChampionsStatisticService/Rewards/Portraits/PortraitRepository.cs
+++ b/W3ChampionsStatisticService/Rewards/Portraits/PortraitRepository.cs
@@ -8,9 +8,9 @@ namespace W3ChampionsStatisticService.Rewards.Portraits;
 
 public class PortraitRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IPortraitRepository
 {
-    public Task<List<PortraitDefinition>> LoadPortraitDefinitions()
+    public async Task<List<PortraitDefinition>> LoadPortraitDefinitions()
     {
-        return LoadAll<PortraitDefinition>();
+        return await LoadAll<PortraitDefinition>();
     }
 
     public async Task SaveNewPortraitDefinitions(List<int> _ids, List<string> _group = null)
@@ -54,11 +54,10 @@ public class PortraitRepository(MongoClient mongoClient) : MongoDbRepositoryBase
 
     public async Task<List<PortraitGroup>> LoadDistinctPortraitGroups()
     {
-        var mongoCollection = CreateCollection<PortraitDefinition>();
+        var filter = Builders<PortraitDefinition>.Filter.Ne(p => p.Groups, []);
 
-        var pipeline = await mongoCollection
-            .Aggregate()
-            .Match(p => p.Groups.Count > 0)
+        var pipeline = await Aggregate<PortraitDefinition>()
+            .Match(filter)
             .Unwind<PortraitDefinition, SinglePortraitDefinitionAndGroup>(p => p.Groups)
             .ToListAsync();
 
@@ -69,6 +68,6 @@ public class PortraitRepository(MongoClient mongoClient) : MongoDbRepositoryBase
 
         }).ToList();
 
-        return grouped;
+        return grouped; 
     }
 }

--- a/W3ChampionsStatisticService/Services/TrackingService.cs
+++ b/W3ChampionsStatisticService/Services/TrackingService.cs
@@ -6,12 +6,24 @@ using Microsoft.Extensions.Logging;
 
 namespace W3ChampionsStatisticService.Services;
 
-public class TrackingService(
-    TelemetryClient telemetry,
-    ILogger<TrackingService> logger)
+public interface ITrackingService
 {
-    private TelemetryClient _telemetry = telemetry;
-    private readonly ILogger<TrackingService> _logger = logger;
+    void TrackUnauthorizedRequest(string authorization, ControllerBase controller);
+    void TrackException(Exception ex, string message);
+}
+
+public class TrackingService : ITrackingService
+{
+    private readonly TelemetryClient _telemetry;
+    private readonly ILogger<TrackingService> _logger;
+
+    public TrackingService(
+        TelemetryClient telemetry,
+        ILogger<TrackingService> logger)
+    {
+        _telemetry = telemetry;
+        _logger = logger;
+    }
 
     public void TrackUnauthorizedRequest(string authorization, ControllerBase controller)
     {

--- a/WC3ChampionsStatisticService.UnitTests/Domain/Repositories/AsyncTransactionScopeTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Domain/Repositories/AsyncTransactionScopeTests.cs
@@ -1,0 +1,120 @@
+using MongoDB.Driver;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+using W3C.Domain.Repositories;
+using W3ChampionsStatisticService.Matches;
+namespace WC3ChampionsStatisticService.Tests.Domain.Repositories;
+
+[TestFixture]
+public class AsyncTransactionScopeTests : IntegrationTestBase
+{
+    private MongoDbTransactionCoordinator _transactionCoordinator;
+
+    [SetUp]
+    public void SetupTest()
+    {
+        _transactionCoordinator = new MongoDbTransactionCoordinator(MongoClient);
+    }
+
+    [Test]
+    public void CreateAsync_NullCoordinator_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => AsyncTransactionScope.Create(null));
+    }
+
+    [Test]
+    public async Task DisposeAsync_WhenCompleted_CallsCommitTransaction()
+    {
+        bool handlerRun = false;
+        await using (var scope = AsyncTransactionScope.Create(_transactionCoordinator))
+        {
+            await scope.Start();
+            await scope.RegisterOnSuccessHandler(async () =>
+            {
+                handlerRun = true;
+            });
+            scope.Complete();
+        }
+
+        Assert.IsTrue(handlerRun);
+    }
+
+    [Test]
+    public async Task DisposeAsync_WhenNotCompleted_CallsAbortTransaction()
+    {
+        bool handlerRun = false;
+        await using (var scope = AsyncTransactionScope.Create(_transactionCoordinator))
+        {
+            await scope.Start();
+            await scope.RegisterOnSuccessHandler(async () =>
+            {
+                handlerRun = true;
+            });
+            // No call to scope.Complete()
+        }
+
+        Assert.IsFalse(handlerRun);
+    }
+
+
+    [Test]
+    public async Task Complete_WhenTransactionNotActive_ThrowsInvalidOperationException()
+    {
+        await using (var scope = AsyncTransactionScope.Create(_transactionCoordinator))
+        {
+            // No call to scope.Start();
+            Assert.Throws<InvalidOperationException>(() => scope.Complete());
+        }
+    }
+
+    [Test]
+    public async Task RollbackWorksForMatches()
+    {
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
+        var matches = await matchRepository.LoadOnGoingMatches();
+        Assert.AreEqual(0, matches.Count);
+        var matchup = OnGoingMatchup.Create(TestDtoHelper.CreateFakeStartedEvent());
+
+        await using (var transactionScope = AsyncTransactionScope.Create(_transactionCoordinator))
+        {
+            await transactionScope.Start();
+            await matchRepository.InsertOnGoingMatch(matchup);
+            var dbMatch = await matchRepository.LoadOnGoingMatchForPlayer(matchup.Teams[0].Players[0].BattleTag);
+            Assert.IsNotNull(dbMatch);
+            transactionScope.Complete(); // Commit
+        }
+
+        await using (var transactionScope = AsyncTransactionScope.Create(_transactionCoordinator))
+        {
+            await transactionScope.Start();
+            var dbMatch2 = await matchRepository.LoadOnGoingMatchForPlayer(matchup.Teams[0].Players[0].BattleTag);
+            Assert.IsNotNull(dbMatch2);
+            await matchRepository.DeleteOnGoingMatch(dbMatch2);
+            dbMatch2 = await matchRepository.LoadOnGoingMatchForPlayer(matchup.Teams[0].Players[0].BattleTag);
+            Assert.IsNull(dbMatch2);
+            // No Complete, roll back
+            transactionScope.Complete();
+        }
+
+        await using (var transactionScope = AsyncTransactionScope.Create(_transactionCoordinator))
+        {
+            await transactionScope.Start();
+            var dbMatch3 = await matchRepository.LoadOnGoingMatchForPlayer(matchup.Teams[0].Players[0].BattleTag);
+            Assert.IsNotNull(dbMatch3);
+            await matchRepository.DeleteOnGoingMatch(dbMatch3);
+            dbMatch3 = await matchRepository.LoadOnGoingMatchForPlayer(matchup.Teams[0].Players[0].BattleTag);
+            Assert.IsNull(dbMatch3);
+            transactionScope.Complete();
+        }
+
+        var dbMatch4 = await matchRepository.LoadOnGoingMatchForPlayer(matchup.Teams[0].Players[0].BattleTag);
+        Assert.IsNull(dbMatch4);
+        var matches2 = await matchRepository.LoadOnGoingMatches();
+        Assert.AreEqual(0, matches2.Count);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
@@ -220,7 +220,7 @@ public static class TestDtoHelper
         };
     }
 
-    public static MatchStartedEvent CreateFakeStartedEvent()
+    public static MatchStartedEvent CreateFakeStartedEvent(long startTime = 1000000, int mmr = 2500)
     {
         var fixture = new Fixture { RepeatCount = 4 };
         var fakeEvent = fixture.Build<MatchStartedEvent>().With(e => e.Id, ObjectId.GenerateNewId()).Create();
@@ -235,11 +235,17 @@ public static class TestDtoHelper
         fakeEvent.match.gateway = GateWay.America;
         fakeEvent.match.gameMode = GameMode.GM_2v2_AT;
         fakeEvent.match.season = 0;
+        fakeEvent.match.startTime = startTime;
 
         fakeEvent.match.players[0].battleTag = name1;
         fakeEvent.match.players[1].battleTag = name2;
         fakeEvent.match.players[2].battleTag = name3;
         fakeEvent.match.players[3].battleTag = name4;
+
+        fakeEvent.match.players[0].mmr.rating = mmr;
+        fakeEvent.match.players[1].mmr.rating = mmr;
+        fakeEvent.match.players[2].mmr.rating = mmr;
+        fakeEvent.match.players[3].mmr.rating = mmr;
 
         return fakeEvent;
     }

--- a/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
+++ b/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
@@ -15,7 +15,7 @@ namespace WC3ChampionsStatisticService.Tests;
 
 public class IntegrationTestBase
 {
-    //protected readonly MongoClient MongoClient = new MongoClient("mongodb://localhost:27017/");
+    //protected readonly MongoClient MongoClient = new MongoClient("mongodb://w3champions:XXX@localhost:3510?directConnection=true&serverSelectionTimeoutMS=2000&authSource=admin&replicaSet=rs0");
     protected readonly MongoClient MongoClient = new("mongodb://157.90.1.251:3512/");
 
     protected PersonalSettingsProvider personalSettingsProvider;
@@ -48,7 +48,7 @@ public class IntegrationTestBase
         var mongoDatabase = database;
         var mongoCollection = mongoDatabase.GetCollection<MatchFinishedEvent>(nameof(MatchFinishedEvent));
         await mongoCollection.FindOneAndReplaceAsync(
-            (Expression<Func<MatchFinishedEvent, bool>>)(ev => ev.match.id == newEvent.match.id),
+            Builders<MatchFinishedEvent>.Filter.Eq(ev => ev.match.id, newEvent.match.id),
             newEvent,
             new FindOneAndReplaceOptions<MatchFinishedEvent> { IsUpsert = true });
     }
@@ -59,7 +59,7 @@ public class IntegrationTestBase
         var mongoDatabase = database;
         var mongoCollection = mongoDatabase.GetCollection<MatchStartedEvent>(nameof(MatchStartedEvent));
         await mongoCollection.FindOneAndReplaceAsync(
-            (Expression<Func<MatchStartedEvent, bool>>)(ev => ev.match.id == newEvent.match.id),
+            Builders<MatchStartedEvent>.Filter.Eq(ev => ev.match.id, newEvent.match.id),
             newEvent,
             new FindOneAndReplaceOptions<MatchStartedEvent> { IsUpsert = true });
     }
@@ -70,7 +70,7 @@ public class IntegrationTestBase
         var mongoDatabase = database;
         var mongoCollection = mongoDatabase.GetCollection<RankingChangedEvent>(nameof(RankingChangedEvent));
         await mongoCollection.FindOneAndReplaceAsync(
-            (Expression<Func<RankingChangedEvent, bool>>)(ev => ev.id == newEvent.id),
+            Builders<RankingChangedEvent>.Filter.Eq(ev => ev.id, newEvent.id),
             newEvent,
             new FindOneAndReplaceOptions<RankingChangedEvent> { IsUpsert = true });
     }

--- a/WC3ChampionsStatisticService.UnitTests/Matches/CanceledMatchesHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matches/CanceledMatchesHandlerTests.cs
@@ -1,0 +1,197 @@
+using Moq;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using W3C.Domain.Repositories;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.ReadModelBase;
+using W3ChampionsStatisticService.Services;
+using W3C.Contracts.Matchmaking;
+using MongoDB.Bson;
+using System;
+using W3C.Domain.MatchmakingService;
+using W3ChampionsStatisticService.Matches;
+
+namespace WC3ChampionsStatisticService.Tests.Matches;
+
+// Helper class to implement the structure required by CanceledMatchesHandler
+// We create this because the handler calls ongoingMatch.Match.Id.ToString() 
+// and whatever object 'Match' refers to must have an ObjectId property named 'Id'
+public class MatchWithObjectId
+{
+    public ObjectId Id { get; set; }
+    // Add other properties if CanceledMatchesHandler accesses them via ongoingMatch.Match
+}
+
+[TestFixture]
+public class CanceledMatchesHandlerTests
+{
+    private Mock<IMatchEventRepository> _mockEventRepo;
+    private Mock<IMatchRepository> _mockMatchRepo;
+    private Mock<ITransactionCoordinator> _mockTransactionCoordinator;
+    private Mock<ITrackingService> _mockTrackingService;
+    private CanceledMatchesHandler _handler;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockEventRepo = new Mock<IMatchEventRepository>();
+        _mockMatchRepo = new Mock<IMatchRepository>();
+        _mockTransactionCoordinator = new Mock<ITransactionCoordinator>();
+        _mockTrackingService = new Mock<ITrackingService>();
+
+        _handler = new CanceledMatchesHandler(
+            _mockEventRepo.Object,
+            _mockMatchRepo.Object,
+            _mockTransactionCoordinator.Object,
+            _mockTrackingService.Object);
+
+        _mockTransactionCoordinator.Setup(t => t.BeginTransactionAsync(It.IsAny<Guid>(), default)).Returns(Task.CompletedTask);
+        _mockTransactionCoordinator.Setup(t => t.CommitTransactionAsync(It.IsAny<Guid>(), default)).Returns(Task.CompletedTask);
+        _mockTransactionCoordinator.Setup(t => t.AbortTransactionAsync(It.IsAny<Guid>(), default)).Returns(Task.CompletedTask);
+        _mockTransactionCoordinator.Setup(t => t.IsTransactionActive).Returns(true);
+    }
+
+    private MatchCanceledEvent CreateFakeMatchCanceledEvent(string matchId, GameMode gameMode = GameMode.GM_1v1)
+    {
+        return new MatchCanceledEvent
+        {
+            Id = ObjectId.GenerateNewId(),
+            match = new W3C.Domain.MatchmakingService.Match { id = matchId, gameMode = gameMode }
+        };
+    }
+
+    [Test]
+    public async Task Update_NoCanceledEvents_DoesNothing()
+    {
+        _mockEventRepo.Setup(r => r.LoadCanceledMatches())
+            .Returns(Task.FromResult(new List<MatchCanceledEvent>()));
+
+        await _handler.Update();
+
+        _mockMatchRepo.Verify(r => r.DeleteOnGoingMatch(It.IsAny<Matchup>()), Times.Never);
+        _mockEventRepo.Verify(r => r.DeleteCanceledEvent(It.IsAny<ObjectId>()), Times.Never);
+        _mockTransactionCoordinator.Verify(t => t.BeginTransactionAsync(It.IsAny<Guid>(),default), Times.Never);
+    }
+
+    [Test]
+    public async Task Update_ProcessesNonCustomGame_DeletesOngoingMatchAndEvent()
+    {
+        var eventMatchId = "someFakeMatchStringId123";
+        var canceledEvent = CreateFakeMatchCanceledEvent(eventMatchId, GameMode.GM_1v1);
+        var dbObjectId = ObjectId.GenerateNewId();
+
+        // Create a mock MatchupDetail with an Id that can be converted to string
+        var mockMatchupDetail = new Mock<MatchupDetail>();
+
+        // Setup the Mock to capture the Matchup object that will be passed to DeleteOnGoingMatch
+        Matchup capturedMatchup = null;
+        _mockMatchRepo.Setup(r => r.DeleteOnGoingMatch(It.IsAny<Matchup>()))
+            .Callback<Matchup>(m => capturedMatchup = m)
+            .Returns(Task.CompletedTask);
+
+        _mockEventRepo.SetupSequence(r => r.LoadCanceledMatches())
+            .Returns(Task.FromResult(new List<MatchCanceledEvent> { canceledEvent }))
+            .Returns(Task.FromResult(new List<MatchCanceledEvent>()));
+
+        // Mock this call to return a MatchupDetail with a known MatchId
+        // The CanceledMatchesHandler implementation must now construct a Matchup from this
+        _mockMatchRepo.Setup(r => r.LoadDetailsByOngoingMatchId(eventMatchId))
+            .Returns(Task.FromResult(mockMatchupDetail.Object));
+
+        await _handler.Update();
+
+        _mockTransactionCoordinator.Verify(t => t.BeginTransactionAsync(It.IsAny<Guid>(),default), Times.Once);
+        _mockMatchRepo.Verify(r => r.DeleteOnGoingMatch(It.IsAny<Matchup>()), Times.Once);
+        _mockEventRepo.Verify(r => r.DeleteCanceledEvent(canceledEvent.Id), Times.Once);
+        _mockTransactionCoordinator.Verify(t => t.CommitTransactionAsync(It.IsAny<Guid>(),default), Times.Once);
+        _mockTransactionCoordinator.Verify(t => t.AbortTransactionAsync(It.IsAny<Guid>(),default), Times.Never);
+    }
+
+    [Test]
+    public async Task Update_ProcessesCustomGame_DeletesOnlyEvent()
+    {
+        var matchId = "customGameMatchId789";
+        var canceledEvent = CreateFakeMatchCanceledEvent(matchId, GameMode.CUSTOM);
+
+        _mockEventRepo.SetupSequence(r => r.LoadCanceledMatches())
+            .Returns(Task.FromResult(new List<MatchCanceledEvent> { canceledEvent }))
+            .Returns(Task.FromResult(new List<MatchCanceledEvent>()));
+
+        await _handler.Update();
+
+        _mockTransactionCoordinator.Verify(t => t.BeginTransactionAsync(It.IsAny<Guid>(),default), Times.Once);
+        _mockMatchRepo.Verify(r => r.DeleteOnGoingMatch(It.IsAny<Matchup>()), Times.Never);
+        _mockMatchRepo.Verify(r => r.LoadDetailsByOngoingMatchId(It.IsAny<string>()), Times.Never);
+        _mockEventRepo.Verify(r => r.DeleteCanceledEvent(canceledEvent.Id), Times.Once);
+        _mockTransactionCoordinator.Verify(t => t.CommitTransactionAsync(It.IsAny<Guid>(),default), Times.Once);
+    }
+
+    [Test]
+    public async Task Update_OngoingMatchNotFound_LogsWarningAndContinues_DeletesEvent()
+    {
+        var matchId = "nonExistentMatchId456";
+        var canceledEvent = CreateFakeMatchCanceledEvent(matchId, GameMode.GM_1v1);
+
+        _mockEventRepo.SetupSequence(r => r.LoadCanceledMatches())
+            .Returns(Task.FromResult(new List<MatchCanceledEvent> { canceledEvent }))
+            .Returns(Task.FromResult(new List<MatchCanceledEvent>()));
+
+        _mockMatchRepo.Setup(r => r.LoadDetailsByOngoingMatchId(matchId))
+            .Returns(Task.FromResult<MatchupDetail>(null));
+
+        await _handler.Update();
+
+        _mockTransactionCoordinator.Verify(t => t.BeginTransactionAsync(It.IsAny<Guid>(),default), Times.Once);
+        _mockMatchRepo.Verify(r => r.DeleteOnGoingMatch(It.IsAny<Matchup>()), Times.Never);
+        _mockEventRepo.Verify(r => r.DeleteCanceledEvent(canceledEvent.Id), Times.Once);
+        _mockTransactionCoordinator.Verify(t => t.CommitTransactionAsync(It.IsAny<Guid>(),default), Times.Once);
+    }
+
+    [Test]
+    public void Update_ExceptionDuringProcessing_AbortsTransactionAndTracksException()
+    {
+        var matchId = "errorMatchId101";
+        var canceledEvent = CreateFakeMatchCanceledEvent(matchId, GameMode.GM_1v1);
+        var expectedException = new Exception("Database error");
+
+        _mockEventRepo.SetupSequence(r => r.LoadCanceledMatches())
+            .Returns(Task.FromResult(new List<MatchCanceledEvent> { canceledEvent }))
+            .Returns(Task.FromResult(new List<MatchCanceledEvent>()));
+
+        _mockMatchRepo.Setup(r => r.LoadDetailsByOngoingMatchId(matchId))
+            .ThrowsAsync(expectedException);
+
+        // Use Throws.TypeOf to assert that an exception is thrown
+        Assert.That(async () => await _handler.Update(), Throws.TypeOf<Exception>());
+
+        _mockTransactionCoordinator.Verify(t => t.BeginTransactionAsync(It.IsAny<Guid>(),default), Times.Once);
+        _mockTransactionCoordinator.Verify(t => t.CommitTransactionAsync(It.IsAny<Guid>(),default), Times.Never);
+        _mockTransactionCoordinator.Verify(t => t.AbortTransactionAsync(It.IsAny<Guid>(),default), Times.Once);
+        _mockTrackingService.Verify(ts => ts.TrackException(expectedException, $"CanceledMatchesHandler died on event {canceledEvent.Id}"), Times.Once);
+        _mockEventRepo.Verify(r => r.DeleteCanceledEvent(It.IsAny<ObjectId>()), Times.Never);
+    }
+
+    [Test]
+    public void Update_ExceptionDeletingEvent_AbortsTransactionAndTracksException()
+    {
+        var matchId = "eventDeleteErrorMatchId102";
+        var canceledEvent = CreateFakeMatchCanceledEvent(matchId, GameMode.CUSTOM);
+        var expectedException = new Exception("Event delete error");
+
+        _mockEventRepo.SetupSequence(r => r.LoadCanceledMatches())
+            .Returns(Task.FromResult(new List<MatchCanceledEvent> { canceledEvent }))
+            .Returns(Task.FromResult(new List<MatchCanceledEvent>()));
+
+        _mockEventRepo.Setup(r => r.DeleteCanceledEvent(canceledEvent.Id))
+            .ThrowsAsync(expectedException);
+
+        // Use Throws.TypeOf to assert that an exception is thrown
+        Assert.That(async () => await _handler.Update(), Throws.TypeOf<Exception>());
+
+        _mockTransactionCoordinator.Verify(t => t.BeginTransactionAsync(It.IsAny<Guid>(),default), Times.Once);
+        _mockTransactionCoordinator.Verify(t => t.CommitTransactionAsync(It.IsAny<Guid>(),default), Times.Never);
+        _mockTransactionCoordinator.Verify(t => t.AbortTransactionAsync(It.IsAny<Guid>(),default), Times.Once);
+        _mockTrackingService.Verify(ts => ts.TrackException(expectedException, $"CanceledMatchesHandler died on event {canceledEvent.Id}"), Times.Once);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
@@ -4,19 +4,32 @@ using NUnit.Framework;
 using W3ChampionsStatisticService.Matches;
 using W3C.Domain.CommonValueObjects;
 using W3C.Contracts.GameObjects;
+using W3C.Domain.Repositories;
+using Moq;
 
 namespace WC3ChampionsStatisticService.Tests.Matchups;
 
 [TestFixture]
 public class MatchupDetailTests : IntegrationTestBase
 {
+    private MongoDbTransactionCoordinator _transactionCoordinator;
+
+    [SetUp]
+    public void SetupTest()
+    {
+        _transactionCoordinator = new MongoDbTransactionCoordinator(MongoClient);
+    }
+
     [Test]
     public async Task LoadDetails_NotDetailsAvailable()
     {
         var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent.match.id = "nmhcCLaRc7";
         matchFinishedEvent.Id = ObjectId.GenerateNewId();
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
@@ -35,7 +48,10 @@ public class MatchupDetailTests : IntegrationTestBase
 
         await InsertMatchEvent(matchFinishedEvent);
 
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
@@ -59,7 +75,10 @@ public class MatchupDetailTests : IntegrationTestBase
 
         await InsertMatchEvent(matchFinishedEvent);
 
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
@@ -85,7 +104,10 @@ public class MatchupDetailTests : IntegrationTestBase
 
         await InsertMatchEvent(matchFinishedEvent);
 
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
@@ -111,7 +133,10 @@ public class MatchupDetailTests : IntegrationTestBase
 
         await InsertMatchEvent(matchFinishedEvent);
 
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -10,23 +10,34 @@ using W3ChampionsStatisticService.Matches;
 using W3C.Domain.MatchmakingService;
 using W3C.Contracts.GameObjects;
 using W3ChampionsStatisticService.Ladder;
+using W3C.Domain.Repositories;
+using Moq;
 
 namespace WC3ChampionsStatisticService.Tests.Matchups;
 
 [TestFixture]
 public class MatchupRepoTests : IntegrationTestBase
 {
+    private MongoDbTransactionCoordinator _transactionCoordinator;
+
     [SetUp]
     public async Task SetupSut()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        _transactionCoordinator = new MongoDbTransactionCoordinator(MongoClient);
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
         await matchRepository.EnsureIndices();
     }
 
     [Test]
     public async Task LoadAndSave()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -41,7 +52,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task LoadWithHeroFilter()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent.result.players.First().heroes = TestDtoHelper.CreateHeroList(
@@ -103,7 +117,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task LoadWithHeroFilterNoResults()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent.result.players.First().heroes = TestDtoHelper.CreateHeroList(
@@ -152,7 +169,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task LoadAndSearch()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -176,7 +196,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task LoadAndSearch_InvalidString()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -194,7 +217,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task Upsert()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
 
@@ -213,7 +239,10 @@ public class MatchupRepoTests : IntegrationTestBase
             Console.WriteLine($"https://www.test.w3champions.com:{i}/login");
         }
 
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -242,7 +271,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForPlayerAndOpponent()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -267,7 +299,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForPlayerAndOpponent_FilterByGateway()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -295,7 +330,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForPlayerAndOppoRace()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -323,7 +361,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [TestCase(0, "wolf#456")]
     public async Task SearchForPlayerAndOpponent_FilterBySeason(int season, string playerTwo)
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -350,7 +391,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [TestCase(0)]
     public async Task SearchForPlayerAndOpponent_FilterBySeason_NoResults(int season)
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
 
@@ -368,7 +412,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForPlayerAndOpponent_2v2_SameTeam()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFake2v2AtEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -394,7 +441,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForPlayerAndOpponent_2v2()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFake2v2AtEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -426,7 +476,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForPlayerAndOpponent_2v2And1V1()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFake2v2AtEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -459,7 +512,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForGameMode2v2_NotFound()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent1.match.gameMode = GameMode.GM_1v1;
 
@@ -472,7 +528,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForGameMode2v2_Found()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent1.match.gameMode = GameMode.GM_2v2_AT;
 
@@ -485,7 +544,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForGameMode2v2_LoadDefault()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent1.match.gameMode = GameMode.GM_2v2_AT;
 
@@ -498,7 +560,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task ReforgedIconGetsReplaced()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
 
@@ -521,9 +586,12 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task Cache_AllOngoingMatches()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
-        var storedEvent = TestDtoHelper.CreateFakeStartedEvent();
+        var storedEvent = TestDtoHelper.CreateFakeStartedEvent(500000, 2500);
         await matchRepository.InsertOnGoingMatch(OnGoingMatchup.Create(storedEvent));
 
         await Task.Delay(100);
@@ -535,7 +603,7 @@ public class MatchupRepoTests : IntegrationTestBase
         Assert.AreEqual(1, result.Count);
         Assert.AreEqual(storedEvent.match.id, result[0].MatchId);
 
-        var notCachedEvent = TestDtoHelper.CreateFakeStartedEvent();
+        var notCachedEvent = TestDtoHelper.CreateFakeStartedEvent(490000, 3000);
         await matchRepository.InsertOnGoingMatch(OnGoingMatchup.Create(notCachedEvent));
 
         await Task.Delay(100);
@@ -544,14 +612,38 @@ public class MatchupRepoTests : IntegrationTestBase
             notCachedEvent.match.gameMode,
             notCachedEvent.match.gateway);
 
-        Assert.AreEqual(2, result2.Count);
-        Assert.AreEqual(storedEvent.match.id, result[0].MatchId);
+        // Same parameters are cached
+        Assert.AreEqual(1, result2.Count);
+        Assert.AreEqual(storedEvent.match.id, result2[0].MatchId);
+
+        // Invoke with different parameters, causing cache miss
+        var result3 = await matchRepository.LoadOnGoingMatches(
+            notCachedEvent.match.gameMode,
+            notCachedEvent.match.gateway,
+            maxMmr: 5000);
+
+        Assert.AreEqual(2, result3.Count);
+        Assert.AreEqual(storedEvent.match.id, result3[0].MatchId);
+        Assert.AreEqual(notCachedEvent.match.id, result3[1].MatchId);
+
+        // Mmr sorting
+        var result4 = await matchRepository.LoadOnGoingMatches(
+            notCachedEvent.match.gameMode,
+            notCachedEvent.match.gateway,
+            sort: "mmrDescending");
+
+        Assert.AreEqual(2, result4.Count);
+        Assert.AreEqual(storedEvent.match.id, result4[1].MatchId);
+        Assert.AreEqual(notCachedEvent.match.id, result4[0].MatchId);
     }
 
     [Test]
     public async Task Cache_ByPlayerId()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var storedEvent = TestDtoHelper.CreateFakeStartedEvent();
         await matchRepository.InsertOnGoingMatch(OnGoingMatchup.Create(storedEvent));
@@ -578,7 +670,10 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task Cache_ByPlayerId_OneTeamEmpty()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
 
         var storedEvent = TestDtoHelper.Create1v1StartedEvent();
 
@@ -606,12 +701,84 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task LoadLastSeason()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
         var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
         await rankRepository.UpsertSeason(new Season(1));
         await rankRepository.UpsertSeason(new Season(2));
         var result = await matchRepository.LoadLastSeason();
         Assert.IsNotNull(result);
         Assert.AreEqual(2, result.Id);
+    }
+
+    [TestCase(W3ChampionsStatisticService.Heroes.HeroType.Archmage, 1)]
+    [TestCase(W3ChampionsStatisticService.Heroes.HeroType.KeeperOfTheGrove, 0)]
+    public async Task LoadHeroSelectionTests(W3ChampionsStatisticService.Heroes.HeroType searchHero, int expectedMatchCount)
+    {
+        var matchRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
+
+        var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
+        matchFinishedEvent.result.players.First().heroes = TestDtoHelper.CreateHeroList(
+            new List<W3ChampionsStatisticService.Heroes.HeroType>
+            {
+                W3ChampionsStatisticService.Heroes.HeroType.Archmage,
+                W3ChampionsStatisticService.Heroes.HeroType.BansheeRanger,
+            }
+        );
+        matchFinishedEvent.result.players.Last().heroes = TestDtoHelper.CreateHeroList(
+            new List<W3ChampionsStatisticService.Heroes.HeroType>
+            {
+                W3ChampionsStatisticService.Heroes.HeroType.Blademaster,
+                W3ChampionsStatisticService.Heroes.HeroType.Farseer,
+            }
+        );
+
+        var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
+        matchFinishedEvent2.result.players.First().heroes = TestDtoHelper.CreateHeroList(
+            new List<W3ChampionsStatisticService.Heroes.HeroType>
+            {
+                W3ChampionsStatisticService.Heroes.HeroType.PriestessOfTheMoon,
+                W3ChampionsStatisticService.Heroes.HeroType.BansheeRanger,
+            }
+        );
+        matchFinishedEvent2.result.players.Last().heroes = TestDtoHelper.CreateHeroList(
+            new List<W3ChampionsStatisticService.Heroes.HeroType>
+            {
+                W3ChampionsStatisticService.Heroes.HeroType.Blademaster,
+                W3ChampionsStatisticService.Heroes.HeroType.Farseer,
+                W3ChampionsStatisticService.Heroes.HeroType.DeathKnight,
+            }
+        );
+
+        await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
+        await matchRepository.Insert(Matchup.Create(matchFinishedEvent2));
+
+        var matches = await matchRepository.Load(
+            matchFinishedEvent.match.season,
+            matchFinishedEvent.match.gameMode,
+            hero: searchHero
+        );
+
+        Assert.AreEqual(expectedMatchCount, matches.Count);
+
+        if (matches.Any())
+        {
+            var firstPlayerHeroes = matches.First().Teams.First().Players.First().Heroes;
+            var expectedHeroes = matchFinishedEvent.result.players.First().heroes.Select(h => new W3ChampionsStatisticService.Heroes.Hero(h)).ToList();
+            Assert.AreEqual(expectedHeroes.Count, firstPlayerHeroes.Count);
+            Assert.AreEqual(expectedHeroes.First().Id, firstPlayerHeroes.First().Id);
+            Assert.AreEqual(expectedHeroes.Last().Id, firstPlayerHeroes.Last().Id);
+
+            var secondPlayerHeroes = matches.First().Teams.Last().Players.First().Heroes;
+            var secondExpectedHeroes = matchFinishedEvent.result.players.Last().heroes.Select(h => new W3ChampionsStatisticService.Heroes.Hero(h)).ToList();
+            Assert.AreEqual(secondExpectedHeroes.Count, secondPlayerHeroes.Count);
+            Assert.AreEqual(secondExpectedHeroes.First().Id, secondPlayerHeroes.First().Id);
+            Assert.AreEqual(secondExpectedHeroes.Last().Id, secondPlayerHeroes.Last().Id);
+        }
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Performance/DBPerformanceTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Performance/DBPerformanceTest.cs
@@ -7,6 +7,8 @@ using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.Matches;
 using W3ChampionsStatisticService.PlayerProfiles;
 using W3ChampionsStatisticService.W3ChampionsStats;
+using W3C.Domain.Repositories;
+using Moq;
 
 namespace WC3ChampionsStatisticService.Tests.Performance;
 
@@ -14,6 +16,14 @@ namespace WC3ChampionsStatisticService.Tests.Performance;
 [Ignore("Use only when performance testing DB")]
 public class DBPerformanceTest : IntegrationTestBase
 {
+    private MongoDbTransactionCoordinator _transactionCoordinator;
+
+    [SetUp]
+    public void SetupTest()
+    {
+        _transactionCoordinator = new MongoDbTransactionCoordinator(MongoClient);
+    }
+
     [Test]
     public async Task PopularHours_TimeslotsAreSetCorrectlyAfterLoad()
     {
@@ -32,7 +42,10 @@ public class DBPerformanceTest : IntegrationTestBase
     [Test]
     public async Task LoadMatchesColorful()
     {
-        var matchesRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchesRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
         Stopwatch sw = new();
         sw.Start();
         string playerId = "COLORFUL#5214";
@@ -56,7 +69,10 @@ public class DBPerformanceTest : IntegrationTestBase
     [Test]
     public async Task LoadCountColorful()
     {
-        var matchesRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchesRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
         Stopwatch sw = new();
         sw.Start();
         string playerId = "COLORFUL#5214";
@@ -78,7 +94,10 @@ public class DBPerformanceTest : IntegrationTestBase
     [Test]
     public async Task LoadMatchesShaDe()
     {
-        var matchesRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchesRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
         Stopwatch sw = new();
         sw.Start();
         string playerId = "ShaDeFaDe#2441";
@@ -102,7 +121,10 @@ public class DBPerformanceTest : IntegrationTestBase
     [Test]
     public async Task LoadCountShaDe()
     {
-        var matchesRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var matchesRepository = new MatchRepository(
+            MongoClient,
+            new OngoingMatchesCache(MongoClient, _transactionCoordinator),
+            _transactionCoordinator);
         Stopwatch sw = new();
         sw.Start();
         string playerId = "ShaDeFaDe#2441";

--- a/WC3ChampionsStatisticService.UnitTests/ReadModel/ReadModelHandlerBaseTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/ReadModel/ReadModelHandlerBaseTests.cs
@@ -30,11 +30,13 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
         var mockMatchRepo = new Mock<IMatchRepository>();
 
         var versionRepository = new VersionRepository(MongoClient);
+        var transactionCoordinator = new MongoDbTransactionCoordinator(MongoClient);
 
         var handler = new ReadModelHandler<MatchReadModelHandler>(
             mockEvents.Object,
             versionRepository,
-            new MatchReadModelHandler(mockMatchRepo.Object));
+            new MatchReadModelHandler(mockMatchRepo.Object),
+            transactionCoordinator);
 
         await handler.Update();
 
@@ -56,11 +58,12 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
         var mockMatchRepo = new Mock<IMatchRepository>();
 
         var versionRepository = new VersionRepository(MongoClient);
-
+        var transactionCoordinator = new MongoDbTransactionCoordinator(MongoClient);
         var handler = new ReadModelHandler<MatchReadModelHandler>(
             mockEvents.Object,
             versionRepository,
-            new MatchReadModelHandler(mockMatchRepo.Object));
+            new MatchReadModelHandler(mockMatchRepo.Object),
+            transactionCoordinator);
 
         await handler.Update();
 
@@ -100,13 +103,16 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
 
         await InsertMatchEvents(new List<MatchFinishedEvent> { fakeEvent1, fakeEvent2, fakeEvent3, fakeEvent4, fakeEvent5 });
 
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var transactionCoordinator = new MongoDbTransactionCoordinator(MongoClient);
+        var ongoingMatchesCache = new OngoingMatchesCache(MongoClient, transactionCoordinator);
+        var matchRepository = new MatchRepository(MongoClient, ongoingMatchesCache, transactionCoordinator);
         var versionRepository = new VersionRepository(MongoClient);
 
         var handler = new ReadModelHandler<MatchReadModelHandler>(
             new MatchEventRepository(MongoClient),
             versionRepository,
-            new MatchReadModelHandler(matchRepository));
+            new MatchReadModelHandler(matchRepository),
+            transactionCoordinator);
 
         await handler.Update();
 


### PR DESCRIPTION
This PR introduces transactions to the website-backend service in order to ensure consistent execution of our operations.

The matchup cache has been rewritten to ensure good performance.

Match canceled events are now properly consumed.


Debends on database PR: https://github.com/w3champions/docker-compose-files/pull/71