### PR TITLE
Remove ongoing game if MatchCanceledEvent is received

### DIFF
--- a/W3ChampionsStatisticService/Matches/OngoingRemovalMatchCanceledHandler.cs
+++ b/W3ChampionsStatisticService/Matches/OngoingRemovalMatchCanceledHandler.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading.Tasks;
+using W3C.Domain.MatchmakingService;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.ReadModelBase;
+using Serilog;
+using W3C.Domain.Tracing;
+using W3C.Contracts.Matchmaking;
+
+namespace W3ChampionsStatisticService.Matches;
+
+[Trace]
+public class OngoingRemovalMatchCanceledHandler(IMatchRepository matchRepository) : IMatchCanceledReadModelHandler
+{
+    private readonly IMatchRepository _matchRepository = matchRepository;
+
+    public async Task Update(MatchCanceledEvent nextEvent)
+    {
+        var ongoingMatch = await _matchRepository.LoadDetailsByOngoingMatchId(nextEvent.match.id);
+
+        if (ongoingMatch == null)
+        {
+            if (nextEvent.match.gameMode != GameMode.CUSTOM)
+            {
+                Log.Warning($"Canceled match {nextEvent.match.id} not found");
+            }
+            return;
+        }
+
+        if (ongoingMatch.Match != null)
+        {
+            Log.Information($"Canceling ongoing match {ongoingMatch.Match.Id}");
+            await _matchRepository.DeleteOnGoingMatch(ongoingMatch.Match);
+        }
+        else
+        {
+            Log.Warning($"Canceled match detail had null Match property for {nextEvent.match.id}");
+            await _matchRepository.DeleteOnGoingMatch(new Matchup { MatchId = nextEvent.match.id });
+        }
+    }
+}

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -234,6 +234,7 @@ if (startHandlers == "true")
 
     // On going matches
     builder.Services.AddUnversionedReadModelService<StartedMatchIntoOngoingMatchesHandler>();
+    builder.Services.AddMatchCanceledReadModelService<OngoingRemovalMatchCanceledHandler>();
 
     builder.Services.AddUnversionedReadModelService<RankSyncHandler>();
     builder.Services.AddUnversionedReadModelService<LeagueSyncHandler>();

--- a/W3ChampionsStatisticService/ReadModelBase/IReadModelHandler.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/IReadModelHandler.cs
@@ -7,3 +7,8 @@ public interface IMatchFinishedReadModelHandler
 {
     Task Update(MatchFinishedEvent nextEvent);
 }
+
+public interface IMatchCanceledReadModelHandler
+{
+    Task Update(MatchCanceledEvent nextEvent);
+}

--- a/W3ChampionsStatisticService/ReadModelBase/MatchCanceledReadModelHandler.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/MatchCanceledReadModelHandler.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading.Tasks;
+using W3C.Domain.MatchmakingService;
+using W3C.Domain.Repositories;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.Services;
+using W3C.Domain.Tracing;
+
+namespace W3ChampionsStatisticService.ReadModelBase;
+
+[Trace]
+public class MatchCanceledReadModelHandler<T>(
+    IMatchEventRepository eventRepository,
+    IVersionRepository versionRepository,
+    T innerHandler,
+    ITrackingService trackingService) : MatchEventReadModelHandler<MatchCanceledEvent, T>(eventRepository, versionRepository, innerHandler, trackingService)
+    where T : class, IMatchCanceledReadModelHandler
+{
+    private readonly T _innerHandler = innerHandler;
+
+    protected override void ValidateMatchState(MatchCanceledEvent matchEvent)
+    {
+        if (matchEvent.match.state != EMatchState.CANCELED)
+        {
+            throw new InvalidOperationException($"Received match with illegal state {matchEvent.match.state} within the MatchCanceledReadModelHandler");
+        }
+    }
+
+    protected override Match GetMatch(MatchCanceledEvent matchEvent)
+    {
+        return matchEvent.match;
+    }
+
+    protected override async Task UpdateInnerHandler(MatchCanceledEvent matchEvent)
+    {
+        await _innerHandler.Update(matchEvent);
+    }
+}

--- a/W3ChampionsStatisticService/ReadModelBase/MatchEventReadModelHandler.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/MatchEventReadModelHandler.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Serilog;
+using W3C.Domain.MatchmakingService;
+using W3C.Domain.Repositories;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.Services;
+using W3C.Domain.Tracing;
+
+namespace W3ChampionsStatisticService.ReadModelBase;
+
+[Trace]
+public abstract class MatchEventReadModelHandler<TEvent, THandler>(
+    IMatchEventRepository eventRepository,
+    IVersionRepository versionRepository,
+    THandler innerHandler,
+    ITrackingService trackingService) : IAsyncUpdatable
+    where TEvent : MatchmakingEvent
+    where THandler : class
+{
+    private readonly IMatchEventRepository _eventRepository = eventRepository;
+    private readonly IVersionRepository _versionRepository = versionRepository;
+    private readonly THandler _innerHandler = innerHandler;
+    private readonly ITrackingService _trackingService = trackingService;
+
+    public async Task Update()
+    {
+        var lastVersion = await _versionRepository.GetLastVersion<THandler>();
+        var events = await _eventRepository.Load<TEvent>(lastVersion.Version, 1000);
+
+        while (events.Count != 0)
+        {
+            foreach (var matchEvent in events)
+            {
+                if (lastVersion.IsStopped) return;
+
+                try
+                {
+                    lastVersion = await ProcessMatchEvent(matchEvent, lastVersion);
+                }
+                catch (Exception e)
+                {
+                    Log.Error(e, "Error processing {EventType} {EventId} within the {HandlerType}",
+                        typeof(TEvent).Name, matchEvent.Id, typeof(THandler).Name);
+                    _trackingService.TrackException(e, $"ReadmodelHandler: {typeof(THandler).Name} died on event {matchEvent.Id}");
+                    throw; // rethrow the exception so the event is not lost
+                }
+            }
+
+            events = await _eventRepository.Load<TEvent>(events.Last().Id.ToString());
+        }
+    }
+
+    private async Task<HandlerVersion> ProcessMatchEvent(TEvent matchEvent, HandlerVersion lastVersion)
+    {
+        ValidateMatchState(matchEvent);
+
+        lastVersion = await UpdateSeasonIfNeeded(matchEvent, lastVersion);
+
+        await ProcessEventForCurrentSeason(matchEvent, lastVersion);
+
+        await _versionRepository.SaveLastVersion<THandler>(matchEvent.Id.ToString(), lastVersion.Season);
+        return lastVersion;
+    }
+
+    private async Task<HandlerVersion> UpdateSeasonIfNeeded(TEvent matchEvent, HandlerVersion lastVersion)
+    {
+        var match = GetMatch(matchEvent);
+        if (match.season > lastVersion.Season)
+        {
+            await _versionRepository.SaveLastVersion<THandler>(lastVersion.Version, match.season);
+            // Return the updated version from the database
+            return await _versionRepository.GetLastVersion<THandler>();
+        }
+
+        return lastVersion;
+    }
+
+    private async Task ProcessEventForCurrentSeason(TEvent matchEvent, HandlerVersion lastVersion)
+    {
+        var match = GetMatch(matchEvent);
+        if (match.season == lastVersion.Season)
+        {
+            await UpdateInnerHandler(matchEvent);
+        }
+        else
+        {
+            Log.Warning("Old season event {EventSeason} detected during season {CurrentSeason}. Skipping event {EventId}...",
+                match.season, lastVersion.Season, matchEvent.Id);
+        }
+    }
+
+    // Abstract methods that derived classes must implement
+    protected abstract void ValidateMatchState(TEvent matchEvent);
+    protected abstract Match GetMatch(TEvent matchEvent);
+    protected abstract Task UpdateInnerHandler(TEvent matchEvent);
+}

--- a/W3ChampionsStatisticService/ReadModelBase/MatchFinishedReadModelHandler.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/MatchFinishedReadModelHandler.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
-using Serilog;
 using W3C.Domain.MatchmakingService;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.Ports;
@@ -15,53 +13,12 @@ public class MatchFinishedReadModelHandler<T>(
     IMatchEventRepository eventRepository,
     IVersionRepository versionRepository,
     T innerHandler,
-    ITrackingService trackingService) : IAsyncUpdatable where T : IMatchFinishedReadModelHandler
+    ITrackingService trackingService) : MatchEventReadModelHandler<MatchFinishedEvent, T>(eventRepository, versionRepository, innerHandler, trackingService)
+    where T : class, IMatchFinishedReadModelHandler
 {
-    private readonly IMatchEventRepository _eventRepository = eventRepository;
-    private readonly IVersionRepository _versionRepository = versionRepository;
     private readonly T _innerHandler = innerHandler;
-    private readonly ITrackingService _trackingService = trackingService;
 
-    public async Task Update()
-    {
-        var lastVersion = await _versionRepository.GetLastVersion<T>();
-        var finishedEvents = await _eventRepository.Load<MatchFinishedEvent>(lastVersion.Version, 1000);
-
-        while (finishedEvents.Count != 0)
-        {
-            foreach (var matchEvent in finishedEvents)
-            {
-                if (lastVersion.IsStopped) return;
-
-                try
-                {
-                    lastVersion = await ProcessMatchFinishedEvent(matchEvent, lastVersion);
-                }
-                catch (Exception e)
-                {
-                    Log.Error(e, "Error processing MatchFinishedEvent {EventId} within the MatchFinishedReadModelHandler", matchEvent.Id);
-                    _trackingService.TrackException(e, $"ReadmodelHandler: {typeof(T).Name} died on event {matchEvent.Id}");
-                    throw; // rethrow the exception so the event is not lost
-                }
-            }
-
-            finishedEvents = await _eventRepository.Load<MatchFinishedEvent>(finishedEvents.Last().Id.ToString());
-        }
-    }
-
-    private async Task<HandlerVersion> ProcessMatchFinishedEvent(MatchFinishedEvent matchEvent, HandlerVersion lastVersion)
-    {
-        ValidateMatchState(matchEvent);
-
-        lastVersion = await UpdateSeasonIfNeeded(matchEvent, lastVersion);
-
-        await ProcessEventForCurrentSeason(matchEvent, lastVersion);
-
-        await _versionRepository.SaveLastVersion<T>(matchEvent.Id.ToString(), lastVersion.Season);
-        return lastVersion;
-    }
-
-    private static void ValidateMatchState(MatchFinishedEvent matchEvent)
+    protected override void ValidateMatchState(MatchFinishedEvent matchEvent)
     {
         if (matchEvent.match.state != EMatchState.FINISHED)
         {
@@ -69,28 +26,13 @@ public class MatchFinishedReadModelHandler<T>(
         }
     }
 
-    private async Task<HandlerVersion> UpdateSeasonIfNeeded(MatchFinishedEvent matchEvent, HandlerVersion lastVersion)
+    protected override Match GetMatch(MatchFinishedEvent matchEvent)
     {
-        if (matchEvent.match.season > lastVersion.Season)
-        {
-            await _versionRepository.SaveLastVersion<T>(lastVersion.Version, matchEvent.match.season);
-            // Return the updated version from the database
-            return await _versionRepository.GetLastVersion<T>();
-        }
-
-        return lastVersion;
+        return matchEvent.match;
     }
 
-    private async Task ProcessEventForCurrentSeason(MatchFinishedEvent matchEvent, HandlerVersion lastVersion)
+    protected override async Task UpdateInnerHandler(MatchFinishedEvent matchEvent)
     {
-        if (matchEvent.match.season == lastVersion.Season)
-        {
-            await _innerHandler.Update(matchEvent);
-        }
-        else
-        {
-            Log.Warning("Old season event {EventSeason} detected during season {CurrentSeason}. Skipping event {EventId}...",
-                matchEvent.match.season, lastVersion.Season, matchEvent.Id);
-        }
+        await _innerHandler.Update(matchEvent);
     }
 }

--- a/W3ChampionsStatisticService/ReadModelBase/ReadModelExtensions.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/ReadModelExtensions.cs
@@ -13,6 +13,14 @@ public static class ReadModelExtensions
         return services;
     }
 
+    public static IServiceCollection AddMatchCanceledReadModelService<T>(this IServiceCollection services) where T : class, IMatchCanceledReadModelHandler
+    {
+        services.AddTransient<T>();
+        services.AddTransient<MatchCanceledReadModelHandler<T>>();
+        services.AddSingleton<IHostedService, AsyncServiceBase<MatchCanceledReadModelHandler<T>>>();
+        return services;
+    }
+
     public static IServiceCollection AddUnversionedReadModelService<T>(this IServiceCollection services) where T : class, IAsyncUpdatable
     {
         services.AddTransient<T>();

--- a/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
@@ -319,4 +319,20 @@ public static class TestDtoHelper
     {
         return new Mock<ITrackingService>();
     }
+
+    public static MatchCanceledEvent CreateFakeMatchCanceledEvent()
+    {
+        var fixture = new Fixture { RepeatCount = 2 };
+        var fakeEvent = fixture.Build<MatchCanceledEvent>().With(e => e.Id, ObjectId.GenerateNewId()).Create();
+
+        fakeEvent.match.map = "Maps/frozenthrone/community/(2)amazonia.w3x";
+
+        fakeEvent.match.gateway = GateWay.Europe;
+        fakeEvent.match.gameMode = GameMode.GM_1v1;
+        fakeEvent.match.season = 0;
+        fakeEvent.match.id = fakeEvent.Id.ToString();
+        fakeEvent.match.state = EMatchState.CANCELED;
+
+        return fakeEvent;
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
+++ b/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
@@ -64,6 +64,25 @@ public class IntegrationTestBase
             new FindOneAndReplaceOptions<MatchStartedEvent> { IsUpsert = true });
     }
 
+    protected async Task InsertMatchCanceledEvents(List<MatchCanceledEvent> newEvents)
+    {
+        foreach (var ev in newEvents)
+        {
+            await InsertMatchCanceledEvent(ev);
+        }
+    }
+
+    protected async Task InsertMatchCanceledEvent(MatchCanceledEvent newEvent)
+    {
+        var database = MongoClient.GetDatabase("W3Champions-Statistic-Service");
+        var mongoDatabase = database;
+        var mongoCollection = mongoDatabase.GetCollection<MatchCanceledEvent>(nameof(MatchCanceledEvent));
+        await mongoCollection.FindOneAndReplaceAsync(
+            (Expression<Func<MatchCanceledEvent, bool>>)(ev => ev.match.id == newEvent.match.id),
+            newEvent,
+            new FindOneAndReplaceOptions<MatchCanceledEvent> { IsUpsert = true });
+    }
+
     protected async Task InsertRankChangedEvent(RankingChangedEvent newEvent)
     {
         var database = MongoClient.GetDatabase("W3Champions-Statistic-Service");

--- a/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchCanceledReadModelHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchCanceledReadModelHandlerTests.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsStatisticService.Matches;
+using W3C.Domain.MatchmakingService;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Domain.Repositories;
+using W3C.Contracts.Matchmaking;
+using System;
+
+namespace WC3ChampionsStatisticService.Tests.ReadModel;
+
+[TestFixture]
+public class MatchCanceledReadModelHandlerTests : IntegrationTestBase
+{
+    [Test]
+    public async Task DeleteCanceledMatch()
+    {
+        var fakeEvent = TestDtoHelper.CreateFakeMatchCanceledEvent();
+        var mockEvents = new Mock<IMatchEventRepository>();
+        mockEvents.SetupSequence(m => m.Load<MatchCanceledEvent>(It.IsAny<string>(), It.IsAny<int>()))
+            .ReturnsAsync(new List<MatchCanceledEvent>() { fakeEvent })
+            .ReturnsAsync(new List<MatchCanceledEvent>());
+
+        var mockMatchRepo = new Mock<IMatchRepository>();
+        mockMatchRepo.Setup(m => m.LoadDetailsByOngoingMatchId(It.IsAny<string>())).ReturnsAsync(new MatchupDetail());
+
+        var versionRepository = new VersionRepository(MongoClient);
+        var trackingService = TestDtoHelper.CreateMockTrackingService();
+
+        var handler = new MatchCanceledReadModelHandler<OngoingRemovalMatchCanceledHandler>(
+            mockEvents.Object,
+            versionRepository,
+            new OngoingRemovalMatchCanceledHandler(mockMatchRepo.Object),
+            trackingService.Object);
+
+        await handler.Update();
+
+        mockMatchRepo.Verify(m => m.DeleteOnGoingMatch(It.IsAny<Matchup>()), Times.Once);
+    }
+
+    [Test]
+    public async Task CanceledMatchNotFound()
+    {
+        var fakeEvent = TestDtoHelper.CreateFakeMatchCanceledEvent();
+        var mockEvents = new Mock<IMatchEventRepository>();
+        mockEvents.SetupSequence(m => m.Load<MatchCanceledEvent>(It.IsAny<string>(), It.IsAny<int>()))
+            .ReturnsAsync(new List<MatchCanceledEvent>() { fakeEvent })
+            .ReturnsAsync(new List<MatchCanceledEvent>());
+
+        var mockMatchRepo = new Mock<IMatchRepository>();
+        mockMatchRepo.Setup(m => m.LoadDetailsByOngoingMatchId(It.IsAny<string>())).ReturnsAsync((MatchupDetail)null);
+
+        var versionRepository = new VersionRepository(MongoClient);
+        var trackingService = TestDtoHelper.CreateMockTrackingService();
+
+        var handler = new MatchCanceledReadModelHandler<OngoingRemovalMatchCanceledHandler>(
+            mockEvents.Object,
+            versionRepository,
+            new OngoingRemovalMatchCanceledHandler(mockMatchRepo.Object),
+            trackingService.Object);
+
+        await handler.Update();
+
+        mockMatchRepo.Verify(m => m.DeleteOnGoingMatch(It.IsAny<Matchup>()), Times.Never);
+    }
+
+
+    [Test]
+    public void CanceledMatchIllegalState()
+    {
+        var fakeEvent = TestDtoHelper.CreateFakeMatchCanceledEvent();
+
+        fakeEvent.match.map = "Maps/frozenthrone/community/(2)amazonia.w3x";
+        fakeEvent.match.state = EMatchState.FINISHED; // Set it to an illegal state
+        var mockEvents = new Mock<IMatchEventRepository>();
+        mockEvents.SetupSequence(m => m.Load<MatchCanceledEvent>(It.IsAny<string>(), It.IsAny<int>()))
+            .ReturnsAsync(new List<MatchCanceledEvent>() { fakeEvent })
+            .ReturnsAsync(new List<MatchCanceledEvent>());
+
+        var mockMatchRepo = new Mock<IMatchRepository>();
+        var mockTrackingService = TestDtoHelper.CreateMockTrackingService();
+
+        var versionRepository = new VersionRepository(MongoClient);
+
+        var handler = new MatchCanceledReadModelHandler<OngoingRemovalMatchCanceledHandler>(
+            mockEvents.Object,
+            versionRepository,
+            new OngoingRemovalMatchCanceledHandler(mockMatchRepo.Object),
+            mockTrackingService.Object);
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => handler.Update());
+        mockMatchRepo.Verify(m => m.DeleteOnGoingMatch(It.IsAny<Matchup>()), Times.Never);
+        mockTrackingService.Verify(m => m.TrackException(It.IsAny<InvalidOperationException>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public async Task TestThatNewVersionIsUpdated()
+    {
+        var fakeEvent1 = TestDtoHelper.CreateFakeMatchCanceledEvent();
+        var fakeEvent2 = TestDtoHelper.CreateFakeMatchCanceledEvent();
+        var fakeEvent3 = TestDtoHelper.CreateFakeMatchCanceledEvent();
+        var fakeEvent4 = TestDtoHelper.CreateFakeMatchCanceledEvent();
+        var fakeEvent5 = TestDtoHelper.CreateFakeMatchCanceledEvent();
+
+        fakeEvent1.match.season = 0;
+        fakeEvent1.match.startTime = 5000;
+        fakeEvent1.match.endTime = 5500;
+        fakeEvent1.Id = ObjectId.GenerateNewId();
+        fakeEvent2.match.season = 0;
+        fakeEvent2.match.startTime = 4000;
+        fakeEvent2.match.endTime = 4500;
+        fakeEvent2.Id = ObjectId.GenerateNewId();
+        fakeEvent3.match.season = 1;
+        fakeEvent3.match.startTime = 3000;
+        fakeEvent3.match.endTime = 3500;
+        fakeEvent3.Id = ObjectId.GenerateNewId();
+        fakeEvent4.match.season = 1;
+        fakeEvent4.match.startTime = 2000;
+        fakeEvent4.match.endTime = 2500;
+        fakeEvent4.match.id = "Test";
+        fakeEvent4.Id = ObjectId.GenerateNewId();
+        fakeEvent5.match.season = 0;
+        fakeEvent5.match.startTime = 1000;
+        fakeEvent5.match.endTime = 1500;
+        fakeEvent5.Id = ObjectId.GenerateNewId();
+
+        await InsertMatchCanceledEvents(new List<MatchCanceledEvent> { fakeEvent1, fakeEvent2, fakeEvent3, fakeEvent4, fakeEvent5 });
+
+        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var versionRepository = new VersionRepository(MongoClient);
+        var trackingService = TestDtoHelper.CreateMockTrackingService();
+
+        var handler = new MatchCanceledReadModelHandler<OngoingRemovalMatchCanceledHandler>(
+            new MatchEventRepository(MongoClient),
+            versionRepository,
+            new OngoingRemovalMatchCanceledHandler(matchRepository),
+            trackingService.Object);
+
+        await handler.Update();
+
+        var version = await versionRepository.GetLastVersion<OngoingRemovalMatchCanceledHandler>();
+
+        var matches = await matchRepository.Load(1, GameMode.GM_1v1);
+
+        Assert.AreEqual(1, version.Season);
+        Assert.AreEqual(fakeEvent5.Id.ToString(), version.Version);
+        Assert.AreEqual(0, matches.Count);
+    }
+}


### PR DESCRIPTION
We are currently not removing ongoing games if they have been canceled; instead, we rely on them being removed when the player starts a new game (and we receive a MatchFinished event for that game).

This can result in an ever-increasing list of ongoing matches; especially when outages cause a significant number of canceled matches.