### PR TITLE
Introduce tracing instrumentation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,29 +3,38 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
+    <PackageVersion Include="Aliyun.OSS.SDK.NetCore" Version="2.14.1" />
     <PackageVersion Include="AspNetCore.Authentication.Basic" Version="9.0.0" />
-    <PackageVersion Include="AutoFixture" Version="4.13.0" />
-    <PackageVersion Include="AWSSDK.S3" Version="3.7.205.12" />
-    <PackageVersion Include="FluentAssertions" Version="6.7.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.30.0" />
-    <PackageVersion Include="Moq" Version="4.14.5" />
+    <PackageVersion Include="AutoFixture" Version="4.18.1" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.0.6" />
+    <PackageVersion Include="Castle.Core" Version="5.2.1" />
+    <PackageVersion Include="FluentAssertions" Version="8.2.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.4.0" />
+    <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="2.1.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="nunit" Version="3.13.3" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageVersion Include="prometheus-net.AspNetCore" Version="6.0.0" />
-    <PackageVersion Include="Serilog" Version="4.2.0" />
-    <PackageVersion Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageVersion Include="nunit" Version="3.14.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
+    <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.10.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="8.1.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
   </ItemGroup>
 </Project>

--- a/W3C.Domain/ChatService/ChatServiceClient.cs
+++ b/W3C.Domain/ChatService/ChatServiceClient.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Web;
 using W3C.Contracts.Admin.Moderation;
+using W3C.Domain.Tracing;
 
 namespace W3C.Domain.ChatService;
 
@@ -29,6 +30,7 @@ public class ChatServiceClient
         };
     }
 
+    [Trace]
     public async Task<LoungeMuteResponse[]> GetLoungeMutes(string authorization)
     {
         var url = $"{ChatServiceApiUrl}/api/loungeMute/?authorization={authorization}&secret={AdminSecret}";
@@ -42,6 +44,7 @@ public class ChatServiceClient
         return deserializeObject;
     }
 
+    [Trace]
     public async Task<HttpResponseMessage> PostLoungeMute(LoungeMute loungeMute, string authorization)
     {
         var url = $"{ChatServiceApiUrl}/api/loungeMute/?authorization={authorization}&secret={AdminSecret}";
@@ -54,6 +57,7 @@ public class ChatServiceClient
         return response;
     }
 
+    [Trace]
     public async Task<HttpResponseMessage> DeleteLoungeMute(string battleTag, string authorization)
     {
         var encodedTag = HttpUtility.UrlEncode(battleTag);

--- a/W3C.Domain/ChatService/ChatServiceClient.cs
+++ b/W3C.Domain/ChatService/ChatServiceClient.cs
@@ -31,7 +31,7 @@ public class ChatServiceClient
     }
 
     [Trace]
-    public async Task<LoungeMuteResponse[]> GetLoungeMutes(string authorization)
+    public async Task<LoungeMuteResponse[]> GetLoungeMutes([NoTrace] string authorization)
     {
         var url = $"{ChatServiceApiUrl}/api/loungeMute/?authorization={authorization}&secret={AdminSecret}";
         var request = new HttpRequestMessage(HttpMethod.Get, url);
@@ -45,7 +45,7 @@ public class ChatServiceClient
     }
 
     [Trace]
-    public async Task<HttpResponseMessage> PostLoungeMute(LoungeMute loungeMute, string authorization)
+    public async Task<HttpResponseMessage> PostLoungeMute(LoungeMute loungeMute, [NoTrace] string authorization)
     {
         var url = $"{ChatServiceApiUrl}/api/loungeMute/?authorization={authorization}&secret={AdminSecret}";
         var httpcontent = new StringContent(JsonConvert.SerializeObject(loungeMute), Encoding.UTF8, "application/json");
@@ -58,7 +58,7 @@ public class ChatServiceClient
     }
 
     [Trace]
-    public async Task<HttpResponseMessage> DeleteLoungeMute(string battleTag, string authorization)
+    public async Task<HttpResponseMessage> DeleteLoungeMute(string battleTag, [NoTrace] string authorization)
     {
         var encodedTag = HttpUtility.UrlEncode(battleTag);
         var url = $"{ChatServiceApiUrl}/api/loungeMute/{encodedTag}?authorization={authorization}&secret={AdminSecret}";

--- a/W3C.Domain/CommonValueObjects/PatchRepository.cs
+++ b/W3C.Domain/CommonValueObjects/PatchRepository.cs
@@ -4,22 +4,26 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
 
 namespace W3C.Domain.CommonValueObjects;
 
 public class PatchRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IPatchRepository
 {
+    [Trace]
     public async Task<string> GetPatchVersionFromDate(DateTime dateTime)
     {
         var patches = await LoadPatches();
         return patches.Where(x => dateTime > x.StartDate).ToList().Last().Version;
     }
 
+    [Trace]
     public Task<List<Patch>> LoadPatches()
     {
         return LoadAll<Patch>();
     }
 
+    [Trace]
     public Task InsertPatches(List<Patch> patches)
     {
         return UpsertMany(patches);

--- a/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
+++ b/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
@@ -2,7 +2,6 @@
 using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -18,6 +17,7 @@ using W3C.Contracts.Matchmaking.Queue;
 using W3C.Domain.Repositories;
 using System.Net.Http.Json;
 using W3C.Domain.Tracing;
+
 namespace W3C.Domain.MatchmakingService;
 
 [Trace]

--- a/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
+++ b/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
@@ -17,9 +17,10 @@ using W3C.Contracts.Matchmaking;
 using W3C.Contracts.Matchmaking.Queue;
 using W3C.Domain.Repositories;
 using System.Net.Http.Json;
-
+using W3C.Domain.Tracing;
 namespace W3C.Domain.MatchmakingService;
 
+[Trace]
 public class MatchmakingServiceClient
 {
     private static readonly string MatchmakingApiUrl = Environment.GetEnvironmentVariable("MATCHMAKING_API") ?? "https://matchmaking-service.test.w3champions.com";

--- a/W3C.Domain/ReplayService/ReplayServiceClient.cs
+++ b/W3C.Domain/ReplayService/ReplayServiceClient.cs
@@ -4,9 +4,10 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using W3C.Contracts.Replay;
-
+using W3C.Domain.Tracing;
 namespace W3C.Domain.UpdateService;
 
+[Trace]
 public class ReplayServiceClient(IHttpClientFactory httpClientFactory)
 {
     private static readonly string ReplayServiceUrl = Environment.GetEnvironmentVariable("REPLAY_API") ?? "https://replay-service.test.w3champions.com";

--- a/W3C.Domain/ReplayService/ReplayServiceClient.cs
+++ b/W3C.Domain/ReplayService/ReplayServiceClient.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using W3C.Contracts.Replay;
 using W3C.Domain.Tracing;
+
 namespace W3C.Domain.UpdateService;
 
 [Trace]

--- a/W3C.Domain/Repositories/InformationMessagesRepository.cs
+++ b/W3C.Domain/Repositories/InformationMessagesRepository.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using W3C.Domain.CommonValueObjects;
 using W3C.Domain.MatchmakingService;
 using W3C.Domain.Tracing;
+
 namespace W3C.Domain.Repositories;
 
 [Trace]

--- a/W3C.Domain/Repositories/InformationMessagesRepository.cs
+++ b/W3C.Domain/Repositories/InformationMessagesRepository.cs
@@ -6,9 +6,10 @@ using System.Net;
 using System.Threading.Tasks;
 using W3C.Domain.CommonValueObjects;
 using W3C.Domain.MatchmakingService;
-
+using W3C.Domain.Tracing;
 namespace W3C.Domain.Repositories;
 
+[Trace]
 public class InformationMessagesRepository(
     MongoClient mongoClient,
     MatchmakingServiceClient matchmakingServiceClient) : MongoDbRepositoryBase(mongoClient), IInformationMessagesRepository

--- a/W3C.Domain/Repositories/MatchEventRepository.cs
+++ b/W3C.Domain/Repositories/MatchEventRepository.cs
@@ -4,9 +4,10 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using W3C.Domain.MatchmakingService;
-
+using W3C.Domain.Tracing;
 namespace W3C.Domain.Repositories;
 
+[Trace]
 public class MatchEventRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IMatchEventRepository
 {
     public async Task<List<MatchFinishedEvent>> Load(string lastObjectId = null, int pageSize = 100)

--- a/W3C.Domain/Repositories/MongoDbRepositoryBase.cs
+++ b/W3C.Domain/Repositories/MongoDbRepositoryBase.cs
@@ -4,9 +4,11 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using MongoDB.Driver;
+using W3C.Domain.Tracing;
 
 namespace W3C.Domain.Repositories;
 
+[Trace]
 public class MongoDbRepositoryBase(MongoClient mongoClient)
 {
     private readonly MongoClient _mongoClient = mongoClient;

--- a/W3C.Domain/Tracing/NoTraceAttribute.cs
+++ b/W3C.Domain/Tracing/NoTraceAttribute.cs
@@ -6,4 +6,4 @@ namespace W3C.Domain.Tracing;
 public sealed class NoTraceAttribute : Attribute
 {
     public NoTraceAttribute() { }
-} 
+}

--- a/W3C.Domain/Tracing/NoTraceAttribute.cs
+++ b/W3C.Domain/Tracing/NoTraceAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace W3C.Domain.Tracing;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Parameter, Inherited = true, AllowMultiple = false)]
+public sealed class NoTraceAttribute : Attribute
+{
+    public NoTraceAttribute() { }
+} 

--- a/W3C.Domain/Tracing/TraceAttribute.cs
+++ b/W3C.Domain/Tracing/TraceAttribute.cs
@@ -7,8 +7,4 @@ namespace W3C.Domain.Tracing;
 public sealed class TraceAttribute([CallerMemberName] string operationName = null) : Attribute
 {
     public string OperationName { get; } = operationName;
-
-    // If you need an explicit override and want to keep the primary constructor for [CallerMemberName]
-    // you might need a static factory method or a different named attribute if C# rules get too complex.
-    // For now, this primary constructor with [CallerMemberName] is the simplest for auto-naming.
-} 
+}

--- a/W3C.Domain/Tracing/TraceAttribute.cs
+++ b/W3C.Domain/Tracing/TraceAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace W3C.Domain.Tracing;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+public sealed class TraceAttribute([CallerMemberName] string operationName = null) : Attribute
+{
+    public string OperationName { get; } = operationName;
+
+    // If you need an explicit override and want to keep the primary constructor for [CallerMemberName]
+    // you might need a static factory method or a different named attribute if C# rules get too complex.
+    // For now, this primary constructor with [CallerMemberName] is the simplest for auto-naming.
+} 

--- a/W3C.Domain/UpdateService/UpdateServiceClient.cs
+++ b/W3C.Domain/UpdateService/UpdateServiceClient.cs
@@ -4,9 +4,11 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using W3C.Domain.UpdateService.Contracts;
+using W3C.Domain.Tracing;
 
 namespace W3C.Domain.UpdateService;
 
+[Trace]
 public class UpdateServiceClient(IHttpClientFactory httpClientFactory)
 {
     private static readonly string UpdateServiceUrl = Environment.GetEnvironmentVariable("UPDATE_API") ?? "https://update-service.test.w3champions.com";

--- a/W3ChampionsStatisticService/Admin/AdminController.cs
+++ b/W3ChampionsStatisticService/Admin/AdminController.cs
@@ -9,11 +9,12 @@ using W3C.Domain.CommonValueObjects;
 using W3C.Contracts.Matchmaking;
 using System.Net.Http;
 using W3C.Contracts.Admin.Permission;
-
+using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Admin;
 
 [ApiController]
 [Route("api/admin")]
+[Trace]
 public class AdminController(
     IMatchRepository matchRepository,
     MatchmakingServiceClient matchmakingServiceRepository,
@@ -30,12 +31,14 @@ public class AdminController(
     private readonly IRankRepository _rankRepository = rankRepository;
 
     [HttpGet("health-check")]
+    [NoTrace]
     public IActionResult HealthCheck()
     {
         return Ok();
     }
 
     [HttpGet("db-health-check")]
+    [NoTrace]
     public async Task<IActionResult> DatabaseHealthCheck()
     {
         var ongoingMatches = await _matchRepository.LoadOnGoingMatches(
@@ -268,6 +271,7 @@ public class AdminController(
     // Returns a 200 OK if it passes validation and a 401 Unauthorized if it's expired.
     [HttpGet("checkJwtLifetime")]
     [CheckIfBattleTagIsAdmin]
+    [NoTrace]
     public IActionResult CheckJwtLifetime()
     {
         return Ok();

--- a/W3ChampionsStatisticService/Admin/AdminRepository.cs
+++ b/W3ChampionsStatisticService/Admin/AdminRepository.cs
@@ -71,7 +71,7 @@ public class AdminRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mo
 
         // send request to mm with all the node values
         var httpClient = new HttpClient();
-        httpClient.DefaultRequestHeaders.Add("x-admin-secret", AdminSecret); // TODO: ensure x-admin-secret is purged from spans
+        httpClient.DefaultRequestHeaders.Add("x-admin-secret", AdminSecret);
         var url = $"{MatchmakingApiUrl}/player/{HttpUtility.UrlEncode(battleTag)}/flo-proxies";
         var serializedObject = JsonConvert.SerializeObject(newProxiesBeingAdded);
         var buffer = System.Text.Encoding.UTF8.GetBytes(serializedObject);

--- a/W3ChampionsStatisticService/Admin/AdminRepository.cs
+++ b/W3ChampionsStatisticService/Admin/AdminRepository.cs
@@ -9,9 +9,10 @@ using System.Threading.Tasks;
 using System.Web;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
-
+using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Admin;
 
+[Trace]
 public class AdminRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IAdminRepository
 {
     private static readonly string MatchmakingApiUrl = Environment.GetEnvironmentVariable("MATCHMAKING_API") ?? "https://matchmaking-service.test.w3champions.com";
@@ -70,7 +71,7 @@ public class AdminRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mo
 
         // send request to mm with all the node values
         var httpClient = new HttpClient();
-        httpClient.DefaultRequestHeaders.Add("x-admin-secret", AdminSecret);
+        httpClient.DefaultRequestHeaders.Add("x-admin-secret", AdminSecret); // TODO: ensure x-admin-secret is purged from spans
         var url = $"{MatchmakingApiUrl}/player/{HttpUtility.UrlEncode(battleTag)}/flo-proxies";
         var serializedObject = JsonConvert.SerializeObject(newProxiesBeingAdded);
         var buffer = System.Text.Encoding.UTF8.GetBytes(serializedObject);

--- a/W3ChampionsStatisticService/Admin/CloudStorage/Alibaba/AlibabaService.cs
+++ b/W3ChampionsStatisticService/Admin/CloudStorage/Alibaba/AlibabaService.cs
@@ -6,9 +6,11 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using W3C.Contracts.Admin.CloudStorage;
 using Aliyun.OSS;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Admin.CloudStorage.Alibaba;
 
+[Trace]
 public class AlibabaService : IAlibabaService
 {
     private readonly string alibabaBucketName = Environment.GetEnvironmentVariable("ALIBABA_BUCKET_NAME") ?? "";
@@ -36,7 +38,7 @@ public class AlibabaService : IAlibabaService
             }).ToList();
     }
 
-    public void UploadFile(UploadFileRequest file)
+    public void UploadFile([NoTrace] UploadFileRequest file)
     {
         var client = new OssClient(alibabaEndpoint, alibabaAccessKey, alibabaSecretKey);
         byte[] bytes = Convert.FromBase64String(file.Content);

--- a/W3ChampionsStatisticService/Admin/CloudStorage/CloudStorageController.cs
+++ b/W3ChampionsStatisticService/Admin/CloudStorage/CloudStorageController.cs
@@ -9,11 +9,12 @@ using W3C.Contracts.Admin.CloudStorage;
 using W3ChampionsStatisticService.Admin.CloudStorage.S3;
 using W3ChampionsStatisticService.Admin.CloudStorage.Alibaba;
 using W3C.Contracts.Admin.Permission;
-
+using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Admin.CloudStorage;
 
 [ApiController]
 [Route("api/admin/storage")]
+[Trace]
 public class CloudStorageController : ControllerBase
 {
     [HttpGet("alibaba")]
@@ -50,7 +51,7 @@ public class CloudStorageController : ControllerBase
 
     [HttpPost("alibaba/upload")]
     [BearerHasPermissionFilter(Permission = EPermission.Content)]
-    public IActionResult UploadAlibabaFile([FromBody] UploadFileRequest req)
+    public IActionResult UploadAlibabaFile([FromBody][NoTrace] UploadFileRequest req)
     {
         AlibabaService alibabaService = new();
         try
@@ -75,7 +76,7 @@ public class CloudStorageController : ControllerBase
 
     [HttpPost("s3/upload")]
     [BearerHasPermissionFilter(Permission = EPermission.Content)]
-    public async Task<IActionResult> UploadS3File([FromBody] UploadFileRequest req)
+    public async Task<IActionResult> UploadS3File([FromBody][NoTrace] UploadFileRequest req)
     {
         S3Service s3Service = new();
         try

--- a/W3ChampionsStatisticService/Admin/CloudStorage/S3/S3Service.cs
+++ b/W3ChampionsStatisticService/Admin/CloudStorage/S3/S3Service.cs
@@ -7,9 +7,11 @@ using System.Collections.Generic;
 using W3C.Contracts.Admin.CloudStorage;
 using Amazon.S3;
 using Amazon.S3.Model;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Admin.CloudStorage.S3;
 
+[Trace]
 public class S3Service : IS3Service
 {
     private readonly string S3BucketName = Environment.GetEnvironmentVariable("S3_BUCKET_NAME") ?? "";
@@ -34,12 +36,12 @@ public class S3Service : IS3Service
         return listObjectsResponse.S3Objects.Select(x => new CloudFile
         {
             Name = x.Key.Substring(x.Key.LastIndexOf('/') + 1), // Do not include the prefix
-            Size = x.Size / 1024, // Size in kilobytes
-            LastModified = x.LastModified
+            Size = x.Size / 1024 ?? -1, // Size in kilobytes
+            LastModified = x.LastModified ?? DateTime.MinValue
         }).ToList();
     }
 
-    public async Task UploadFile(UploadFileRequest file)
+    public async Task UploadFile([NoTrace] UploadFileRequest file)
     {
         AmazonS3Config config = new()
         {

--- a/W3ChampionsStatisticService/Admin/Logs/LogsController.cs
+++ b/W3ChampionsStatisticService/Admin/Logs/LogsController.cs
@@ -5,11 +5,13 @@ using W3ChampionsStatisticService.WebApi.ActionFilters;
 using System.Net.Http;
 using System.Net.Mime;
 using W3C.Contracts.Admin.Permission;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Admin.Logs;
 
 [ApiController]
 [Route("api/admin/logs")]
+[Trace]
 public class LogsController(
     ILogsRepository logsRepository) : ControllerBase
 {

--- a/W3ChampionsStatisticService/Admin/Logs/LogsRepository.cs
+++ b/W3ChampionsStatisticService/Admin/Logs/LogsRepository.cs
@@ -8,9 +8,10 @@ using System.Threading.Tasks;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
 using System.IO;
-
+using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Admin.Logs;
 
+[Trace]
 public class LogsRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), ILogsRepository
 {
     private static readonly string MatchmakingApiUrl = Environment.GetEnvironmentVariable("MATCHMAKING_API") ?? "https://matchmaking-service.test.w3champions.com";

--- a/W3ChampionsStatisticService/Admin/NewsRepository.cs
+++ b/W3ChampionsStatisticService/Admin/NewsRepository.cs
@@ -4,9 +4,11 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Admin;
 
+[Trace]
 public class NewsRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), INewsRepository
 {
     public Task<List<NewsMessage>> Get(int? limit = 5)

--- a/W3ChampionsStatisticService/Admin/Permissions/PermissionsController.cs
+++ b/W3ChampionsStatisticService/Admin/Permissions/PermissionsController.cs
@@ -4,18 +4,20 @@ using W3ChampionsStatisticService.WebApi.ActionFilters;
 using System.Net.Http;
 using W3C.Contracts.Admin.Permission;
 using W3ChampionsStatisticService.Services;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Admin.Permissions;
 
 [ApiController]
 [Route("api/admin/permissions")]
+[Trace]
 public class PermissionsController(IdentityServiceClient identityServiceClient) : ControllerBase
 {
     private readonly IdentityServiceClient _identityServiceClient = identityServiceClient;
 
     [HttpGet]
     [InjectAuthToken]
-    public async Task<IActionResult> GetPermissions(string authToken)
+    public async Task<IActionResult> GetPermissions([NoTrace] string authToken)
     {
         try
         {
@@ -30,7 +32,7 @@ public class PermissionsController(IdentityServiceClient identityServiceClient) 
 
     [HttpPost("add")]
     [InjectAuthToken]
-    public async Task<IActionResult> AddAdmin([FromBody] Permission permission, string authToken)
+    public async Task<IActionResult> AddAdmin([FromBody] Permission permission, [NoTrace] string authToken)
     {
         try
         {
@@ -45,7 +47,7 @@ public class PermissionsController(IdentityServiceClient identityServiceClient) 
 
     [HttpPut("edit")]
     [InjectAuthToken]
-    public async Task<IActionResult> EditAdmin([FromBody] Permission permission, string authToken)
+    public async Task<IActionResult> EditAdmin([FromBody] Permission permission, [NoTrace] string authToken)
     {
         try
         {
@@ -60,7 +62,7 @@ public class PermissionsController(IdentityServiceClient identityServiceClient) 
 
     [HttpDelete("delete")]
     [InjectAuthToken]
-    public async Task<IActionResult> DeleteAdmin([FromQuery] string id, string authToken)
+    public async Task<IActionResult> DeleteAdmin([FromQuery] string id, [NoTrace] string authToken)
     {
         try
         {

--- a/W3ChampionsStatisticService/Cache/InMemoryCacheData.cs
+++ b/W3ChampionsStatisticService/Cache/InMemoryCacheData.cs
@@ -3,9 +3,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Cache;
 
+[Trace]
 public class InMemoryCachedDataProvider<T>(IOptions<CacheOptionsFor<T>> cacheDataOptions, IMemoryCache memoryCache) : ICachedDataProvider<T> where T : class
 {
     // NOTE: It is intentional to have different semaphores for different generic types

--- a/W3ChampionsStatisticService/Clans/Clan.cs
+++ b/W3ChampionsStatisticService/Clans/Clan.cs
@@ -4,9 +4,11 @@ using System.Text.Json.Serialization;
 using MongoDB.Bson.Serialization.Attributes;
 using W3ChampionsStatisticService.Clans.ClanStates;
 using W3ChampionsStatisticService.Ladder;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Clans;
 
+[Trace]
 public class Clan
 {
     [JsonIgnore]

--- a/W3ChampionsStatisticService/Clans/ClanCommandHandler.cs
+++ b/W3ChampionsStatisticService/Clans/ClanCommandHandler.cs
@@ -6,9 +6,11 @@ using System.Threading.Tasks;
 using W3ChampionsStatisticService.Ladder;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.Services;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Clans;
 
+[Trace]
 public class ClanCommandHandler(
     IClanRepository clanRepository,
     IRankRepository rankRepository,

--- a/W3ChampionsStatisticService/Clans/ClanController.cs
+++ b/W3ChampionsStatisticService/Clans/ClanController.cs
@@ -2,11 +2,13 @@
 using Microsoft.AspNetCore.Mvc;
 using W3ChampionsStatisticService.Clans.Commands;
 using W3ChampionsStatisticService.WebApi.ActionFilters;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Clans;
 
 [ApiController]
 [Route("api/clans")]
+[Trace]
 public class ClanController(
     ClanCommandHandler clanCommandHandler) : ControllerBase
 {

--- a/W3ChampionsStatisticService/Clans/ClanMembership.cs
+++ b/W3ChampionsStatisticService/Clans/ClanMembership.cs
@@ -2,9 +2,11 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Clans;
 
+[Trace]
 public class ClanMembership : IIdentifiable, IVersionable
 {
     public string BattleTag { get; set; }

--- a/W3ChampionsStatisticService/Clans/ClanRepository.cs
+++ b/W3ChampionsStatisticService/Clans/ClanRepository.cs
@@ -5,9 +5,11 @@ using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Clans;
 
+[Trace]
 public class ClanRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IClanRepository
 {
     public async Task TryInsertClan(Clan clan)

--- a/W3ChampionsStatisticService/Clans/ClanStates/FoundedClan.cs
+++ b/W3ChampionsStatisticService/Clans/ClanStates/FoundedClan.cs
@@ -1,8 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-
+using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Clans.ClanStates;
 
+[Trace]
 public class FoundedClan : ClanState
 {
     public FoundedClan(List<string> foundingFathers, string chiefTain)

--- a/W3ChampionsStatisticService/Clans/ClanStates/NotFoundedClan.cs
+++ b/W3ChampionsStatisticService/Clans/ClanStates/NotFoundedClan.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Clans.ClanStates;
 
+[Trace]
 public class NotFoundedClan : ClanState
 {
     public NotFoundedClan(string founder)

--- a/W3ChampionsStatisticService/Clans/MembershipController.cs
+++ b/W3ChampionsStatisticService/Clans/MembershipController.cs
@@ -1,11 +1,13 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using W3ChampionsStatisticService.Ports;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Clans;
 
 [ApiController]
 [Route("api/memberships")]
+[Trace]
 public class MembershipController(IClanRepository clanRepository) : ControllerBase
 {
     private readonly IClanRepository _clanRepository = clanRepository;

--- a/W3ChampionsStatisticService/Extensions/ServiceCollectionExtensions.cs
+++ b/W3ChampionsStatisticService/Extensions/ServiceCollectionExtensions.cs
@@ -1,11 +1,10 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Castle.DynamicProxy;
-using W3ChampionsStatisticService.Services.Interceptors; // Assuming TracingInterceptor is here
-using System.Linq; // Added for LINQ
-using System.Reflection; // Added for Assembly
+using W3ChampionsStatisticService.Services.Interceptors;
+using System.Linq;
 
-namespace W3ChampionsStatisticService.Extensions; // Or any other appropriate namespace
+namespace W3ChampionsStatisticService.Extensions;
 
 public static class ServiceCollectionExtensions
 {
@@ -20,7 +19,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<TInterface>(serviceProvider =>
         {
             var implementation = serviceProvider.GetRequiredService<TImplementation>();
-            var interceptor = serviceProvider.GetRequiredService<TracingInterceptor>(); 
+            var interceptor = serviceProvider.GetRequiredService<TracingInterceptor>();
             return ProxyGenerator.CreateInterfaceProxyWithTarget<TInterface>(implementation, interceptor);
         });
         return services;
@@ -73,7 +72,7 @@ public static class ServiceCollectionExtensions
             var constructorArgs = constructor.GetParameters()
                 .Select(p => serviceProvider.GetRequiredService(p.ParameterType))
                 .ToArray();
-            
+
             return ProxyGenerator.CreateClassProxy<TImplementation>(constructorArgs, interceptor);
         });
         return services;
@@ -117,7 +116,7 @@ public static class ServiceCollectionExtensions
             var constructorArgs = constructor.GetParameters()
                 .Select(p => serviceProvider.GetRequiredService(p.ParameterType))
                 .ToArray();
-            
+
             return ProxyGenerator.CreateClassProxy<TImplementation>(constructorArgs, interceptor);
         });
         return services;

--- a/W3ChampionsStatisticService/Extensions/ServiceCollectionExtensions.cs
+++ b/W3ChampionsStatisticService/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,125 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Castle.DynamicProxy;
+using W3ChampionsStatisticService.Services.Interceptors; // Assuming TracingInterceptor is here
+using System.Linq; // Added for LINQ
+using System.Reflection; // Added for Assembly
+
+namespace W3ChampionsStatisticService.Extensions; // Or any other appropriate namespace
+
+public static class ServiceCollectionExtensions
+{
+    private static readonly ProxyGenerator ProxyGenerator = new ProxyGenerator();
+
+    public static IServiceCollection AddInterceptedSingleton<TInterface, TImplementation>(
+        this IServiceCollection services)
+        where TInterface : class
+        where TImplementation : class, TInterface
+    {
+        services.AddSingleton<TImplementation>(); // Register the actual implementation
+        services.AddSingleton<TInterface>(serviceProvider =>
+        {
+            var implementation = serviceProvider.GetRequiredService<TImplementation>();
+            var interceptor = serviceProvider.GetRequiredService<TracingInterceptor>(); 
+            return ProxyGenerator.CreateInterfaceProxyWithTarget<TInterface>(implementation, interceptor);
+        });
+        return services;
+    }
+
+    public static IServiceCollection AddInterceptedTransient<TInterface, TImplementation>(
+        this IServiceCollection services)
+        where TInterface : class
+        where TImplementation : class, TInterface
+    {
+        services.AddTransient<TImplementation>(); // Register the actual implementation
+        services.AddTransient<TInterface>(serviceProvider =>
+        {
+            var implementation = serviceProvider.GetRequiredService<TImplementation>();
+            var interceptor = serviceProvider.GetRequiredService<TracingInterceptor>();
+            return ProxyGenerator.CreateInterfaceProxyWithTarget<TInterface>(implementation, interceptor);
+        });
+        return services;
+    }
+
+    public static IServiceCollection AddInterceptedScoped<TInterface, TImplementation>(
+        this IServiceCollection services)
+        where TInterface : class
+        where TImplementation : class, TInterface
+    {
+        services.AddScoped<TImplementation>(); // Register the actual implementation
+        services.AddScoped<TInterface>(serviceProvider =>
+        {
+            var implementation = serviceProvider.GetRequiredService<TImplementation>();
+            var interceptor = serviceProvider.GetRequiredService<TracingInterceptor>();
+            return ProxyGenerator.CreateInterfaceProxyWithTarget<TInterface>(implementation, interceptor);
+        });
+        return services;
+    }
+
+    // AddInterceptedSingleton for a concrete type (TImplementation is the service type)
+    public static IServiceCollection AddInterceptedSingleton<TImplementation>(
+        this IServiceCollection services)
+        where TImplementation : class
+    {
+        services.AddSingleton<TImplementation>(serviceProvider =>
+        {
+            var interceptor = serviceProvider.GetRequiredService<TracingInterceptor>();
+            // Get constructor with most parameters (assuming it's the one DI would use)
+            var constructor = typeof(TImplementation).GetConstructors().OrderByDescending(c => c.GetParameters().Length).FirstOrDefault();
+            if (constructor == null)
+            {
+                throw new InvalidOperationException($"Could not find a public constructor for {typeof(TImplementation)}.");
+            }
+            var constructorArgs = constructor.GetParameters()
+                .Select(p => serviceProvider.GetRequiredService(p.ParameterType))
+                .ToArray();
+            
+            return ProxyGenerator.CreateClassProxy<TImplementation>(constructorArgs, interceptor);
+        });
+        return services;
+    }
+
+    // AddInterceptedTransient for a concrete type (TImplementation is the service type)
+    public static IServiceCollection AddInterceptedTransient<TImplementation>(
+        this IServiceCollection services)
+        where TImplementation : class
+    {
+        services.AddTransient<TImplementation>(serviceProvider =>
+        {
+            var interceptor = serviceProvider.GetRequiredService<TracingInterceptor>();
+            var constructor = typeof(TImplementation).GetConstructors().OrderByDescending(c => c.GetParameters().Length).FirstOrDefault();
+            if (constructor == null)
+            {
+                throw new InvalidOperationException($"Could not find a public constructor for {typeof(TImplementation)}.");
+            }
+            var constructorArgs = constructor.GetParameters()
+                .Select(p => serviceProvider.GetRequiredService(p.ParameterType))
+                .ToArray();
+
+            return ProxyGenerator.CreateClassProxy<TImplementation>(constructorArgs, interceptor);
+        });
+        return services;
+    }
+
+    // AddInterceptedScoped for a concrete type (TImplementation is the service type)
+    public static IServiceCollection AddInterceptedScoped<TImplementation>(
+        this IServiceCollection services)
+        where TImplementation : class
+    {
+        services.AddScoped<TImplementation>(serviceProvider =>
+        {
+            var interceptor = serviceProvider.GetRequiredService<TracingInterceptor>();
+            var constructor = typeof(TImplementation).GetConstructors().OrderByDescending(c => c.GetParameters().Length).FirstOrDefault();
+            if (constructor == null)
+            {
+                throw new InvalidOperationException($"Could not find a public constructor for {typeof(TImplementation)}.");
+            }
+            var constructorArgs = constructor.GetParameters()
+                .Select(p => serviceProvider.GetRequiredService(p.ParameterType))
+                .ToArray();
+            
+            return ProxyGenerator.CreateClassProxy<TImplementation>(constructorArgs, interceptor);
+        });
+        return services;
+    }
+}

--- a/W3ChampionsStatisticService/Filters/SignalRTraceContextFilter.cs
+++ b/W3ChampionsStatisticService/Filters/SignalRTraceContextFilter.cs
@@ -1,12 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics; // Added for Activity.Current
-using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
-using Serilog;
-using W3ChampionsStatisticService.Services; // Assuming TracingService is here
+using W3ChampionsStatisticService.Services;
 
 namespace W3ChampionsStatisticService.Filters;
 
@@ -18,7 +15,7 @@ public class SignalRTraceContextFilter(TracingService tracingService) : IHubFilt
     {
         public string TraceParent { get; set; }
         public string TraceState { get; set; }
-        public string FaroSessionId {get; set; } // Optional, based on your client structure
+        public string FaroSessionId { get; set; }
     }
 
     public async ValueTask<object> InvokeMethodAsync(
@@ -31,7 +28,7 @@ public class SignalRTraceContextFilter(TracingService tracingService) : IHubFilt
 
         // Extract BattleTag if user is authenticated
         string battleTag = null;
-        if (invocationContext.Context.User?.Identity?.IsAuthenticated == true && 
+        if (invocationContext.Context.User?.Identity?.IsAuthenticated == true &&
             !string.IsNullOrEmpty(invocationContext.Context.User.Identity.Name))
         {
             battleTag = invocationContext.Context.User.Identity.Name;
@@ -56,14 +53,14 @@ public class SignalRTraceContextFilter(TracingService tracingService) : IHubFilt
                             traceState = tracingContextPayload.TraceState;
                             if (!string.IsNullOrEmpty(tracingContextPayload.FaroSessionId))
                             {
-                                clientTags ??= []; // Use collection expression
+                                clientTags ??= [];
                                 clientTags[BaggageToTagProcessor.SessionIdKey] = tracingContextPayload.FaroSessionId;
                             }
                         }
                     }
                 }
                 catch (JsonException)
-                { 
+                {
                     // Argument was not the expected JSON structure, ignore and continue.
                 }
             }
@@ -89,4 +86,4 @@ public class SignalRTraceContextFilter(TracingService tracingService) : IHubFilt
             return await _tracingService.ExecuteAsNewServerSpanAsync(operationName, async () => await next(invocationContext), clientTags);
         }
     }
-} 
+}

--- a/W3ChampionsStatisticService/Filters/SignalRTraceContextFilter.cs
+++ b/W3ChampionsStatisticService/Filters/SignalRTraceContextFilter.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using W3ChampionsStatisticService.Services;
+using W3ChampionsStatisticService.Services.Tracing;
 
 namespace W3ChampionsStatisticService.Filters;
 

--- a/W3ChampionsStatisticService/Filters/SignalRTraceContextFilter.cs
+++ b/W3ChampionsStatisticService/Filters/SignalRTraceContextFilter.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics; // Added for Activity.Current
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Serilog;
+using W3ChampionsStatisticService.Services; // Assuming TracingService is here
+
+namespace W3ChampionsStatisticService.Filters;
+
+public class SignalRTraceContextFilter(TracingService tracingService) : IHubFilter
+{
+    private readonly TracingService _tracingService = tracingService;
+
+    private class TracingContextPayload
+    {
+        public string TraceParent { get; set; }
+        public string TraceState { get; set; }
+        public string FaroSessionId {get; set; } // Optional, based on your client structure
+    }
+
+    public async ValueTask<object> InvokeMethodAsync(
+        HubInvocationContext invocationContext,
+        Func<HubInvocationContext, ValueTask<object>> next)
+    {
+        string traceParent = null;
+        string traceState = null;
+        Dictionary<string, object> clientTags = null;
+
+        // Extract BattleTag if user is authenticated
+        string battleTag = null;
+        if (invocationContext.Context.User?.Identity?.IsAuthenticated == true && 
+            !string.IsNullOrEmpty(invocationContext.Context.User.Identity.Name))
+        {
+            battleTag = invocationContext.Context.User.Identity.Name;
+            clientTags ??= [];
+            clientTags[BaggageToTagProcessor.BattleTagKey] = battleTag;
+        }
+
+        if (invocationContext.HubMethodArguments.Count > 0)
+        {
+            var arg = invocationContext.HubMethodArguments[^1]; // We always pass the tracing context as the last argument
+            if (arg is JsonElement jsonElement)
+            {
+                try
+                {
+                    // Check this for backwards compatibility
+                    if (jsonElement.TryGetProperty("tracingContext", out var tracingContextElement))
+                    {
+                        var tracingContextPayload = tracingContextElement.Deserialize<TracingContextPayload>();
+                        if (tracingContextPayload != null)
+                        {
+                            traceParent = tracingContextPayload.TraceParent;
+                            traceState = tracingContextPayload.TraceState;
+                            if (!string.IsNullOrEmpty(tracingContextPayload.FaroSessionId))
+                            {
+                                clientTags ??= []; // Use collection expression
+                                clientTags[BaggageToTagProcessor.SessionIdKey] = tracingContextPayload.FaroSessionId;
+                            }
+                        }
+                    }
+                }
+                catch (JsonException)
+                { 
+                    // Argument was not the expected JSON structure, ignore and continue.
+                }
+            }
+        }
+
+        var operationName = $"{invocationContext.HubMethod.DeclaringType.Name}/{invocationContext.HubMethodName}";
+
+        if (!string.IsNullOrEmpty(traceParent))
+        {
+            return await _tracingService.ExecuteWithExternalParentTraceAsync(
+                operationName,
+                traceParent,
+                traceState,
+                async () => await next(invocationContext),
+                clientTags);
+        }
+        else
+        {
+            // No external trace context found from client message arguments.
+            // Create a new server span. It will be a root span if Activity.Current is null,
+            // or a child of Activity.Current if it exists (e.g., from OnConnectedAsync).
+            // clientTags will be null here if no tracingContext was found in args.
+            return await _tracingService.ExecuteAsNewServerSpanAsync(operationName, async () => await next(invocationContext), clientTags);
+        }
+    }
+} 

--- a/W3ChampionsStatisticService/Friends/FriendCommandHandler.cs
+++ b/W3ChampionsStatisticService/Friends/FriendCommandHandler.cs
@@ -1,9 +1,11 @@
 using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Driver;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Friends;
 
+[Trace]
 public class FriendCommandHandler(
     FriendRepository friendRepository,
     FriendRequestCache friendRequestCache,

--- a/W3ChampionsStatisticService/Friends/FriendListCache.cs
+++ b/W3ChampionsStatisticService/Friends/FriendListCache.cs
@@ -3,9 +3,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Driver;
 using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Friends;
 
+[Trace]
 public class FriendListCache(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient)
 {
     private List<Friendlist> _friendLists = [];

--- a/W3ChampionsStatisticService/Friends/FriendRepository.cs
+++ b/W3ChampionsStatisticService/Friends/FriendRepository.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Friends;
 
+[Trace]
 public class FriendRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IFriendRepository
 {
     public async Task<Friendlist> LoadFriendlist(string battleTag)

--- a/W3ChampionsStatisticService/Friends/FriendRequestCache.cs
+++ b/W3ChampionsStatisticService/Friends/FriendRequestCache.cs
@@ -19,7 +19,7 @@ public class FriendRequestCache(MongoClient mongoClient) : MongoDbRepositoryBase
         return _requests;
     }
 
-    
+
     public async Task<List<FriendRequest>> LoadSentFriendRequests(string sender)
     {
         await UpdateCacheIfNeeded();

--- a/W3ChampionsStatisticService/Friends/FriendRequestCache.cs
+++ b/W3ChampionsStatisticService/Friends/FriendRequestCache.cs
@@ -3,20 +3,23 @@ using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Driver;
 using W3C.Domain.Repositories;
-
+using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Friends;
 
+[Trace]
 public class FriendRequestCache(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient)
 {
     private List<FriendRequest> _requests = [];
     private readonly object _lock = new();
 
+    [NoTrace]
     public async Task<List<FriendRequest>> LoadAllFriendRequests()
     {
         await UpdateCacheIfNeeded();
         return _requests;
     }
 
+    
     public async Task<List<FriendRequest>> LoadSentFriendRequests(string sender)
     {
         await UpdateCacheIfNeeded();
@@ -57,6 +60,7 @@ public class FriendRequestCache(MongoClient mongoClient) : MongoDbRepositoryBase
         }
     }
 
+    [NoTrace]
     private async Task UpdateCacheIfNeeded()
     {
         if (_requests.Count == 0)

--- a/W3ChampionsStatisticService/Hero/HeroController.cs
+++ b/W3ChampionsStatisticService/Hero/HeroController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Heroes;
 
@@ -8,6 +9,7 @@ namespace W3ChampionsStatisticService.Heroes;
 [ApiController]
 [Route("api/hero")]
 [ResponseCache(Duration = 60 * 60 * 24 * 7, VaryByHeader = "HeroFilterVersion")]
+[Trace]
 public class HeroController() : ControllerBase
 {
     [HttpGet("filters")]

--- a/W3ChampionsStatisticService/Hubs/ConnectionMapping.cs
+++ b/W3ChampionsStatisticService/Hubs/ConnectionMapping.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-
+using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Hubs;
 
+[Trace]
 public class ConnectionMapping
 {
     private readonly Dictionary<string, WebSocketUser> _connections = new();

--- a/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
+++ b/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
@@ -37,8 +37,8 @@ public class WebsiteBackendHub(
     [NoTrace]
     public override async Task OnConnectedAsync()
     {
-        // TODO: Extract tracing context
-        await _tracingService.ExecuteWithSpanAsync(this, async () => {
+        await _tracingService.ExecuteWithSpanAsync(this, async () =>
+        {
             var accessToken = _contextAccessor?.HttpContext?.Request.Query["access_token"];
             W3CUserAuthenticationDto w3cUserAuthentication = _authenticationService.GetUserByToken(accessToken, false);
             if (w3cUserAuthentication == null)

--- a/W3ChampionsStatisticService/Ladder/LadderController.cs
+++ b/W3ChampionsStatisticService/Ladder/LadderController.cs
@@ -5,11 +5,12 @@ using System.Threading.Tasks;
 using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.Services;
-
+using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Ladder;
 
 [ApiController]
 [Route("api/ladder")]
+[Trace]
 public class LadderController(
     IRankRepository rankRepository,
     IPlayerRepository playerRepository,

--- a/W3ChampionsStatisticService/Ladder/LeagueSyncHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/LeagueSyncHandler.cs
@@ -3,9 +3,11 @@ using System.Threading.Tasks;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Ladder;
 
+[Trace]
 public class LeagueSyncHandler(
     IRankRepository rankRepository,
     IMatchEventRepository matchEventRepository

--- a/W3ChampionsStatisticService/Ladder/PlayOverviewHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/PlayOverviewHandler.cs
@@ -7,9 +7,11 @@ using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Contracts.Matchmaking;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Ladder;
 
+[Trace]
 public class PlayOverviewHandler(IPlayerRepository playerRepository) : IReadModelHandler
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;
@@ -88,6 +90,7 @@ public class PlayOverviewHandler(IPlayerRepository playerRepository) : IReadMode
         return winner;
     }
 
+    [NoTrace]
     private GameMode GetOverviewGameMode(GameMode gameMode, PlayerMMrChange player)
     {
         if (gameMode == GameMode.GM_2v2 && player.IsAt)

--- a/W3ChampionsStatisticService/Ladder/PlayerWinrateHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/PlayerWinrateHandler.cs
@@ -3,9 +3,11 @@ using System.Threading.Tasks;
 using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Ladder;
 
+[Trace]
 public class PlayerWinrateHandler(IPlayerRepository playerRepository) : IReadModelHandler
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;

--- a/W3ChampionsStatisticService/Ladder/RankQueryHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/RankQueryHandler.cs
@@ -3,9 +3,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.Ports;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Ladder;
 
+[Trace]
 public class RankQueryHandler(
     IRankRepository rankRepository,
     IPlayerRepository playerRepository,

--- a/W3ChampionsStatisticService/Ladder/RankRepository.cs
+++ b/W3ChampionsStatisticService/Ladder/RankRepository.cs
@@ -8,9 +8,11 @@ using W3C.Contracts.Matchmaking;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.Services;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Ladder;
 
+[Trace]
 public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider personalSettingsProvider) : MongoDbRepositoryBase(mongoClient), IRankRepository
 {
     private PersonalSettingsProvider _personalSettingsProvider = personalSettingsProvider;

--- a/W3ChampionsStatisticService/Ladder/RankSyncHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/RankSyncHandler.cs
@@ -3,9 +3,11 @@ using System.Threading.Tasks;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Ladder;
 
+[Trace]
 public class RankSyncHandler(
     IRankRepository rankRepository,
     IMatchEventRepository matchEventRepository

--- a/W3ChampionsStatisticService/Maps/MapsController.cs
+++ b/W3ChampionsStatisticService/Maps/MapsController.cs
@@ -7,11 +7,13 @@ using W3C.Domain.UpdateService;
 using W3ChampionsStatisticService.WebApi.ActionFilters;
 using System.Net.Http;
 using W3C.Contracts.Admin.Permission;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Maps;
 
 [ApiController]
 [Route("api/maps")]
+[Trace]
 public class MapsController(
     MatchmakingServiceClient matchmakingServiceClient,
     UpdateServiceClient updateServiceClient) : ControllerBase

--- a/W3ChampionsStatisticService/Matches/MatchQueryHandler.cs
+++ b/W3ChampionsStatisticService/Matches/MatchQueryHandler.cs
@@ -2,14 +2,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using W3ChampionsStatisticService.Ports;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Matches;
 
+[Trace]
 public class MatchQueryHandler(IPersonalSettingsRepository personalSettingsRepository)
 {
     private readonly IPersonalSettingsRepository _personalSettingsRepository = personalSettingsRepository;
 
-    public async Task PopulatePlayerInfos(List<OnGoingMatchup> matches)
+    public virtual async Task PopulatePlayerInfos(List<OnGoingMatchup> matches)
     {
         var battleTags = matches.SelectMany(match => match.Teams).SelectMany(team => team.Players).Select(player => player.BattleTag);
         var personalSettings = await _personalSettingsRepository.LoadMany(battleTags.ToArray());

--- a/W3ChampionsStatisticService/Matches/MatchQueryHandler.cs
+++ b/W3ChampionsStatisticService/Matches/MatchQueryHandler.cs
@@ -11,7 +11,8 @@ public class MatchQueryHandler(IPersonalSettingsRepository personalSettingsRepos
 {
     private readonly IPersonalSettingsRepository _personalSettingsRepository = personalSettingsRepository;
 
-    public virtual async Task PopulatePlayerInfos(List<OnGoingMatchup> matches)
+    //public virtual async Task PopulatePlayerInfos(List<OnGoingMatchup> matches)
+    public async Task PopulatePlayerInfos(List<OnGoingMatchup> matches)
     {
         var battleTags = matches.SelectMany(match => match.Teams).SelectMany(team => team.Players).Select(player => player.BattleTag);
         var personalSettings = await _personalSettingsRepository.LoadMany(battleTags.ToArray());

--- a/W3ChampionsStatisticService/Matches/MatchReadModelHandler.cs
+++ b/W3ChampionsStatisticService/Matches/MatchReadModelHandler.cs
@@ -4,9 +4,11 @@ using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using Serilog;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Matches;
 
+[Trace]
 public class MatchReadModelHandler(IMatchRepository matchRepository) : IReadModelHandler
 {
     private readonly IMatchRepository _matchRepository = matchRepository;

--- a/W3ChampionsStatisticService/Matches/MatchRepository.cs
+++ b/W3ChampionsStatisticService/Matches/MatchRepository.cs
@@ -4,7 +4,6 @@ using MongoDB.Driver.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
 using W3C.Contracts.GameObjects;
@@ -15,9 +14,11 @@ using W3ChampionsStatisticService.Ports;
 using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.Heroes;
 using W3ChampionsStatisticService.Ladder;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Matches;
 
+[Trace]
 public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache) : MongoDbRepositoryBase(mongoClient), IMatchRepository
 {
     private readonly IOngoingMatchesCache _cache = cache;

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -6,11 +6,13 @@ using W3ChampionsStatisticService.Heroes;
 using W3ChampionsStatisticService.Ports;
 using W3C.Contracts.GameObjects;
 using W3ChampionsStatisticService.Services;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Matches;
 
 [ApiController]
 [Route("api/matches")]
+[Trace]
 public class MatchesController(IMatchRepository matchRepository, MatchQueryHandler matchQueryHandler, MatchService matchService) : ControllerBase
 {
     private readonly IMatchRepository _matchRepository = matchRepository;

--- a/W3ChampionsStatisticService/Matches/Matchup.cs
+++ b/W3ChampionsStatisticService/Matches/Matchup.cs
@@ -8,6 +8,7 @@ using W3C.Domain.CommonValueObjects;
 using W3C.Domain.MatchmakingService;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.GameModes;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Matches;
 
@@ -56,6 +57,7 @@ public class Matchup
     {
     }
 
+    [Trace]
     public static Matchup Create(MatchFinishedEvent matchFinishedEvent)
     {
         var match = matchFinishedEvent.match;

--- a/W3ChampionsStatisticService/Matches/OngoingMatchesCache.cs
+++ b/W3ChampionsStatisticService/Matches/OngoingMatchesCache.cs
@@ -5,9 +5,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Matches;
 
+[Trace]
 public class OngoingMatchesCache(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IOngoingMatchesCache
 {
     private List<OnGoingMatchup> _values = [];
@@ -58,11 +60,13 @@ public class OngoingMatchesCache(MongoClient mongoClient) : MongoDbRepositoryBas
             .ToList();
     }
 
+    [NoTrace]
     public int GetMaxMmrInTeam(Team team)
     {
         return team.Players.Max(p => p.OldMmr);
     }
 
+    [NoTrace]
     public int GetMaxMmrInMatch(OnGoingMatchup match)
     {
         return match.Teams.Max(t => GetMaxMmrInTeam(t));
@@ -95,6 +99,7 @@ public class OngoingMatchesCache(MongoClient mongoClient) : MongoDbRepositoryBas
         }
     }
 
+    [NoTrace]
     private async Task UpdateCacheIfNeeded()
     {
         if (_values.Count == 0)

--- a/W3ChampionsStatisticService/Matches/OngoingMatchesHandler.cs
+++ b/W3ChampionsStatisticService/Matches/OngoingMatchesHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;

--- a/W3ChampionsStatisticService/Matches/OngoingMatchesHandler.cs
+++ b/W3ChampionsStatisticService/Matches/OngoingMatchesHandler.cs
@@ -4,9 +4,11 @@ using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Contracts.Matchmaking;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Matches;
 
+[Trace]
 public class OngoingMatchesHandler(
     IMatchEventRepository eventRepository,
     IMatchRepository matchRepository,

--- a/W3ChampionsStatisticService/Matches/PlayersObfuscator.cs
+++ b/W3ChampionsStatisticService/Matches/PlayersObfuscator.cs
@@ -1,8 +1,10 @@
 ﻿using System.Linq;
 using W3C.Domain.GameModes;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Matches;
 
+[Trace]
 public static class PlayersObfuscator
 {
     public static void ObfuscatePlayersForFFA(params OnGoingMatchup[] matches)

--- a/W3ChampionsStatisticService/Moderation/ModerationController.cs
+++ b/W3ChampionsStatisticService/Moderation/ModerationController.cs
@@ -5,11 +5,13 @@ using W3ChampionsStatisticService.WebApi.ActionFilters;
 using System.Net;
 using W3C.Contracts.Admin.Moderation;
 using W3C.Contracts.Admin.Permission;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Moderation;
 
 [ApiController]
 [Route("api/moderation")]
+[Trace]
 public class ModerationController(ChatServiceClient chatServiceRepository) : ControllerBase
 {
     private readonly ChatServiceClient _chatServiceRepository = chatServiceRepository;
@@ -17,7 +19,7 @@ public class ModerationController(ChatServiceClient chatServiceRepository) : Con
     [HttpGet("loungeMute")]
     [InjectAuthToken]
     [BearerHasPermissionFilter(Permission = EPermission.Moderation)]
-    public async Task<IActionResult> GetLoungeMutes(string authToken)
+    public async Task<IActionResult> GetLoungeMutes([NoTrace]string authToken)
     {
         var loungeMutes = await _chatServiceRepository.GetLoungeMutes(authToken);
         return Ok(loungeMutes);
@@ -26,7 +28,7 @@ public class ModerationController(ChatServiceClient chatServiceRepository) : Con
     [HttpPost("loungeMute")]
     [InjectAuthToken]
     [BearerHasPermissionFilter(Permission = EPermission.Moderation)]
-    public async Task<IActionResult> PostLoungeMute([FromBody] LoungeMute loungeMute, string authToken)
+    public async Task<IActionResult> PostLoungeMute([FromBody] LoungeMute loungeMute, [NoTrace] string authToken)
     {
         if (loungeMute.battleTag == "")
         {
@@ -58,7 +60,7 @@ public class ModerationController(ChatServiceClient chatServiceRepository) : Con
     [HttpDelete("loungeMute/{bTag}")]
     [InjectAuthToken]
     [BearerHasPermissionFilter(Permission = EPermission.Moderation)]
-    public async Task<IActionResult> DeleteLoungeMute([FromRoute] string bTag, string authToken)
+    public async Task<IActionResult> DeleteLoungeMute([FromRoute] string bTag, [NoTrace] string authToken)
     {
         var result = await _chatServiceRepository.DeleteLoungeMute(bTag, authToken);
         if (result.StatusCode == HttpStatusCode.BadRequest)

--- a/W3ChampionsStatisticService/Moderation/ModerationController.cs
+++ b/W3ChampionsStatisticService/Moderation/ModerationController.cs
@@ -19,7 +19,7 @@ public class ModerationController(ChatServiceClient chatServiceRepository) : Con
     [HttpGet("loungeMute")]
     [InjectAuthToken]
     [BearerHasPermissionFilter(Permission = EPermission.Moderation)]
-    public async Task<IActionResult> GetLoungeMutes([NoTrace]string authToken)
+    public async Task<IActionResult> GetLoungeMutes([NoTrace] string authToken)
     {
         var loungeMutes = await _chatServiceRepository.GetLoungeMutes(authToken);
         return Ok(loungeMutes);

--- a/W3ChampionsStatisticService/PersonalSettings/PersonalSetting.cs
+++ b/W3ChampionsStatisticService/PersonalSettings/PersonalSetting.cs
@@ -7,6 +7,7 @@ using W3C.Contracts.GameObjects;
 using W3C.Domain.CommonValueObjects;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.PlayerProfiles;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PersonalSettings;
 
@@ -43,6 +44,7 @@ public class PersonalSetting : IVersionable, IIdentifiable
     public string ChatColor { get; set; }
     public AkaSettings AliasSettings { get; set; }
 
+    [Trace]
     public bool SetProfilePicture(SetPictureCommand cmd)
     {
         bool isValid = false;

--- a/W3ChampionsStatisticService/PersonalSettings/PersonalSettingsController.cs
+++ b/W3ChampionsStatisticService/PersonalSettings/PersonalSettingsController.cs
@@ -5,11 +5,13 @@ using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.Rewards.Portraits;
 using W3ChampionsStatisticService.Services;
 using W3ChampionsStatisticService.WebApi.ActionFilters;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PersonalSettings;
 
 [ApiController]
 [Route("api/personal-settings")]
+[Trace]
 public class PersonalSettingsController(
     IPersonalSettingsRepository personalSettingsRepository,
     PortraitCommandHandler commandHandler,

--- a/W3ChampionsStatisticService/PersonalSettings/PersonalSettingsRepository.cs
+++ b/W3ChampionsStatisticService/PersonalSettings/PersonalSettingsRepository.cs
@@ -7,9 +7,11 @@ using System.Threading.Tasks;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.PlayerProfiles;
 using W3ChampionsStatisticService.Ports;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PersonalSettings;
 
+[Trace]
 public class PersonalSettingsRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IPersonalSettingsRepository
 {
     public async Task<PersonalSetting> Load(string battletag)
@@ -113,6 +115,7 @@ public class PersonalSettingsRepository(MongoClient mongoClient) : MongoDbReposi
         return;
     }
 
+    [NoTrace]
     public bool SchemaOutdated(PersonalSetting setting)
     {
         if (!setting.ToBsonDocument().Contains("SpecialPictures"))

--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/GameModeStatQueryHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/GameModeStatQueryHandler.cs
@@ -7,9 +7,11 @@ using W3ChampionsStatisticService.Ladder;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.Services;
 using Serilog;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
 
+[Trace]
 public class GameModeStatQueryHandler(
     IPlayerRepository playerRepository,
     PlayerService playerService,

--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGatewayHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGatewayHandler.cs
@@ -7,9 +7,11 @@ using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Contracts.Matchmaking;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
 
+[Trace]
 public class PlayerGameModeStatPerGatewayHandler(IPlayerRepository playerRepository) : IReadModelHandler
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;
@@ -113,6 +115,7 @@ public class PlayerGameModeStatPerGatewayHandler(IPlayerRepository playerReposit
         await _playerRepository.UpsertPlayerGameModeStatPerGateway(winner);
     }
 
+    [NoTrace]
     private GameMode GetGameModeStatGameMode(GameMode gameMode, PlayerMMrChange player)
     {
         if (gameMode == GameMode.GM_2v2 && player.IsAt)

--- a/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrRpTimeline.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrRpTimeline.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 
@@ -11,6 +12,7 @@ public class PlayerMmrRpTimeline(string battleTag, Race race, GateWay gateWay, i
     public string Id { get; set; } = $"{season}_{battleTag}_@{gateWay}_{race}_{gameMode}";
     public List<MmrRpAtDate> MmrRpAtDates { get; set; } = new List<MmrRpAtDate>();
 
+    [Trace]
     public void UpdateTimeline(MmrRpAtDate mmrRpAtDate)
     {
         // Empty?

--- a/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrRpTimelineHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrRpTimelineHandler.cs
@@ -3,9 +3,11 @@ using System.Threading.Tasks;
 using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 
+[Trace]
 public class PlayerMmrRpTimelineHandler(IPlayerRepository playerRepository) : IReadModelHandler
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayerDetails.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayerDetails.cs
@@ -17,12 +17,5 @@ public class PlayerDetails
     public PersonalSetting[] PersonalSettings { get; set; }
     public Player PlayerAkaData { get; set; }
 
-    public Race GetMainRace()
-    {
-        var mostGamesRace = WinLosses?
-                .OrderByDescending(x => x.Games)
-                .FirstOrDefault();
-
-        return mostGamesRace != null ? mostGamesRace.Race : Race.RnD;
-    }
+    public Race GetMainRace() => WinLosses?.MaxBy(x => x.Games)?.Race ?? Race.RnD;
 }

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayerOverallStatsHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayerOverallStatsHandler.cs
@@ -3,9 +3,11 @@ using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerProfiles;
 
+[Trace]
 public class PlayerOverallStatsHandler(
     IPlayerRepository playerRepository,
     IPersonalSettingsRepository personalSettingsRepository) : IReadModelHandler

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
@@ -12,9 +12,11 @@ using W3ChampionsStatisticService.PlayerProfiles.RaceStats;
 using W3ChampionsStatisticService.Ports;
 using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.PlayerStats.GameLengthForPlayerStatistics;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerProfiles;
 
+[Trace]
 public class PlayerRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IPlayerRepository
 {
     public async Task UpsertPlayer(PlayerOverallStats playerOverallStats)

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
@@ -9,11 +9,12 @@ using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.WebApi.ActionFilters;
 using W3ChampionsStatisticService.Services;
 using W3C.Contracts.GameObjects;
-
+using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.PlayerProfiles;
 
 [ApiController]
 [Route("api/players")]
+[Trace]
 public class PlayersController(
     IPlayerRepository playerRepository,
     GameModeStatQueryHandler queryHandler,
@@ -92,6 +93,11 @@ public class PlayersController(
     [HttpGet]
     public async Task<IActionResult> SearchPlayer(string search)
     {
+        if (string.IsNullOrEmpty(search))
+        {
+            return BadRequest("Battle tag is required");
+        }
+
         var players = await _playerRepository.SearchForPlayer(search);
         return Ok(players);
     }

--- a/W3ChampionsStatisticService/PlayerProfiles/RaceStats/PlayerRaceStatPerGatewayHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/RaceStats/PlayerRaceStatPerGatewayHandler.cs
@@ -2,9 +2,11 @@
 using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerProfiles.RaceStats;
 
+[Trace]
 public class PlayerRaceStatPerGatewayHandler(IPlayerRepository playerRepository) : IReadModelHandler
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;

--- a/W3ChampionsStatisticService/PlayerStats/GameLengthForPlayerStatistics/GameLengthForPlayerStatisticsHandler.cs
+++ b/W3ChampionsStatisticService/PlayerStats/GameLengthForPlayerStatistics/GameLengthForPlayerStatisticsHandler.cs
@@ -4,8 +4,11 @@ using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Contracts.Matchmaking;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerStats.GameLengthForPlayerStatistics;
+
+[Trace]
 public class GameLengthForPlayerStatisticsHandler(IPlayerRepository playerRepo) : IReadModelHandler
 {
     private readonly IPlayerRepository _playerRepo = playerRepo;

--- a/W3ChampionsStatisticService/PlayerStats/GameLengthForPlayerStatistics/PlayerGameLength.cs
+++ b/W3ChampionsStatisticService/PlayerStats/GameLengthForPlayerStatistics/PlayerGameLength.cs
@@ -3,8 +3,11 @@ using System.Linq;
 using System.Text.Json.Serialization;
 using W3C.Contracts.GameObjects;
 using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerStats.GameLengthForPlayerStatistics;
+
+[Trace]
 public class PlayerGameLength : IIdentifiable
 {
     public string Id => CompoundId(BattleTag, Season);
@@ -42,6 +45,7 @@ public class PlayerGameLength : IIdentifiable
         PlayerGameLengthIntervalByOpponentRace[raceTotalString].Apply(seconds);
     }
 
+    [NoTrace]
     public static string CompoundId(string battleTag, int Season)
     {
         return battleTag + "_" + Season;

--- a/W3ChampionsStatisticService/PlayerStats/HeroStats/PlayerHeroStatsHandler.cs
+++ b/W3ChampionsStatisticService/PlayerStats/HeroStats/PlayerHeroStatsHandler.cs
@@ -4,9 +4,11 @@ using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Domain.GameModes;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerStats.HeroStats;
 
+[Trace]
 public class PlayerHeroStatsHandler(IPlayerStatsRepository playerRepository) : IReadModelHandler
 {
     private readonly IPlayerStatsRepository _playerRepository = playerRepository;

--- a/W3ChampionsStatisticService/PlayerStats/PlayerStatsController.cs
+++ b/W3ChampionsStatisticService/PlayerStats/PlayerStatsController.cs
@@ -4,11 +4,13 @@ using Microsoft.AspNetCore.Mvc;
 using W3ChampionsStatisticService.PlayerStats.HeroStats;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.Services;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerStats;
 
 [ApiController]
 [Route("api/player-stats")]
+[Trace]
 public class PlayerStatsController(IPlayerStatsRepository playerRepository, PlayerStatisticsService playerStatisticsService) : ControllerBase
 {
     private readonly IPlayerStatsRepository _playerRepository = playerRepository;

--- a/W3ChampionsStatisticService/PlayerStats/PlayerStatsRepository.cs
+++ b/W3ChampionsStatisticService/PlayerStats/PlayerStatsRepository.cs
@@ -4,9 +4,11 @@ using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.PlayerStats.HeroStats;
 using W3ChampionsStatisticService.PlayerStats.RaceOnMapVersusRaceStats;
 using W3ChampionsStatisticService.Ports;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerStats;
 
+[Trace]
 public class PlayerStatsRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IPlayerStatsRepository
 {
     public Task<PlayerRaceOnMapVersusRaceRatio> LoadMapAndRaceStat(string battleTag, int season)

--- a/W3ChampionsStatisticService/PlayerStats/RaceOnMapVersusRaceStats/PlayerRaceOnMapVersusRaceRatioHandler.cs
+++ b/W3ChampionsStatisticService/PlayerStats/RaceOnMapVersusRaceStats/PlayerRaceOnMapVersusRaceRatioHandler.cs
@@ -6,9 +6,11 @@ using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Domain.GameModes;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerStats.RaceOnMapVersusRaceStats;
 
+[Trace]
 public class PlayerRaceOnMapVersusRaceRatioHandler(
     IPlayerStatsRepository playerRepository,
     IPatchRepository patchRepository

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -1,7 +1,6 @@
 ﻿using MongoDB.Bson;
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -11,13 +11,6 @@ using Prometheus;
 using Serilog;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-
-using OpenTelemetry.Resources;
-using OpenTelemetry.Trace;
-using OpenTelemetry.Metrics;
-using OpenTelemetry;
-using System.Diagnostics;
 
 using W3C.Domain.ChatService;
 using W3C.Domain.CommonValueObjects;
@@ -65,12 +58,7 @@ using W3ChampionsStatisticService.W3ChampionsStats.MatchupLengths;
 using Serilog.Events;
 using Serilog.Formatting.Json;
 using MongoDB.Driver.Core.Extensions.DiagnosticSources;
-using Castle.DynamicProxy;
-using W3ChampionsStatisticService.Services.Interceptors;
 using W3ChampionsStatisticService.Extensions;
-using Microsoft.AspNetCore.Http;
-using W3ChampionsStatisticService.Services.Tracing.Sampling;
-using W3ChampionsStatisticService.Filters;
 using W3ChampionsStatisticService.Services.Tracing;
 
 const string WEBSITE_BACKEND_HUB_PATH = "/websiteBackendHub";
@@ -116,21 +104,11 @@ MongoClientSettings mongoSettings = MongoClientSettings.FromConnectionString(mon
 mongoSettings.ServerSelectionTimeout = TimeSpan.FromSeconds(5);
 mongoSettings.ConnectTimeout = TimeSpan.FromSeconds(5);
 
-// Add OTEL MongoDB Instrumentation
-mongoSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityEventSubscriber(new InstrumentationOptions { CaptureCommandText = true }));
-mongoSettings.ApplicationName = "W3ChampionsStatisticService"; // Set
+builder.Services.AddW3CTracing(WEBSITE_BACKEND_HUB_PATH, mongoSettings);
 
 var mongoClient = new MongoClient(mongoSettings);
 builder.Services.AddSingleton(mongoClient);
 
-// Configure OpenTelemetry
-var serviceName = "W3ChampionsStatisticService";
-var serviceVersion = "1.0.0";
-
-// Get OTLP endpoint from environment variable or use default
-var otlpEndpoint = Environment.GetEnvironmentVariable("OTLP_ENDPOINT") ?? "http://localhost:4317";
-
-builder.Services.AddW3CTracing(serviceName, serviceVersion, otlpEndpoint, WEBSITE_BACKEND_HUB_PATH);
 
 // Add SignalR for using websockets
 builder.Services.AddSignalR();

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -111,7 +111,7 @@ builder.Services.AddSwaggerGen(f =>
 });
 
 // Configure and add MongoDB
-string mongoConnectionString = Environment.GetEnvironmentVariable("MONGO_CONNECTION_STRING") ?? "mongodb://localhost:27020";
+string mongoConnectionString = Environment.GetEnvironmentVariable("MONGO_CONNECTION_STRING") ?? "mongodb://157.90.1.251:3513"; // "mongodb://localhost:27017";
 MongoClientSettings mongoSettings = MongoClientSettings.FromConnectionString(mongoConnectionString.Replace("'", ""));
 mongoSettings.ServerSelectionTimeout = TimeSpan.FromSeconds(5);
 mongoSettings.ConnectTimeout = TimeSpan.FromSeconds(5);

--- a/W3ChampionsStatisticService/ReadModelBase/ReadModelHandler.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/ReadModelHandler.cs
@@ -4,9 +4,11 @@ using System.Threading.Tasks;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.Services;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.ReadModelBase;
 
+[Trace]
 public class ReadModelHandler<T>(
     IMatchEventRepository eventRepository,
     IVersionRepository versionRepository,

--- a/W3ChampionsStatisticService/ReadModelBase/VersionRepository.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/VersionRepository.cs
@@ -3,9 +3,11 @@ using MongoDB.Driver;
 using System.Threading.Tasks;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.ReadModelBase;
 
+[Trace]
 public class VersionRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IVersionRepository
 {
     private readonly string _collection = "HandlerVersions";
@@ -46,6 +48,7 @@ public class VersionRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
         }
     }
 
+    [NoTrace]
     private static string HandlerName<T>()
     {
         return typeof(T).Name;

--- a/W3ChampionsStatisticService/Replays/ReplaysController.cs
+++ b/W3ChampionsStatisticService/Replays/ReplaysController.cs
@@ -4,11 +4,13 @@ using W3C.Contracts.Admin.Permission;
 using W3C.Domain.UpdateService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.WebApi.ActionFilters;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Maps;
 
 [ApiController]
 [Route("api/replays")]
+[Trace]
 public class ReplaysController(
     ReplayServiceClient replayServiceClient,
     IMatchRepository matchRepository) : ControllerBase

--- a/W3ChampionsStatisticService/Rewards/Portraits/PortraitCommandHandler.cs
+++ b/W3ChampionsStatisticService/Rewards/Portraits/PortraitCommandHandler.cs
@@ -3,9 +3,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.Ports;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Rewards.Portraits;
 
+[Trace]
 public class PortraitCommandHandler(
     IPersonalSettingsRepository personalSettingsRepository,
     IPortraitRepository portraitRepository)

--- a/W3ChampionsStatisticService/Rewards/Portraits/PortraitRepository.cs
+++ b/W3ChampionsStatisticService/Rewards/Portraits/PortraitRepository.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Rewards.Portraits;
 
+[Trace]
 public class PortraitRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IPortraitRepository
 {
     public Task<List<PortraitDefinition>> LoadPortraitDefinitions()

--- a/W3ChampionsStatisticService/Rewards/RewardsController.cs
+++ b/W3ChampionsStatisticService/Rewards/RewardsController.cs
@@ -4,11 +4,13 @@ using W3C.Contracts.Admin.Permission;
 using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.Rewards.Portraits;
 using W3ChampionsStatisticService.WebApi.ActionFilters;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Rewards;
 
 [Route("api/rewards")]
 [ApiController]
+[Trace]
 public class RewardsController(
     IPortraitRepository portraitRepository,
     PortraitCommandHandler portraitCommandHandler) : ControllerBase

--- a/W3ChampionsStatisticService/Services/IdentityServiceClient.cs
+++ b/W3ChampionsStatisticService/Services/IdentityServiceClient.cs
@@ -7,14 +7,16 @@ using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json;
 using W3C.Contracts.Admin.Permission;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Services;
 
+[Trace]
 public class IdentityServiceClient()
 {
     private static readonly string IdentityApiUrl = Environment.GetEnvironmentVariable("IDENTIFICATION_SERVICE_URI") ?? "https://identification-service.test.w3champions.com";
 
-    public async Task<List<Permission>> GetPermissions(string authorization)
+    public async Task<List<Permission>> GetPermissions([NoTrace] string authorization)
     {
         var httpClient = new HttpClient();
         var response = await httpClient.GetAsync($"{IdentityApiUrl}/api/permissions?authorization={authorization}");
@@ -33,7 +35,7 @@ public class IdentityServiceClient()
         return permissionList;
     }
 
-    public async Task<HttpStatusCode> AddAdmin(Permission permission, string authorization)
+    public async Task<HttpStatusCode> AddAdmin(Permission permission, [NoTrace] string authorization)
     {
         var httpClient = new HttpClient();
         var serializedObject = JsonConvert.SerializeObject(permission);
@@ -49,7 +51,7 @@ public class IdentityServiceClient()
         return response.StatusCode;
     }
 
-    public async Task<HttpStatusCode> EditAdmin(Permission permission, string authorization)
+    public async Task<HttpStatusCode> EditAdmin(Permission permission, [NoTrace] string authorization)
     {
         var httpClient = new HttpClient();
         var serializedObject = JsonConvert.SerializeObject(permission);
@@ -65,7 +67,7 @@ public class IdentityServiceClient()
         return response.StatusCode;
     }
 
-    public async Task<HttpStatusCode> DeleteAdmin(string id, string authorization)
+    public async Task<HttpStatusCode> DeleteAdmin(string id, [NoTrace] string authorization)
     {
         var httpClient = new HttpClient();
         var encodedTag = HttpUtility.UrlEncode(id);

--- a/W3ChampionsStatisticService/Services/MatchService.cs
+++ b/W3ChampionsStatisticService/Services/MatchService.cs
@@ -6,6 +6,7 @@ using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.Matches;
 using W3ChampionsStatisticService.Ports;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Services;
 
@@ -16,6 +17,7 @@ public class CachedLong
 }
 
 // Calls MatchRepository and caches results
+[Trace]
 public class MatchService(
     IMatchRepository matchRepository,
     ICachedDataProvider<List<Matchup>> cachedMatchesProvider,

--- a/W3ChampionsStatisticService/Services/MatchmakingProvider.cs
+++ b/W3ChampionsStatisticService/Services/MatchmakingProvider.cs
@@ -4,10 +4,12 @@ using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Cache;
 using W3C.Domain.MatchmakingService;
 using System.Collections.Generic;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Services;
 
 // TODO: It is a repository with a cache
+[Trace]
 public class MatchmakingProvider(
     MongoClient mongoClient,
     MatchmakingServiceClient matchmakingServiceClient,

--- a/W3ChampionsStatisticService/Services/MatchupHeroBackfillService.cs
+++ b/W3ChampionsStatisticService/Services/MatchupHeroBackfillService.cs
@@ -4,9 +4,12 @@ using System.Threading.Tasks;
 using Serilog;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Domain.Tracing;
+
 
 namespace W3ChampionsStatisticService.Services;
 
+[Trace]
 public class MatchupHeroBackfillService(IMatchRepository matchRepository) : IAsyncUpdatable
 {
     private readonly IMatchRepository matchRepository = matchRepository;

--- a/W3ChampionsStatisticService/Services/MatchupHeroBackfillService.cs
+++ b/W3ChampionsStatisticService/Services/MatchupHeroBackfillService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
 using W3ChampionsStatisticService.Ports;

--- a/W3ChampionsStatisticService/Services/PersonalSettingsProvider.cs
+++ b/W3ChampionsStatisticService/Services/PersonalSettingsProvider.cs
@@ -4,10 +4,12 @@ using System.Threading.Tasks;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Cache;
 using W3ChampionsStatisticService.PersonalSettings;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Services;
 
 // TODO: It is a repository with a cache
+[Trace]
 public class PersonalSettingsProvider(MongoClient mongoClient, ICachedDataProvider<List<PersonalSetting>> cachedDataProvider) : MongoDbRepositoryBase(mongoClient)
 {
     private readonly ICachedDataProvider<List<PersonalSetting>> _cachedDataProvider = cachedDataProvider;

--- a/W3ChampionsStatisticService/Services/PlayerAkaProvider.cs
+++ b/W3ChampionsStatisticService/Services/PlayerAkaProvider.cs
@@ -6,9 +6,11 @@ using System.Collections.Generic;
 using W3ChampionsStatisticService.Cache;
 using W3ChampionsStatisticService.PlayerProfiles.War3InfoPlayerAkas;
 using W3ChampionsStatisticService.PersonalSettings;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Services;
 
+[Trace]
 public class PlayerAkaProvider(ICachedDataProvider<List<PlayerAka>> userAccountsCached)
 {
     private readonly ICachedDataProvider<List<PlayerAka>> _userAccountsCached = userAccountsCached;

--- a/W3ChampionsStatisticService/Services/PlayerService.cs
+++ b/W3ChampionsStatisticService/Services/PlayerService.cs
@@ -9,9 +9,11 @@ using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.PlayerProfiles.GlobalSearch;
 using W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 using W3ChampionsStatisticService.Ports;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Services;
 
+[Trace]
 public class PlayerService(IPlayerRepository playerRepository, ICachedDataProvider<List<MmrRank>> mmrCachedDataProvider, PersonalSettingsProvider personalSettingsProvider)
 {
     private readonly ICachedDataProvider<List<MmrRank>> _mmrCachedDataProvider = mmrCachedDataProvider;
@@ -130,6 +132,7 @@ public class PlayerService(IPlayerRepository playerRepository, ICachedDataProvid
         return result;
     }
 
+    [NoTrace]
     private string GetRankKey(List<PlayerId> playerIds, GameMode gameMode, Race? race)
     {
         if (gameMode != GameMode.GM_2v2_AT

--- a/W3ChampionsStatisticService/Services/PlayerStatsService.cs
+++ b/W3ChampionsStatisticService/Services/PlayerStatsService.cs
@@ -6,9 +6,12 @@ using W3ChampionsStatisticService.Matches;
 using W3ChampionsStatisticService.PlayerStats.RaceOnMapVersusRaceStats;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.W3ChampionsStats.MapsPerSeasons;
+using W3C.Domain.Tracing;
+
 
 namespace W3ChampionsStatisticService.Services;
 
+[Trace]
 public class PlayerStatisticsService(
     IPlayerStatsRepository playerStatsRepository,
     MatchmakingProvider matchmakingProvider,

--- a/W3ChampionsStatisticService/Services/Tracing/BaggageToTagProcessor.cs
+++ b/W3ChampionsStatisticService/Services/Tracing/BaggageToTagProcessor.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace W3ChampionsStatisticService.Services.Tracing;
+
+public class BaggageToTagProcessor : BaseProcessor<Activity>
+{
+    public const string SessionIdKey = "session_id"; // This key is used to correlate Faro traces across backend services
+    public const string BattleTagKey = "battle_tag";
+
+    public override void OnStart(Activity activity)
+    {
+        ProcessBaggageItem(activity, SessionIdKey);
+        ProcessBaggageItem(activity, BattleTagKey);
+    }
+
+    private void ProcessBaggageItem(Activity activity, string baggageKey)
+    {
+        var baggageValue = activity.GetBaggageItem(baggageKey);
+        if (!string.IsNullOrEmpty(baggageValue))
+        {
+            bool tagExists = false;
+            foreach (var tag in activity.TagObjects)
+            {
+                if (tag.Key == baggageKey)
+                {
+                    tagExists = true;
+                    break;
+                }
+            }
+            if (!tagExists)
+            {
+                activity.SetTag(baggageKey, baggageValue);
+            }
+        }
+    }
+}

--- a/W3ChampionsStatisticService/Services/Tracing/Interceptors/TracingInterceptor.cs
+++ b/W3ChampionsStatisticService/Services/Tracing/Interceptors/TracingInterceptor.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading.Tasks;
+using Castle.DynamicProxy;
+using W3C.Domain.Tracing;
+namespace W3ChampionsStatisticService.Services.Interceptors;
+
+public class TracingInterceptor(ActivitySource activitySource) : IInterceptor
+{
+    private readonly ActivitySource _activitySource = activitySource;
+
+    public void Intercept(IInvocation invocation)
+    {
+        // 1. Check for [NoTrace] on the method first
+        var noTraceAttributeOnMethod = invocation.MethodInvocationTarget.GetCustomAttribute<NoTraceAttribute>()
+                                     ?? invocation.Method.GetCustomAttribute<NoTraceAttribute>();
+
+        if (noTraceAttributeOnMethod != null)
+        {
+            invocation.Proceed(); // [NoTrace] found, proceed without tracing.
+            return;
+        }
+
+        // 2. Check for [Trace] on the method
+        var methodTraceAttribute = invocation.MethodInvocationTarget.GetCustomAttribute<TraceAttribute>()
+                                 ?? invocation.Method.GetCustomAttribute<TraceAttribute>();
+
+        TraceAttribute effectiveTraceAttribute = methodTraceAttribute; // Prioritize method attribute
+
+        // 3. If no [Trace] on method, check for [Trace] on the class (TargetType)
+        if (effectiveTraceAttribute == null)
+        {
+            effectiveTraceAttribute = invocation.TargetType.GetCustomAttribute<TraceAttribute>();
+        }
+
+        if (effectiveTraceAttribute == null)
+        {
+            invocation.Proceed(); // No [Trace] attribute on method or class, proceed without tracing.
+            return;
+        }
+
+        string className = invocation.TargetType.Name;
+        string methodName;
+
+        if (methodTraceAttribute != null) 
+        {
+            // [Trace] is on the method, OperationName is correctly set by [CallerMemberName]
+            methodName = methodTraceAttribute.OperationName;
+        }
+        else
+        {
+            // [Trace] is on the class, so use the actual invoked method's name for the span's method part.
+            // effectiveTraceAttribute.OperationName (from class) is ignored here for the method part of the span name.
+            methodName = invocation.Method.Name;
+        }
+
+        string fullSpanName = $"{className}.{methodName}";
+
+        using var activity = _activitySource.StartActivity(fullSpanName, ActivityKind.Internal);
+
+        try
+        {
+            if (activity != null)
+            {
+                ParameterInfo[] parameters = invocation.Method.GetParameters();
+                for (int i = 0; i < invocation.Arguments.Length; i++)
+                {
+                    // Check if the parameter has [NoTrace]
+                    if (parameters[i].GetCustomAttribute<NoTraceAttribute>() == null)
+                    {
+                        var arg = invocation.Arguments[i];
+                        var paramName = parameters[i].Name;
+                        activity.SetTag($"param.{paramName}", arg?.ToString() ?? "null");
+                    }
+                }
+            }
+
+            invocation.Proceed();
+
+            if (invocation.ReturnValue is Task taskResult)
+            {
+                taskResult.ContinueWith(task =>
+                {
+                    if (task.Exception != null)
+                    {
+                        activity?.SetStatus(ActivityStatusCode.Error, task.Exception.InnerException?.ToString() ?? task.Exception.ToString());
+                    }
+                }, TaskScheduler.Default);
+            }
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.ToString());
+            throw;
+        }
+    }
+} 

--- a/W3ChampionsStatisticService/Services/Tracing/Interceptors/TracingInterceptor.cs
+++ b/W3ChampionsStatisticService/Services/Tracing/Interceptors/TracingInterceptor.cs
@@ -43,7 +43,7 @@ public class TracingInterceptor(ActivitySource activitySource) : IInterceptor
         string className = invocation.TargetType.Name;
         string methodName;
 
-        if (methodTraceAttribute != null) 
+        if (methodTraceAttribute != null)
         {
             // [Trace] is on the method, OperationName is correctly set by [CallerMemberName]
             methodName = methodTraceAttribute.OperationName;
@@ -95,4 +95,4 @@ public class TracingInterceptor(ActivitySource activitySource) : IInterceptor
             throw;
         }
     }
-} 
+}

--- a/W3ChampionsStatisticService/Services/Tracing/Sampling/CustomRootSampler.cs
+++ b/W3ChampionsStatisticService/Services/Tracing/Sampling/CustomRootSampler.cs
@@ -7,7 +7,6 @@ namespace W3ChampionsStatisticService.Services.Tracing.Sampling;
 public class CustomRootSampler : Sampler
 {
     private readonly TraceIdRatioBasedSampler _serverRatioSampler;
-    // No custom Description property needed here; base Sampler.Description can be used if necessary.
 
     public CustomRootSampler(double serverSamplingRatio)
     {
@@ -26,8 +25,8 @@ public class CustomRootSampler : Sampler
 
         return samplingParameters.Kind switch
         {
-            ActivityKind.Server => _serverRatioSampler.ShouldSample(samplingParameters),// Delegate to TraceIdRatioBasedSampler for SERVER spans when they are roots.
-            _ => new SamplingResult(SamplingDecision.RecordAndSample),// Always sample for other kinds (Internal, Client, Producer, Consumer) when they are roots.
+            ActivityKind.Server => _serverRatioSampler.ShouldSample(samplingParameters), // Delegate to TraceIdRatioBasedSampler for SERVER spans when they are roots.
+            _ => new SamplingResult(SamplingDecision.RecordAndSample), // Always sample for other kinds (Internal, Client, Producer, Consumer) when they are roots.
         };
     }
-} 
+}

--- a/W3ChampionsStatisticService/Services/Tracing/Sampling/CustomRootSampler.cs
+++ b/W3ChampionsStatisticService/Services/Tracing/Sampling/CustomRootSampler.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Trace;
+
+namespace W3ChampionsStatisticService.Services.Tracing.Sampling;
+
+public class CustomRootSampler : Sampler
+{
+    private readonly TraceIdRatioBasedSampler _serverRatioSampler;
+    // No custom Description property needed here; base Sampler.Description can be used if necessary.
+
+    public CustomRootSampler(double serverSamplingRatio)
+    {
+        if (serverSamplingRatio < 0.0 || serverSamplingRatio > 1.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(serverSamplingRatio), "Sampling ratio must be between 0.0 and 1.0");
+        }
+        // For root server spans, use TraceIdRatioBasedSampler
+        _serverRatioSampler = new TraceIdRatioBasedSampler(serverSamplingRatio);
+    }
+
+    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+    {
+        // This sampler is intended for use as the rootSampler within a ParentBasedSampler.
+        // Thus, it's typically only called when there is no parent context.
+
+        return samplingParameters.Kind switch
+        {
+            ActivityKind.Server => _serverRatioSampler.ShouldSample(samplingParameters),// Delegate to TraceIdRatioBasedSampler for SERVER spans when they are roots.
+            _ => new SamplingResult(SamplingDecision.RecordAndSample),// Always sample for other kinds (Internal, Client, Producer, Consumer) when they are roots.
+        };
+    }
+} 

--- a/W3ChampionsStatisticService/Services/Tracing/TracingService.cs
+++ b/W3ChampionsStatisticService/Services/Tracing/TracingService.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
+using W3ChampionsStatisticService.Services.Tracing;
 
 namespace W3ChampionsStatisticService.Services;
 

--- a/W3ChampionsStatisticService/Services/Tracing/TracingService.cs
+++ b/W3ChampionsStatisticService/Services/Tracing/TracingService.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Http;
+
+namespace W3ChampionsStatisticService.Services;
+
+public class TracingService(ActivitySource activitySource, IHttpContextAccessor httpContextAccessor)
+{
+    private readonly ActivitySource _activitySource = activitySource;
+    private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
+
+    // Optional: If you need to manually start an activity and manage its lifecycle elsewhere.
+    public Activity StartActivity(
+        object classInstance, 
+        IEnumerable<KeyValuePair<string, object>> tags = null,
+        [CallerMemberName] string methodName = "")
+    {
+        string fullSpanName = $"{classInstance.GetType().Name}.{methodName}";
+        var activity = _activitySource.StartActivity(fullSpanName, ActivityKind.Internal);
+        if (activity != null && tags != null)
+        {
+            foreach (var tag in tags)
+            {
+                activity.SetTag(tag.Key, tag.Value);
+            }
+        }
+        return activity;
+    }
+
+    public void ExecuteWithSpan(
+        object classInstance,
+        Action action,
+        IEnumerable<KeyValuePair<string, object>> tags = null,
+        bool forceNewRoot = false,
+        [CallerMemberName] string methodName = "")
+    {
+        ExecuteWithActivityInternal<object>(classInstance, () => { action(); return null; }, tags, forceNewRoot, methodName);
+    }
+
+    public T ExecuteWithSpan<T>(
+        object classInstance,
+        Func<T> func,
+        IEnumerable<KeyValuePair<string, object>> tags = null,
+        bool forceNewRoot = false,
+        [CallerMemberName] string methodName = "")
+    {
+        return ExecuteWithActivityInternal(classInstance, func, tags, forceNewRoot, methodName);
+    }
+
+    public async Task ExecuteWithSpanAsync(
+        object classInstance,
+        Func<Task> funcAsync,
+        IEnumerable<KeyValuePair<string, object>> tags = null,
+        bool forceNewRoot = false,
+        [CallerMemberName] string methodName = "")
+    {
+        await ExecuteWithActivityInternalAsync<object>(classInstance, async () => { await funcAsync(); return null; }, tags, forceNewRoot, methodName);
+    }
+
+    public async Task<T> ExecuteWithSpanAsync<T>(
+        object classInstance,
+        Func<Task<T>> funcAsync,
+        IEnumerable<KeyValuePair<string, object>> tags = null,
+        bool forceNewRoot = false,
+        [CallerMemberName] string methodName = "")
+    {
+        return await ExecuteWithActivityInternalAsync(classInstance, funcAsync, tags, forceNewRoot, methodName);
+    }
+
+    private void ApplyTags(Activity activity, IEnumerable<KeyValuePair<string, object>> tags)
+    {
+        if (activity != null && tags != null)
+        {
+            foreach (var tag in tags)
+            {
+                activity.SetTag(tag.Key, tag.Value);
+            }
+        }
+    }
+
+    private TResult ExecuteWithActivityInternal<TResult>(
+        object classInstance,
+        Func<TResult> operation,
+        IEnumerable<KeyValuePair<string, object>> tags,
+        bool forceNewRoot,
+        string methodName)
+    {
+        string fullSpanName = $"{classInstance.GetType().Name}.{methodName}";
+        Activity createdActivity;
+        if (forceNewRoot)
+        {
+            createdActivity = _activitySource.StartActivity(fullSpanName, ActivityKind.Internal, parentContext: default);
+        }
+        else
+        {
+            createdActivity = _activitySource.StartActivity(fullSpanName, ActivityKind.Internal);
+        }
+
+        using var activity = createdActivity;
+        ApplyTags(activity, tags);
+
+        try
+        {
+            return operation();
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.ToString());
+            throw;
+        }
+    }
+
+    private async Task<TResult> ExecuteWithActivityInternalAsync<TResult>(
+        object classInstance,
+        Func<Task<TResult>> operationAsync,
+        IEnumerable<KeyValuePair<string, object>> tags,
+        bool forceNewRoot,
+        string methodName)
+    {
+        string fullSpanName = $"{classInstance.GetType().Name}.{methodName}";
+        Activity createdActivity;
+        if (forceNewRoot)
+        {
+            createdActivity = _activitySource.StartActivity(fullSpanName, ActivityKind.Internal, parentContext: default);
+        }
+        else
+        {
+            createdActivity = _activitySource.StartActivity(fullSpanName, ActivityKind.Internal);
+        }
+
+        using var activity = createdActivity;
+        ApplyTags(activity, tags);
+
+        try
+        {
+            return await operationAsync();
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.ToString());
+            throw;
+        }
+    }
+
+    public async Task<T> ExecuteWithExternalParentTraceAsync<T>(string name, string traceParent, string traceState, Func<Task<T>> action, Dictionary<string, object> clientTags = null)
+    {
+        ActivityContext parentContext = default;
+        if (!string.IsNullOrEmpty(traceParent))
+        {
+            if (ActivityContext.TryParse(traceParent, traceState, out var context))
+            {
+                parentContext = context;
+            }
+        }
+
+        using var activity = _activitySource.StartActivity(name, ActivityKind.Server, parentContext);
+        ApplyServerSpanTags(activity, clientTags);
+
+        try
+        {
+            return await action();
+        }
+        catch (Exception ex)
+        {
+            RecordOtelError(activity, ex);
+            throw;
+        }
+    }
+
+    public async Task<T> ExecuteAsNewServerSpanAsync<T>(string name, Func<Task<T>> action, Dictionary<string, object> tags = null)
+    {
+        // If Activity.Current is null, this becomes a root. Otherwise, a child.
+        // The ActivityKind.Server indicates this span represents a server-side operation typically initiated by a remote request.
+        using var activity = _activitySource.StartActivity(name, ActivityKind.Server); // Parent context is implicitly Activity.Current
+        ApplyServerSpanTags(activity, tags);
+
+        try
+        {
+            return await action();
+        }
+        catch (Exception ex)
+        {
+            RecordOtelError(activity, ex);
+            throw;
+        }
+    }
+
+    private void ApplyServerSpanTags(Activity activity, IDictionary<string, object> tags)
+    {
+        if (activity != null && tags != null)
+        {
+            foreach (var tag in tags)
+            {
+                activity.SetTag(tag.Key, tag.Value);
+
+                // Add specific tags to baggage for propagation
+                if (tag.Key == BaggageToTagProcessor.SessionIdKey && tag.Value is string sessionId && !string.IsNullOrEmpty(sessionId))
+                {
+                    activity.AddBaggage(BaggageToTagProcessor.SessionIdKey, sessionId);
+                }
+                else if (tag.Key == BaggageToTagProcessor.BattleTagKey && tag.Value is string battleTag && !string.IsNullOrEmpty(battleTag))
+                {
+                    activity.AddBaggage(BaggageToTagProcessor.BattleTagKey, battleTag);
+                }
+            }
+        }
+    }
+
+    private void RecordOtelError(Activity activity, Exception ex)
+    {
+        if (activity == null) return;
+        activity.SetTag("otel.status_code", "ERROR");
+        activity.SetTag("otel.status_description", ex.Message);
+        activity.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection {
+            { "exception.type", ex.GetType().FullName },
+            { "exception.message", ex.Message },
+            { "exception.stacktrace", ex.StackTrace }
+        }));
+    }
+} 

--- a/W3ChampionsStatisticService/Services/Tracing/TracingService.cs
+++ b/W3ChampionsStatisticService/Services/Tracing/TracingService.cs
@@ -12,9 +12,8 @@ public class TracingService(ActivitySource activitySource, IHttpContextAccessor 
     private readonly ActivitySource _activitySource = activitySource;
     private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
 
-    // Optional: If you need to manually start an activity and manage its lifecycle elsewhere.
     public Activity StartActivity(
-        object classInstance, 
+        object classInstance,
         IEnumerable<KeyValuePair<string, object>> tags = null,
         [CallerMemberName] string methodName = "")
     {
@@ -220,4 +219,4 @@ public class TracingService(ActivitySource activitySource, IHttpContextAccessor 
             { "exception.stacktrace", ex.StackTrace }
         }));
     }
-} 
+}

--- a/W3ChampionsStatisticService/Services/Tracing/TracingServiceCollectionExtensions.cs
+++ b/W3ChampionsStatisticService/Services/Tracing/TracingServiceCollectionExtensions.cs
@@ -1,0 +1,92 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using W3ChampionsStatisticService.Services.Tracing.Sampling;
+using W3ChampionsStatisticService.Services.Interceptors;
+using W3ChampionsStatisticService.Filters;
+
+namespace W3ChampionsStatisticService.Services.Tracing;
+
+public static class TracingServiceCollectionExtensions
+{
+    const double TRACING_DEFAULT_SAMPLING_RATE = 0.01;
+    const string TRACING_FARO_SESSION_ID_HTTP_HEADER = "x-faro-session-id";
+    public static IServiceCollection AddW3CTracing(
+        this IServiceCollection services,
+        string serviceName,
+        string serviceVersion,
+        string otlpEndpoint,
+        string websiteBackendHubPath)
+    {
+        services.AddSingleton(new ActivitySource(serviceName));
+
+        services.AddOpenTelemetry()
+            .ConfigureResource(resource => resource
+                .AddService(serviceName, serviceVersion: serviceVersion))
+            .WithTracing(tracing => tracing
+                .SetSampler(new ParentBasedSampler(new CustomRootSampler(TRACING_DEFAULT_SAMPLING_RATE)))
+                .AddAspNetCoreInstrumentation(options =>
+                {
+                    options.Filter = context =>
+                    {
+                        if (HttpMethods.IsOptions(context.Request.Method))
+                        {
+                            return false;
+                        }
+                        if (context.Request.Path.Equals(websiteBackendHubPath))
+                        {
+                            return false;
+                        }
+                        return true;
+                    };
+                    options.EnrichWithHttpRequest = (activity, httpRequest) =>
+                    {
+                        if (httpRequest.Headers.TryGetValue(TRACING_FARO_SESSION_ID_HTTP_HEADER, out var faroSessionIdValues))
+                        {
+                            var faroSessionId = faroSessionIdValues.FirstOrDefault();
+                            if (!string.IsNullOrEmpty(faroSessionId))
+                            {
+                                activity.SetTag(BaggageToTagProcessor.SessionIdKey, faroSessionId);
+                                activity.AddBaggage(BaggageToTagProcessor.SessionIdKey, faroSessionId);
+                            }
+                        }
+                    };
+                })
+                .AddHttpClientInstrumentation(options =>
+                {
+                    options.FilterHttpRequestMessage = request =>
+                    {
+                        // Instance-metadata endpoint (AWS, etc)
+                        return request.RequestUri?.Host != "169.254.169.254";
+                    };
+                    options.EnrichWithHttpRequestMessage = (activity, httpRequestMessage) =>
+                    {
+                        var faroSessionIdFromBaggage = activity.GetBaggageItem(BaggageToTagProcessor.SessionIdKey);
+                        if (!string.IsNullOrEmpty(faroSessionIdFromBaggage))
+                        {
+                            httpRequestMessage.Headers.TryAddWithoutValidation(TRACING_FARO_SESSION_ID_HTTP_HEADER, faroSessionIdFromBaggage);
+                        }
+                    };
+                })
+                .AddSource("MongoDB.Driver.Core.Extensions.DiagnosticSources")
+                .AddSource(serviceName)
+                .AddProcessor(new BaggageToTagProcessor())
+                .AddOtlpExporter(options =>
+                {
+                    options.Endpoint = new Uri(otlpEndpoint);
+                })
+            );
+
+        // Add core tracing services
+        services.AddSingleton<TracingService>();
+        services.AddSingleton<TracingInterceptor>();
+        services.AddTransient<SignalRTraceContextFilter>();
+
+        return services;
+    }
+}

--- a/W3ChampionsStatisticService/Services/TrackingService.cs
+++ b/W3ChampionsStatisticService/Services/TrackingService.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using Microsoft.Extensions.Logging;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Services;
 
+[Trace]
 public class TrackingService(
     TelemetryClient telemetry,
     ILogger<TrackingService> logger)

--- a/W3ChampionsStatisticService/Tournaments/TournamentsController.cs
+++ b/W3ChampionsStatisticService/Tournaments/TournamentsController.cs
@@ -5,11 +5,13 @@ using W3C.Contracts.GameObjects;
 using W3ChampionsStatisticService.WebApi.ActionFilters;
 using W3ChampionsStatisticService.Ports;
 using W3C.Contracts.Admin.Permission;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Tournaments;
 
 [ApiController]
 [Route("api/tournaments")]
+[Trace]
 public class TournamentsController(
     MatchmakingServiceClient matchmakingServiceRepository,
     IPersonalSettingsRepository personalSettingsRepository

--- a/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
+++ b/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
@@ -3,10 +3,17 @@
     <PackageReference Include="Aliyun.OSS.SDK.NetCore" />
     <PackageReference Include="AspNetCore.Authentication.Basic" />
     <PackageReference Include="AWSSDK.S3" />
+    <PackageReference Include="Castle.Core" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Http" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" />
     <PackageReference Include="MongoDB.Driver" />
+    <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="prometheus-net.AspNetCore" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.AspNetCore" />

--- a/W3ChampionsStatisticService/W3ChampionsStats/DistinctPlayersPerDays/DistinctPlayersPerDayHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/DistinctPlayersPerDays/DistinctPlayersPerDayHandler.cs
@@ -3,9 +3,11 @@ using System.Threading.Tasks;
 using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.DistinctPlayersPerDays;
 
+[Trace]
 public class DistinctPlayersPerDayHandler(IW3StatsRepo w3Stats) : IReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;

--- a/W3ChampionsStatisticService/W3ChampionsStats/GameLengths/GameLengthStatHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/GameLengths/GameLengthStatHandler.cs
@@ -4,9 +4,12 @@ using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Contracts.Matchmaking;
+using W3C.Domain.Tracing;
+
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.GameLengths;
 
+[Trace]
 public class GameLengthStatHandler(IW3StatsRepo w3Stats) : IReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;

--- a/W3ChampionsStatisticService/W3ChampionsStats/GamesPerDays/GamesPerDayHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/GamesPerDays/GamesPerDayHandler.cs
@@ -5,9 +5,11 @@ using W3C.Contracts.Matchmaking;
 using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.GamesPerDays;
 
+[Trace]
 public class GamesPerDayHandler(IW3StatsRepo w3Stats) : IReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;

--- a/W3ChampionsStatisticService/W3ChampionsStats/HeroPlayedStats/HeroPlayedStatHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/HeroPlayedStats/HeroPlayedStatHandler.cs
@@ -4,9 +4,11 @@ using W3C.Domain.CommonValueObjects;
 using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.HeroPlayedStats;
 
+[Trace]
 public class HeroPlayedStatHandler(IW3StatsRepo w3Stats) : IReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;

--- a/W3ChampionsStatisticService/W3ChampionsStats/HeroWinrate/HeroStatsQueryHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/HeroWinrate/HeroStatsQueryHandler.cs
@@ -4,9 +4,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using W3C.Domain.CommonValueObjects;
 using W3ChampionsStatisticService.Ports;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.HeroWinrate;
 
+[Trace]
 public class HeroStatsQueryHandler(IW3StatsRepo w3StatsRepo)
 {
     private readonly IW3StatsRepo _w3StatsRepo = w3StatsRepo;
@@ -50,6 +52,7 @@ public class HeroStatsQueryHandler(IW3StatsRepo w3StatsRepo)
         return CombineWinrates(stats, s => s.HeroCombo == $"{opFirst}_{opSecond}_{opThird}");
     }
 
+    [NoTrace]
     private WinLoss CombineWinrates(
         List<OverallHeroWinRatePerHero> stats,
         Func<HeroWinRate, bool> func)

--- a/W3ChampionsStatisticService/W3ChampionsStats/HeroWinrate/HourOfPlayModelHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/HeroWinrate/HourOfPlayModelHandler.cs
@@ -6,9 +6,11 @@ using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Contracts.Matchmaking;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.HeroWinrate;
 
+[Trace]
 public class OverallHeroWinRatePerHeroModelHandler(IW3StatsRepo w3Stats) : IReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;

--- a/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeason.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeason.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text.Json.Serialization;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.MapsPerSeasons;
 
@@ -23,6 +24,7 @@ public class MapsPerSeason : IIdentifiable
 
     public int Season { get; set; }
 
+    [Trace]
     public void Count(string map, GameMode gameMode)
     {
         var matchOnMapOverall = MatchesOnMapPerModes.SingleOrDefault(m => m.GameMode == GameMode.Undefined);

--- a/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonHandler.cs
@@ -3,9 +3,10 @@ using W3ChampionsStatisticService.Matches;
 using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
-
+using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.W3ChampionsStats.MapsPerSeasons;
 
+[Trace]
 public class MapsPerSeasonHandler(IW3StatsRepo w3Stats) : IReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;

--- a/W3ChampionsStatisticService/W3ChampionsStats/MatchupLengths/MatchupLengthsHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MatchupLengths/MatchupLengthsHandler.cs
@@ -5,9 +5,11 @@ using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Contracts.Matchmaking;
 using W3C.Contracts.GameObjects;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.MatchupLengths;
 
+[Trace]
 public class MatchupLengthsHandler(IW3StatsRepo w3Stats) : IReadModelHandler
 {
     private readonly IW3StatsRepo _w3StatsRepo = w3Stats;

--- a/W3ChampionsStatisticService/W3ChampionsStats/MmrDistribution/MmrDistributionHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MmrDistribution/MmrDistributionHandler.cs
@@ -4,9 +4,11 @@ using System.Threading.Tasks;
 using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.Ports;
 using System;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.MmrDistribution;
 
+[Trace]
 public class MmrDistributionHandler(IPlayerRepository playerRepository)
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;
@@ -22,6 +24,7 @@ public class MmrDistributionHandler(IPlayerRepository playerRepository)
         return new MmrStats(grouped, orderedMMrs);
     }
 
+    [NoTrace]
     private static IEnumerable<int> Ranges(int max, int min, int steps)
     {
         while (max > min)
@@ -58,6 +61,7 @@ public class MmrStats
         StandardDeviation = CalculateStandardDeviation(mmrs);
     }
 
+    [Trace]
     private static double CalculateStandardDeviation(List<int> values)
     {
         if (!values.Any())

--- a/W3ChampionsStatisticService/W3ChampionsStats/OverallRaceAndWinStats/OverallRaceAndWinStatHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/OverallRaceAndWinStats/OverallRaceAndWinStatHandler.cs
@@ -7,9 +7,11 @@ using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Contracts.Matchmaking;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.OverallRaceAndWinStats;
 
+[Trace]
 public class OverallRaceAndWinStatHandler(
     IW3StatsRepo w3Stats,
     IPatchRepository patchRepository
@@ -69,6 +71,7 @@ public class OverallRaceAndWinStatHandler(
         }
     }
 
+    [NoTrace]
     private int ToMaxMMr(double averageMmr)
     {
         if (averageMmr > 2200) return 2200;

--- a/W3ChampionsStatisticService/W3ChampionsStats/PopularHours/PopularHoursStat.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/PopularHours/PopularHoursStat.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.PopularHours;
 
+[Trace]
 public class PopularHoursStat : IIdentifiable
 {
     public string Id => GameMode.ToString();

--- a/W3ChampionsStatisticService/W3ChampionsStats/PopularHours/PopularHoursStatHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/PopularHours/PopularHoursStatHandler.cs
@@ -3,9 +3,11 @@ using System.Threading.Tasks;
 using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.PopularHours;
 
+[Trace]
 public class PopularHoursStatHandler(IW3StatsRepo w3Stats) : IReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;

--- a/W3ChampionsStatisticService/W3ChampionsStats/W3CStatsController.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/W3CStatsController.cs
@@ -9,11 +9,12 @@ using W3ChampionsStatisticService.W3ChampionsStats.MmrDistribution;
 using System.Linq;
 using W3C.Contracts.GameObjects;
 using System.Net.Http;
-
+using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.W3ChampionsStats;
 
 [ApiController]
 [Route("api/w3c-stats")]
+[Trace]
 public class W3CStatsController(
     IW3StatsRepo w3StatsRepo,
     HeroStatsQueryHandler heroStatsQueryHandler,

--- a/W3ChampionsStatisticService/W3ChampionsStats/W3StatsRepo.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/W3StatsRepo.cs
@@ -15,9 +15,11 @@ using W3ChampionsStatisticService.W3ChampionsStats.PopularHours;
 using W3ChampionsStatisticService.W3ChampionsStats.MapsPerSeasons;
 using W3ChampionsStatisticService.W3ChampionsStats.OverallRaceAndWinStats;
 using W3ChampionsStatisticService.W3ChampionsStats.MatchupLengths;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats;
 
+[Trace]
 public class W3StatsRepo(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IW3StatsRepo
 {
     public Task<List<OverallRaceAndWinStat>> LoadRaceVsRaceStats()

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/BearerCheckIfBattleTagBelongsToAuthFilter.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/BearerCheckIfBattleTagBelongsToAuthFilter.cs
@@ -7,13 +7,14 @@ using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
 using W3ChampionsStatisticService.WebApi.ExceptionFilters;
-
+using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.WebApi.ActionFilters;
 
 public class BearerCheckIfBattleTagBelongsToAuthFilter(IW3CAuthenticationService authService) : IAsyncActionFilter
 {
     private readonly IW3CAuthenticationService _authService = authService;
 
+    [Trace]
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
         context.RouteData.Values.TryGetValue("battleTag", out var battleTag);

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/BearerHasPermissionFilter.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/BearerHasPermissionFilter.cs
@@ -10,7 +10,7 @@ using Microsoft.Net.Http.Headers;
 using W3ChampionsStatisticService.WebApi.ExceptionFilters;
 using W3C.Contracts.Admin.Permission;
 using Serilog;
-
+using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.WebApi.ActionFilters;
 
 [AttributeUsage(AttributeTargets.Method)]
@@ -18,6 +18,7 @@ public class BearerHasPermissionFilter : Attribute, IAsyncActionFilter
 {
     public EPermission Permission { get; set; }
 
+    [Trace]
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
         W3CAuthenticationService authService = new();

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/CheckIfBattleTagIsAdminFilter.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/CheckIfBattleTagIsAdminFilter.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
 using W3ChampionsStatisticService.WebApi.ExceptionFilters;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.WebApi.ActionFilters;
 
@@ -15,6 +16,7 @@ public class CheckIfBattleTagIsAdminFilter(IW3CAuthenticationService authService
 {
     private readonly IW3CAuthenticationService _authService = authService;
 
+    [Trace]
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
         try

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/InjectActingPlayerFromAuthCodeFilter.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/InjectActingPlayerFromAuthCodeFilter.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using W3ChampionsStatisticService.WebApi.ExceptionFilters;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.WebApi.ActionFilters;
 
@@ -14,6 +15,7 @@ public class InjectActingPlayerFromAuthCodeFilter(IW3CAuthenticationService auth
 {
     private readonly IW3CAuthenticationService _authService = authService;
 
+    [Trace]
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
         try

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/InjectAuthTokenFilter.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/InjectAuthTokenFilter.cs
@@ -5,11 +5,13 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using W3ChampionsStatisticService.WebApi.ExceptionFilters;
+using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.WebApi.ActionFilters;
 
 public class InjectAuthTokenFilter : IAsyncActionFilter
 {
+    [Trace]
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
         var token = GetToken(context.HttpContext.Request.Headers[HeaderNames.Authorization]);

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/W3CAuthenticationService.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/W3CAuthenticationService.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 using Microsoft.IdentityModel.Tokens;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace W3ChampionsStatisticService.WebApi.ActionFilters;
 
@@ -51,6 +52,12 @@ public class W3CUserAuthenticationDto
             .Where(claim => claim.Type == "permissions")
             .Select(x => x.Value)
             .ToList();
+
+        if (!string.IsNullOrEmpty(btag))
+        {
+            Activity.Current?.AddBaggage(BaggageToTagProcessor.BattleTagKey, btag);
+            Activity.Current?.SetTag(BaggageToTagProcessor.BattleTagKey, btag);
+        }
 
         return new W3CUserAuthenticationDto
         {

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/W3CAuthenticationService.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/W3CAuthenticationService.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Microsoft.IdentityModel.Tokens;
 using System.Collections.Generic;
 using System.Diagnostics;
+using W3ChampionsStatisticService.Services.Tracing;
 
 namespace W3ChampionsStatisticService.WebApi.ActionFilters;
 

--- a/WC3ChampionsStatisticService.UnitTests/Clans/ClanTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Clans/ClanTests.cs
@@ -11,7 +11,6 @@ using W3ChampionsStatisticService.Ladder;
 using W3ChampionsStatisticService.PlayerProfiles;
 using W3ChampionsStatisticService.Ports;
 using W3C.Contracts.Matchmaking;
-using W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 
 namespace WC3ChampionsStatisticService.Tests.Clans;
 

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
@@ -2,7 +2,6 @@ using System.Threading.Tasks;
 using MongoDB.Bson;
 using NUnit.Framework;
 using W3ChampionsStatisticService.Matches;
-using W3C.Domain.CommonValueObjects;
 using W3C.Contracts.GameObjects;
 
 namespace WC3ChampionsStatisticService.Tests.Matchups;

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupEventRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupEventRepoTests.cs
@@ -3,7 +3,6 @@ using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
 using W3C.Domain.Repositories;
-using W3ChampionsStatisticService.Matches;
 
 namespace WC3ChampionsStatisticService.Tests.Matchups;
 

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupLengthsTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupLengthsTest.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 using NUnit.Framework;
 using W3C.Contracts.GameObjects;
-using W3ChampionsStatisticService.PlayerProfiles;
 using W3ChampionsStatisticService.W3ChampionsStats;
 using W3ChampionsStatisticService.W3ChampionsStats.MatchupLengths;
 

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -2,12 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using AutoFixture;
-using MongoDB.Bson;
 using NUnit.Framework;
 using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.Matches;
-using W3C.Domain.MatchmakingService;
 using W3C.Contracts.GameObjects;
 using W3ChampionsStatisticService.Ladder;
 

--- a/WC3ChampionsStatisticService.UnitTests/PersonalSettings/PersonalSettingsTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PersonalSettings/PersonalSettingsTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -7,7 +6,6 @@ using W3C.Contracts.GameObjects;
 using W3C.Domain.CommonValueObjects;
 using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.PlayerProfiles;
-using W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 using W3ChampionsStatisticService.Rewards.Portraits;
 
 namespace WC3ChampionsStatisticService.Tests.PersonalSettings;

--- a/WC3ChampionsStatisticService.UnitTests/Player/PlayerGameLengthStatsTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Player/PlayerGameLengthStatsTests.cs
@@ -1,8 +1,6 @@
 using System.Threading.Tasks;
 using NUnit.Framework;
 using W3C.Contracts.GameObjects;
-using W3C.Domain.MatchmakingService;
-using W3ChampionsStatisticService.W3ChampionsStats;
 using W3ChampionsStatisticService.PlayerStats.GameLengthForPlayerStatistics;
 using W3ChampionsStatisticService.PlayerProfiles;
 

--- a/WC3ChampionsStatisticService.UnitTests/Player/PlayerOverviewTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Player/PlayerOverviewTests.cs
@@ -9,7 +9,6 @@ using W3ChampionsStatisticService.Ladder;
 using W3ChampionsStatisticService.PlayerProfiles;
 using W3ChampionsStatisticService.W3ChampionsStats.MmrDistribution;
 using W3C.Contracts.Matchmaking;
-using W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 
 namespace WC3ChampionsStatisticService.Tests.Player;
 

--- a/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
@@ -12,7 +12,6 @@ using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.PlayerProfiles;
 using W3ChampionsStatisticService.Ports;
 using W3C.Contracts.Matchmaking;
-using W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 
 namespace WC3ChampionsStatisticService.Tests.Ranks;
 

--- a/WC3ChampionsStatisticService.UnitTests/Replay/ReplayTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Replay/ReplayTests.cs
@@ -3,7 +3,6 @@ using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using W3C.Contracts.Replay;
-using W3ChampionsStatisticService.WebApi.ActionFilters;
 
 namespace WC3ChampionsStatisticService.Tests.Replay;
 

--- a/WC3ChampionsStatisticService.UnitTests/Statistics/PlayerStatsTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Statistics/PlayerStatsTests.cs
@@ -8,7 +8,6 @@ using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ladder;
 using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.PlayerProfiles;
-using W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 using W3ChampionsStatisticService.PlayerStats;
 using W3ChampionsStatisticService.PlayerStats.HeroStats;
 using W3ChampionsStatisticService.PlayerStats.RaceOnMapVersusRaceStats;


### PR DESCRIPTION
This PR introduces tracing to website-backend. HTTP as well as websocket calls are instrumented and will be traced. In case a tracing context is already present, it will be inherited and hence allow us to do cross-service traces such as this example:
![image](https://github.com/user-attachments/assets/91e11e81-03bb-4a4d-aca0-3679661cc01a)

We are also propagating the Faro Session ID in order to correlate spans within a session. 

It was necessary to update the dependencies in order to properly instrument everything. I had to do some slight modifications (S3 and Telemetry), but they should all be good from what I can tell.

I did not update nunit to version 4 because they have made some breaking changes that would've required rewriting around 600 assertions. 