### PR TITLE
Add tracing placeholder for zero-arg socket methods

### DIFF
--- a/W3ChampionsStatisticService/Filters/SignalRTraceContextFilter.cs
+++ b/W3ChampionsStatisticService/Filters/SignalRTraceContextFilter.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using W3ChampionsStatisticService.Services;
 using W3ChampionsStatisticService.Services.Tracing;
+using Serilog;
 
 namespace W3ChampionsStatisticService.Filters;
 
@@ -19,6 +21,18 @@ public class SignalRTraceContextFilter(TracingService tracingService) : IHubFilt
         public string FaroSessionId { get; set; }
     }
 
+    /// <summary>
+    /// This class merely serves as placeholder. Due to the way we are tracing function calls, every SignalR invocations needs to have at least one argument.
+    /// Hence, this placeholder here is used to ensure that every function has at least one argument.
+    /// Please make sure that all websocket handlers have at least one argument or this placeholder here added.
+    /// </summary>
+    public class PreventZeroArgumentHandler
+    {
+        public PreventZeroArgumentHandler()
+        {
+        }
+    }
+
     public async ValueTask<object> InvokeMethodAsync(
         HubInvocationContext invocationContext,
         Func<HubInvocationContext, ValueTask<object>> next)
@@ -26,6 +40,7 @@ public class SignalRTraceContextFilter(TracingService tracingService) : IHubFilt
         string traceParent = null;
         string traceState = null;
         Dictionary<string, object> clientTags = null;
+        HubInvocationContext contextToPass = invocationContext; // By default, pass the original context
 
         // Extract BattleTag if user is authenticated
         string battleTag = null;
@@ -39,31 +54,49 @@ public class SignalRTraceContextFilter(TracingService tracingService) : IHubFilt
 
         if (invocationContext.HubMethodArguments.Count > 0)
         {
-            var arg = invocationContext.HubMethodArguments[^1]; // We always pass the tracing context as the last argument
-            if (arg is JsonElement jsonElement)
+            var lastArg = invocationContext.HubMethodArguments[^1];  // We always pass the tracing context as the last argument
+            TracingContextPayload parsedPayload = null;
+
+            if (lastArg is JsonElement jsonElement)
             {
                 try
                 {
-                    // Check this for backwards compatibility
-                    if (jsonElement.TryGetProperty("tracingContext", out var tracingContextElement))
-                    {
-                        var tracingContextPayload = tracingContextElement.Deserialize<TracingContextPayload>();
-                        if (tracingContextPayload != null)
-                        {
-                            traceParent = tracingContextPayload.TraceParent;
-                            traceState = tracingContextPayload.TraceState;
-                            if (!string.IsNullOrEmpty(tracingContextPayload.FaroSessionId))
-                            {
-                                clientTags ??= [];
-                                clientTags[BaggageToTagProcessor.SessionIdKey] = tracingContextPayload.FaroSessionId;
-                            }
-                        }
-                    }
+                    // Attempt to deserialize the last argument directly as TracingContextPayload
+                    parsedPayload = jsonElement.Deserialize<TracingContextPayload>();
                 }
-                catch (JsonException)
+                catch (JsonException ex)
                 {
-                    // Argument was not the expected JSON structure, ignore and continue.
+                    // Log if parsing fails, but don't break the call if it wasn't a tracing context.
+                    // This could happen if the last argument is genuinely a JsonElement for the method itself.
+                    Log.Debug(ex, "[SignalRTraceContextFilter] JSON error deserializing last argument as TracingContextPayload. It might not be a tracing context.");
                 }
+            }
+
+            // Check if we successfully parsed a payload AND it looks like a valid trace context (TraceParent is key)
+            if (parsedPayload != null && !string.IsNullOrEmpty(parsedPayload.TraceParent))
+            {
+                traceParent = parsedPayload.TraceParent;
+                traceState = parsedPayload.TraceState;
+                if (!string.IsNullOrEmpty(parsedPayload.FaroSessionId))
+                {
+                    clientTags ??= [];
+                    clientTags[BaggageToTagProcessor.SessionIdKey] = parsedPayload.FaroSessionId;
+                }
+
+                // Create a new invocation context with the tracing payload argument removed
+                var originalArguments = invocationContext.HubMethodArguments.ToList();
+                var argumentsForNext = originalArguments.Take(originalArguments.Count - 1).ToArray();
+                if (argumentsForNext.Length == 0)
+                {
+                    // If the original method actually had no arguments, inject our placeholder argument.
+                    argumentsForNext = [new PreventZeroArgumentHandler()];
+                }
+                contextToPass = new HubInvocationContext(
+                    invocationContext.Context,
+                    invocationContext.ServiceProvider,
+                    invocationContext.Hub,
+                    invocationContext.HubMethod,
+                    argumentsForNext);
             }
         }
 
@@ -75,7 +108,7 @@ public class SignalRTraceContextFilter(TracingService tracingService) : IHubFilt
                 operationName,
                 traceParent,
                 traceState,
-                async () => await next(invocationContext),
+                async () => await next(contextToPass),
                 clientTags);
         }
         else
@@ -84,7 +117,7 @@ public class SignalRTraceContextFilter(TracingService tracingService) : IHubFilt
             // Create a new server span. It will be a root span if Activity.Current is null,
             // or a child of Activity.Current if it exists (e.g., from OnConnectedAsync).
             // clientTags will be null here if no tracingContext was found in args.
-            return await _tracingService.ExecuteAsNewServerSpanAsync(operationName, async () => await next(invocationContext), clientTags);
+            return await _tracingService.ExecuteAsNewServerSpanAsync(operationName, async () => await next(contextToPass), clientTags);
         }
     }
 }


### PR DESCRIPTION
The way we pass the tracing context requires that every invoked socket handler has at least one arguments.

SignalR allows to pass an arbitrary number of arguments, even if unmatched, which we're using to transfer the tracing context. Unfortunately, this method does not work for handlers with zero arguments as SignalR has some sort of optimization in place that intercepts the call too early. Hence, I've introduced this placeholder concept.

From the caller side, nothing is going to actually change. I've also added a static check that ensures all handlers have at least one argument so that we don't have the error during invocation but instead during boot.