### PR TITLE
Obfuscate ping in ffa

### DIFF
--- a/W3ChampionsStatisticService/Matches/PlayersObfuscator.cs
+++ b/W3ChampionsStatisticService/Matches/PlayersObfuscator.cs
@@ -25,6 +25,12 @@ public static class PlayersObfuscator
                     player.Twitch = null;
                 }
             }
+
+            foreach (var serverInfo in ffaMatch.ServerInfo.PlayerServerInfos)
+            {
+                serverInfo.CurrentPing = 0;
+                serverInfo.AveragePing = 0;
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, you can infer the player via the pings. This PR adds ping anonymization to ongoing matches.