### PR TITLE
Make tracking service testable

### DIFF
--- a/W3ChampionsStatisticService/Clans/ClanCommandHandler.cs
+++ b/W3ChampionsStatisticService/Clans/ClanCommandHandler.cs
@@ -14,10 +14,10 @@ namespace W3ChampionsStatisticService.Clans;
 public class ClanCommandHandler(
     IClanRepository clanRepository,
     IRankRepository rankRepository,
-    TrackingService trackingService)
+    ITrackingService trackingService)
 {
     private readonly IClanRepository _clanRepository = clanRepository;
-    private readonly TrackingService _trackingService = trackingService;
+    private readonly ITrackingService _trackingService = trackingService;
     private readonly IRankRepository _rankRepository = rankRepository;
 
     public async Task<Clan> CreateClan(string clanName, string clanAbbrevation, string battleTagOfFounder)

--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/GameModeStatQueryHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/GameModeStatQueryHandler.cs
@@ -15,12 +15,12 @@ namespace W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
 public class GameModeStatQueryHandler(
     IPlayerRepository playerRepository,
     PlayerService playerService,
-    TrackingService trackingService,
+    ITrackingService trackingService,
     IRankRepository rankRepository)
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;
     private readonly PlayerService _playerService = playerService;
-    private readonly TrackingService _trackingService = trackingService;
+    private readonly ITrackingService _trackingService = trackingService;
     private readonly IRankRepository _rankRepository = rankRepository;
 
     public async Task<List<PlayerGameModeStatPerGateway>> LoadPlayerStatsWithRanks(

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -123,7 +123,7 @@ builder.Services.AddSpecialBsonRegistrations();
 builder.Services.AddBasicAuthForMetrics();
 
 // Add Application Insights
-builder.Services.AddInterceptedSingleton<TrackingService>();
+builder.Services.AddInterceptedSingleton<ITrackingService, TrackingService>();
 string disableTelemetry = Environment.GetEnvironmentVariable("DISABLE_TELEMETRY");
 if (disableTelemetry == "true")
 {

--- a/W3ChampionsStatisticService/ReadModelBase/AsyncServiceBase.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/AsyncServiceBase.cs
@@ -40,7 +40,7 @@ public class AsyncServiceBase<T>(IServiceScopeFactory serviceScopeFactory) : IHo
                 }
                 catch (Exception e)
                 {
-                    var telemetryClient = scope.ServiceProvider.GetService<TrackingService>();
+                    var telemetryClient = scope.ServiceProvider.GetService<ITrackingService>();
                     telemetryClient.TrackException(e, "Some Readmodelhandler is dying");
                     Log.Error($"Some Readmodelhandler is dying: {e.Message}");
                 }

--- a/W3ChampionsStatisticService/ReadModelBase/MatchFinishedReadModelHandler.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/MatchFinishedReadModelHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using W3C.Domain.MatchmakingService;
@@ -14,12 +14,12 @@ public class MatchFinishedReadModelHandler<T>(
     IMatchEventRepository eventRepository,
     IVersionRepository versionRepository,
     T innerHandler,
-    TrackingService trackingService = null) : IAsyncUpdatable where T : IMatchFinishedReadModelHandler
+    ITrackingService trackingService) : IAsyncUpdatable where T : IMatchFinishedReadModelHandler
 {
     private readonly IMatchEventRepository _eventRepository = eventRepository;
     private readonly IVersionRepository _versionRepository = versionRepository;
     private readonly T _innerHandler = innerHandler;
-    private readonly TrackingService _trackingService = trackingService;
+    private readonly ITrackingService _trackingService = trackingService;
 
     public async Task Update()
     {

--- a/W3ChampionsStatisticService/Services/TrackingService.cs
+++ b/W3ChampionsStatisticService/Services/TrackingService.cs
@@ -7,27 +7,33 @@ using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.Services;
 
+public interface ITrackingService
+{
+    void TrackUnauthorizedRequest(string authorization, ControllerBase controller);
+    void TrackException(Exception ex, string message);
+}
+
 [Trace]
 public class TrackingService(
     TelemetryClient telemetry,
-    ILogger<TrackingService> logger)
+    ILogger<TrackingService> logger) : ITrackingService
 {
-    private TelemetryClient _telemetry = telemetry;
+    private readonly TelemetryClient _telemetry = telemetry;
     private readonly ILogger<TrackingService> _logger = logger;
 
     public void TrackUnauthorizedRequest(string authorization, ControllerBase controller)
     {
         try
         {
-            var properties = new Dictionary<string, string>();
-
-            properties.Add("RemoteIp", controller.ControllerContext.HttpContext.Connection.RemoteIpAddress.ToString());
-            properties.Add("UsedAuth", authorization);
-
-            properties.Add("RequestPath", controller.Request.Path);
-            properties.Add("RequestMethod", controller.Request.Method);
-            properties.Add("RequestProtocol", controller.Request.Protocol);
-            properties.Add("RequestQueryString", controller.Request.QueryString.ToString());
+            var properties = new Dictionary<string, string>
+            {
+                { "RemoteIp", controller.ControllerContext.HttpContext.Connection.RemoteIpAddress.ToString() },
+                { "UsedAuth", authorization },
+                { "RequestPath", controller.Request.Path },
+                { "RequestMethod", controller.Request.Method },
+                { "RequestProtocol", controller.Request.Protocol },
+                { "RequestQueryString", controller.Request.QueryString.ToString() }
+            };
 
             _telemetry.TrackEvent("UnauthorizedRequest", properties);
         }

--- a/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
@@ -7,6 +7,8 @@ using W3C.Domain.CommonValueObjects;
 using W3C.Domain.MatchmakingService;
 using W3C.Contracts.Matchmaking;
 using W3C.Contracts.GameObjects;
+using Moq;
+using W3ChampionsStatisticService.Services;
 
 namespace WC3ChampionsStatisticService.Tests;
 
@@ -311,5 +313,10 @@ public static class TestDtoHelper
     public static List<Hero> CreateHeroList(IList<W3ChampionsStatisticService.Heroes.HeroType> heroes)
     {
         return heroes.Select((hero, index) => new Hero { icon = $"{Enum.GetName(hero).ToLower()}.png", level = index + 1 }).ToList();
+    }
+
+    public static Mock<ITrackingService> CreateMockTrackingService()
+    {
+        return new Mock<ITrackingService>();
     }
 }


### PR DESCRIPTION
The tracking service is currently directly injected as an object, which makes it not mockable for tests. This PR refactors this in order to allow mocking it in tests.