### PR TITLE
Make MatchReadModelHandler generic

### DIFF
--- a/W3C.Domain/Repositories/Contracts/IMatchEventRepository.cs
+++ b/W3C.Domain/Repositories/Contracts/IMatchEventRepository.cs
@@ -7,7 +7,7 @@ namespace W3C.Domain.Repositories;
 
 public interface IMatchEventRepository
 {
-    Task<List<MatchFinishedEvent>> Load(string lastObjectId, int pageSize = 100);
+    Task<List<T>> Load<T>(string lastObjectId, int pageSize = 100) where T : MatchmakingEvent;
     Task<List<MatchStartedEvent>> LoadStartedMatches();
     Task<bool> InsertIfNotExisting(MatchFinishedEvent matchFinishedEvent, int i = 0);
     Task<List<RankingChangedEvent>> CheckoutForRead();

--- a/W3C.Domain/Repositories/MatchEventRepository.cs
+++ b/W3C.Domain/Repositories/MatchEventRepository.cs
@@ -10,11 +10,11 @@ namespace W3C.Domain.Repositories;
 [Trace]
 public class MatchEventRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IMatchEventRepository
 {
-    public async Task<List<MatchFinishedEvent>> Load(string lastObjectId = null, int pageSize = 100)
+    public async Task<List<T>> Load<T>(string lastObjectId, int pageSize = 100) where T : MatchmakingEvent
     {
         lastObjectId ??= ObjectId.Empty.ToString();
 
-        var mongoCollection = CreateCollection<MatchFinishedEvent>();
+        var mongoCollection = CreateCollection<T>();
 
         var events = await mongoCollection.Find(m => m.Id > ObjectId.Parse(lastObjectId))
             .SortBy(s => s.Id)

--- a/W3ChampionsStatisticService/Ladder/PlayOverviewHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/PlayOverviewHandler.cs
@@ -12,7 +12,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Ladder;
 
 [Trace]
-public class PlayOverviewHandler(IPlayerRepository playerRepository) : IReadModelHandler
+public class PlayOverviewHandler(IPlayerRepository playerRepository) : IMatchFinishedReadModelHandler
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;
 

--- a/W3ChampionsStatisticService/Ladder/PlayerWinrateHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/PlayerWinrateHandler.cs
@@ -8,7 +8,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Ladder;
 
 [Trace]
-public class PlayerWinrateHandler(IPlayerRepository playerRepository) : IReadModelHandler
+public class PlayerWinrateHandler(IPlayerRepository playerRepository) : IMatchFinishedReadModelHandler
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;
 

--- a/W3ChampionsStatisticService/Matches/MatchReadModelHandler.cs
+++ b/W3ChampionsStatisticService/Matches/MatchReadModelHandler.cs
@@ -9,7 +9,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Matches;
 
 [Trace]
-public class MatchReadModelHandler(IMatchRepository matchRepository) : IReadModelHandler
+public class MatchReadModelHandler(IMatchRepository matchRepository) : IMatchFinishedReadModelHandler
 {
     private readonly IMatchRepository _matchRepository = matchRepository;
 

--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGatewayHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGatewayHandler.cs
@@ -12,7 +12,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
 
 [Trace]
-public class PlayerGameModeStatPerGatewayHandler(IPlayerRepository playerRepository) : IReadModelHandler
+public class PlayerGameModeStatPerGatewayHandler(IPlayerRepository playerRepository) : IMatchFinishedReadModelHandler
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;
 

--- a/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrRpTimelineHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrRpTimelineHandler.cs
@@ -8,7 +8,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 
 [Trace]
-public class PlayerMmrRpTimelineHandler(IPlayerRepository playerRepository) : IReadModelHandler
+public class PlayerMmrRpTimelineHandler(IPlayerRepository playerRepository) : IMatchFinishedReadModelHandler
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;
 

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayerOverallStatsHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayerOverallStatsHandler.cs
@@ -10,7 +10,7 @@ namespace W3ChampionsStatisticService.PlayerProfiles;
 [Trace]
 public class PlayerOverallStatsHandler(
     IPlayerRepository playerRepository,
-    IPersonalSettingsRepository personalSettingsRepository) : IReadModelHandler
+    IPersonalSettingsRepository personalSettingsRepository) : IMatchFinishedReadModelHandler
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;
     private readonly IPersonalSettingsRepository _personalSettingsRepository = personalSettingsRepository;

--- a/W3ChampionsStatisticService/PlayerProfiles/RaceStats/PlayerRaceStatPerGatewayHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/RaceStats/PlayerRaceStatPerGatewayHandler.cs
@@ -7,7 +7,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.PlayerProfiles.RaceStats;
 
 [Trace]
-public class PlayerRaceStatPerGatewayHandler(IPlayerRepository playerRepository) : IReadModelHandler
+public class PlayerRaceStatPerGatewayHandler(IPlayerRepository playerRepository) : IMatchFinishedReadModelHandler
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;
 

--- a/W3ChampionsStatisticService/PlayerStats/GameLengthForPlayerStatistics/GameLengthForPlayerStatisticsHandler.cs
+++ b/W3ChampionsStatisticService/PlayerStats/GameLengthForPlayerStatistics/GameLengthForPlayerStatisticsHandler.cs
@@ -9,7 +9,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.PlayerStats.GameLengthForPlayerStatistics;
 
 [Trace]
-public class GameLengthForPlayerStatisticsHandler(IPlayerRepository playerRepo) : IReadModelHandler
+public class GameLengthForPlayerStatisticsHandler(IPlayerRepository playerRepo) : IMatchFinishedReadModelHandler
 {
     private readonly IPlayerRepository _playerRepo = playerRepo;
 

--- a/W3ChampionsStatisticService/PlayerStats/HeroStats/PlayerHeroStatsHandler.cs
+++ b/W3ChampionsStatisticService/PlayerStats/HeroStats/PlayerHeroStatsHandler.cs
@@ -9,7 +9,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.PlayerStats.HeroStats;
 
 [Trace]
-public class PlayerHeroStatsHandler(IPlayerStatsRepository playerRepository) : IReadModelHandler
+public class PlayerHeroStatsHandler(IPlayerStatsRepository playerRepository) : IMatchFinishedReadModelHandler
 {
     private readonly IPlayerStatsRepository _playerRepository = playerRepository;
 

--- a/W3ChampionsStatisticService/PlayerStats/RaceOnMapVersusRaceStats/PlayerRaceOnMapVersusRaceRatioHandler.cs
+++ b/W3ChampionsStatisticService/PlayerStats/RaceOnMapVersusRaceStats/PlayerRaceOnMapVersusRaceRatioHandler.cs
@@ -14,7 +14,7 @@ namespace W3ChampionsStatisticService.PlayerStats.RaceOnMapVersusRaceStats;
 public class PlayerRaceOnMapVersusRaceRatioHandler(
     IPlayerStatsRepository playerRepository,
     IPatchRepository patchRepository
-        ) : IReadModelHandler
+        ) : IMatchFinishedReadModelHandler
 {
     private readonly IPlayerStatsRepository _playerRepository = playerRepository;
     private readonly IPatchRepository _patchRepository = patchRepository;

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -204,33 +204,33 @@ string startHandlers = Environment.GetEnvironmentVariable("START_HANDLERS");
 if (startHandlers == "true")
 {
     // PlayerProfile
-    builder.Services.AddReadModelService<PlayerOverallStatsHandler>();
-    builder.Services.AddReadModelService<PlayOverviewHandler>();
-    builder.Services.AddReadModelService<PlayerWinrateHandler>();
+    builder.Services.AddMatchFinishedReadModelService<PlayerOverallStatsHandler>();
+    builder.Services.AddMatchFinishedReadModelService<PlayOverviewHandler>();
+    builder.Services.AddMatchFinishedReadModelService<PlayerWinrateHandler>();
 
     // PlayerStats
-    builder.Services.AddReadModelService<PlayerRaceOnMapVersusRaceRatioHandler>();
-    builder.Services.AddReadModelService<PlayerHeroStatsHandler>();
-    builder.Services.AddReadModelService<PlayerGameModeStatPerGatewayHandler>();
-    builder.Services.AddReadModelService<PlayerRaceStatPerGatewayHandler>();
-    builder.Services.AddReadModelService<PlayerMmrRpTimelineHandler>();
-    builder.Services.AddReadModelService<GameLengthForPlayerStatisticsHandler>();
+    builder.Services.AddMatchFinishedReadModelService<PlayerRaceOnMapVersusRaceRatioHandler>();
+    builder.Services.AddMatchFinishedReadModelService<PlayerHeroStatsHandler>();
+    builder.Services.AddMatchFinishedReadModelService<PlayerGameModeStatPerGatewayHandler>();
+    builder.Services.AddMatchFinishedReadModelService<PlayerRaceStatPerGatewayHandler>();
+    builder.Services.AddMatchFinishedReadModelService<PlayerMmrRpTimelineHandler>();
+    builder.Services.AddMatchFinishedReadModelService<GameLengthForPlayerStatisticsHandler>();
 
     // General Stats
-    builder.Services.AddReadModelService<GamesPerDayHandler>();
-    builder.Services.AddReadModelService<GameLengthStatHandler>();
-    builder.Services.AddReadModelService<MatchupLengthsHandler>();
-    builder.Services.AddReadModelService<DistinctPlayersPerDayHandler>();
-    builder.Services.AddReadModelService<PopularHoursStatHandler>();
-    builder.Services.AddReadModelService<HeroPlayedStatHandler>();
-    builder.Services.AddReadModelService<MapsPerSeasonHandler>();
+    builder.Services.AddMatchFinishedReadModelService<GamesPerDayHandler>();
+    builder.Services.AddMatchFinishedReadModelService<GameLengthStatHandler>();
+    builder.Services.AddMatchFinishedReadModelService<MatchupLengthsHandler>();
+    builder.Services.AddMatchFinishedReadModelService<DistinctPlayersPerDayHandler>();
+    builder.Services.AddMatchFinishedReadModelService<PopularHoursStatHandler>();
+    builder.Services.AddMatchFinishedReadModelService<HeroPlayedStatHandler>();
+    builder.Services.AddMatchFinishedReadModelService<MapsPerSeasonHandler>();
 
     // Game Balance Stats
-    builder.Services.AddReadModelService<OverallRaceAndWinStatHandler>();
-    builder.Services.AddReadModelService<OverallHeroWinRatePerHeroModelHandler>();
+    builder.Services.AddMatchFinishedReadModelService<OverallRaceAndWinStatHandler>();
+    builder.Services.AddMatchFinishedReadModelService<OverallHeroWinRatePerHeroModelHandler>();
 
     // Ladder Syncs
-    builder.Services.AddReadModelService<MatchReadModelHandler>();
+    builder.Services.AddMatchFinishedReadModelService<MatchReadModelHandler>();
 
     // On going matches
     builder.Services.AddUnversionedReadModelService<OngoingMatchesHandler>();

--- a/W3ChampionsStatisticService/ReadModelBase/IReadModelHandler.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/IReadModelHandler.cs
@@ -3,7 +3,7 @@ using W3C.Domain.MatchmakingService;
 
 namespace W3ChampionsStatisticService.ReadModelBase;
 
-public interface IReadModelHandler
+public interface IMatchFinishedReadModelHandler
 {
     Task Update(MatchFinishedEvent nextEvent);
 }

--- a/W3ChampionsStatisticService/ReadModelBase/MatchFinishedReadModelHandler.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/MatchFinishedReadModelHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using W3C.Domain.MatchmakingService;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.Services;
@@ -9,11 +10,11 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.ReadModelBase;
 
 [Trace]
-public class ReadModelHandler<T>(
+public class MatchFinishedReadModelHandler<T>(
     IMatchEventRepository eventRepository,
     IVersionRepository versionRepository,
     T innerHandler,
-    TrackingService trackingService = null) : IAsyncUpdatable where T : IReadModelHandler
+    TrackingService trackingService = null) : IAsyncUpdatable where T : IMatchFinishedReadModelHandler
 {
     private readonly IMatchEventRepository _eventRepository = eventRepository;
     private readonly IVersionRepository _versionRepository = versionRepository;
@@ -23,7 +24,7 @@ public class ReadModelHandler<T>(
     public async Task Update()
     {
         var lastVersion = await _versionRepository.GetLastVersion<T>();
-        var nextEvents = await _eventRepository.Load(lastVersion.Version, 1000);
+        var nextEvents = await _eventRepository.Load<MatchFinishedEvent>(lastVersion.Version, 1000);
 
         while (nextEvents.Any())
         {
@@ -54,7 +55,7 @@ public class ReadModelHandler<T>(
                 }
             }
 
-            nextEvents = await _eventRepository.Load(nextEvents.Last().Id.ToString());
+            nextEvents = await _eventRepository.Load<MatchFinishedEvent>(nextEvents.Last().Id.ToString());
         }
     }
 }

--- a/W3ChampionsStatisticService/ReadModelBase/ReadModelExtensions.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/ReadModelExtensions.cs
@@ -5,11 +5,11 @@ namespace W3ChampionsStatisticService.ReadModelBase;
 
 public static class ReadModelExtensions
 {
-    public static IServiceCollection AddReadModelService<T>(this IServiceCollection services) where T : class, IReadModelHandler
+    public static IServiceCollection AddMatchFinishedReadModelService<T>(this IServiceCollection services) where T : class, IMatchFinishedReadModelHandler
     {
         services.AddTransient<T>();
-        services.AddTransient<ReadModelHandler<T>>();
-        services.AddSingleton<IHostedService, AsyncServiceBase<ReadModelHandler<T>>>();
+        services.AddTransient<MatchFinishedReadModelHandler<T>>();
+        services.AddSingleton<IHostedService, AsyncServiceBase<MatchFinishedReadModelHandler<T>>>();
         return services;
     }
 

--- a/W3ChampionsStatisticService/W3ChampionsStats/DistinctPlayersPerDays/DistinctPlayersPerDayHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/DistinctPlayersPerDays/DistinctPlayersPerDayHandler.cs
@@ -8,7 +8,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.W3ChampionsStats.DistinctPlayersPerDays;
 
 [Trace]
-public class DistinctPlayersPerDayHandler(IW3StatsRepo w3Stats) : IReadModelHandler
+public class DistinctPlayersPerDayHandler(IW3StatsRepo w3Stats) : IMatchFinishedReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;
 

--- a/W3ChampionsStatisticService/W3ChampionsStats/GameLengths/GameLengthStatHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/GameLengths/GameLengthStatHandler.cs
@@ -10,7 +10,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.W3ChampionsStats.GameLengths;
 
 [Trace]
-public class GameLengthStatHandler(IW3StatsRepo w3Stats) : IReadModelHandler
+public class GameLengthStatHandler(IW3StatsRepo w3Stats) : IMatchFinishedReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;
 

--- a/W3ChampionsStatisticService/W3ChampionsStats/GamesPerDays/GamesPerDayHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/GamesPerDays/GamesPerDayHandler.cs
@@ -10,7 +10,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.W3ChampionsStats.GamesPerDays;
 
 [Trace]
-public class GamesPerDayHandler(IW3StatsRepo w3Stats) : IReadModelHandler
+public class GamesPerDayHandler(IW3StatsRepo w3Stats) : IMatchFinishedReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;
 

--- a/W3ChampionsStatisticService/W3ChampionsStats/HeroPlayedStats/HeroPlayedStatHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/HeroPlayedStats/HeroPlayedStatHandler.cs
@@ -9,7 +9,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.W3ChampionsStats.HeroPlayedStats;
 
 [Trace]
-public class HeroPlayedStatHandler(IW3StatsRepo w3Stats) : IReadModelHandler
+public class HeroPlayedStatHandler(IW3StatsRepo w3Stats) : IMatchFinishedReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;
 

--- a/W3ChampionsStatisticService/W3ChampionsStats/HeroWinrate/HourOfPlayModelHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/HeroWinrate/HourOfPlayModelHandler.cs
@@ -11,7 +11,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.W3ChampionsStats.HeroWinrate;
 
 [Trace]
-public class OverallHeroWinRatePerHeroModelHandler(IW3StatsRepo w3Stats) : IReadModelHandler
+public class OverallHeroWinRatePerHeroModelHandler(IW3StatsRepo w3Stats) : IMatchFinishedReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;
 

--- a/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MapsPerSeasons/MapsPerSeasonHandler.cs
@@ -7,7 +7,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.W3ChampionsStats.MapsPerSeasons;
 
 [Trace]
-public class MapsPerSeasonHandler(IW3StatsRepo w3Stats) : IReadModelHandler
+public class MapsPerSeasonHandler(IW3StatsRepo w3Stats) : IMatchFinishedReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;
 

--- a/W3ChampionsStatisticService/W3ChampionsStats/MatchupLengths/MatchupLengthsHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MatchupLengths/MatchupLengthsHandler.cs
@@ -10,7 +10,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.W3ChampionsStats.MatchupLengths;
 
 [Trace]
-public class MatchupLengthsHandler(IW3StatsRepo w3Stats) : IReadModelHandler
+public class MatchupLengthsHandler(IW3StatsRepo w3Stats) : IMatchFinishedReadModelHandler
 {
     private readonly IW3StatsRepo _w3StatsRepo = w3Stats;
 

--- a/W3ChampionsStatisticService/W3ChampionsStats/OverallRaceAndWinStats/OverallRaceAndWinStatHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/OverallRaceAndWinStats/OverallRaceAndWinStatHandler.cs
@@ -15,7 +15,7 @@ namespace W3ChampionsStatisticService.W3ChampionsStats.OverallRaceAndWinStats;
 public class OverallRaceAndWinStatHandler(
     IW3StatsRepo w3Stats,
     IPatchRepository patchRepository
-        ) : IReadModelHandler
+        ) : IMatchFinishedReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;
     private readonly IPatchRepository _patchRepository = patchRepository;

--- a/W3ChampionsStatisticService/W3ChampionsStats/PopularHours/PopularHoursStatHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/PopularHours/PopularHoursStatHandler.cs
@@ -8,7 +8,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.W3ChampionsStats.PopularHours;
 
 [Trace]
-public class PopularHoursStatHandler(IW3StatsRepo w3Stats) : IReadModelHandler
+public class PopularHoursStatHandler(IW3StatsRepo w3Stats) : IMatchFinishedReadModelHandler
 {
     private readonly IW3StatsRepo _w3Stats = w3Stats;
 

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupEventRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupEventRepoTests.cs
@@ -2,6 +2,7 @@ using MongoDB.Bson;
 using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using W3C.Domain.MatchmakingService;
 using W3C.Domain.Repositories;
 
 namespace WC3ChampionsStatisticService.Tests.Matchups;
@@ -22,7 +23,7 @@ public class MatchupEventRepoTests : IntegrationTestBase
 
         await matchEventRepository.InsertIfNotExisting(matchFinishedEvent1);
 
-        var events = await matchEventRepository.Load();
+        var events = await matchEventRepository.Load<MatchFinishedEvent>(null);
 
         Assert.AreEqual(1, events.Count);
         Assert.AreEqual(false, events[0].WasFromSync);
@@ -44,7 +45,7 @@ public class MatchupEventRepoTests : IntegrationTestBase
         await matchEventRepository.InsertIfNotExisting(matchFinishedEvent1);
         await matchEventRepository.InsertIfNotExisting(matchFinishedEvent2);
 
-        var events = await matchEventRepository.Load();
+        var events = await matchEventRepository.Load<MatchFinishedEvent>(null);
 
         Assert.AreEqual(2, events.Count);
         Assert.AreEqual(false, events[0].WasFromSync);

--- a/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchFinishedReadModelHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchFinishedReadModelHandlerTests.cs
@@ -23,7 +23,7 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
         fakeEvent.match.map = "Maps/frozenthrone/community/(2)amazonia.w3x";
         fakeEvent.match.state = 2;
         var mockEvents = new Mock<IMatchEventRepository>();
-        mockEvents.SetupSequence(m => m.Load(It.IsAny<string>(), It.IsAny<int>()))
+        mockEvents.SetupSequence(m => m.Load<MatchFinishedEvent>(It.IsAny<string>(), It.IsAny<int>()))
             .ReturnsAsync(new List<MatchFinishedEvent>() { fakeEvent })
             .ReturnsAsync(new List<MatchFinishedEvent>());
 
@@ -31,7 +31,7 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
 
         var versionRepository = new VersionRepository(MongoClient);
 
-        var handler = new ReadModelHandler<MatchReadModelHandler>(
+        var handler = new MatchFinishedReadModelHandler<MatchReadModelHandler>(
             mockEvents.Object,
             versionRepository,
             new MatchReadModelHandler(mockMatchRepo.Object));
@@ -49,7 +49,7 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
         fakeEvent.match.map = "Maps/frozenthrone/community/(2)amazonia.w3x";
         fakeEvent.match.state = 3;
         var mockEvents = new Mock<IMatchEventRepository>();
-        mockEvents.SetupSequence(m => m.Load(It.IsAny<string>(), It.IsAny<int>()))
+        mockEvents.SetupSequence(m => m.Load<MatchFinishedEvent>(It.IsAny<string>(), It.IsAny<int>()))
             .ReturnsAsync(new List<MatchFinishedEvent>() { fakeEvent })
             .ReturnsAsync(new List<MatchFinishedEvent>());
 
@@ -57,7 +57,7 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
 
         var versionRepository = new VersionRepository(MongoClient);
 
-        var handler = new ReadModelHandler<MatchReadModelHandler>(
+        var handler = new MatchFinishedReadModelHandler<MatchReadModelHandler>(
             mockEvents.Object,
             versionRepository,
             new MatchReadModelHandler(mockMatchRepo.Object));
@@ -103,7 +103,7 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
         var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
         var versionRepository = new VersionRepository(MongoClient);
 
-        var handler = new ReadModelHandler<MatchReadModelHandler>(
+        var handler = new MatchFinishedReadModelHandler<MatchReadModelHandler>(
             new MatchEventRepository(MongoClient),
             versionRepository,
             new MatchReadModelHandler(matchRepository));


### PR DESCRIPTION
In preparation for supporting MatchCanceledEvents, make the different components generic rather than exclusive for MatchFinishedEvent.