### PR TITLE
Make tracing service testable

### DIFF
--- a/W3ChampionsStatisticService/Matches/OngoingMatchesCache.cs
+++ b/W3ChampionsStatisticService/Matches/OngoingMatchesCache.cs
@@ -6,12 +6,14 @@ using System.Threading.Tasks;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.Repositories;
 using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.Services;
 
 namespace W3ChampionsStatisticService.Matches;
 
 [Trace]
-public class OngoingMatchesCache(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IOngoingMatchesCache
+public class OngoingMatchesCache(MongoClient mongoClient, TracingService tracingService) : MongoDbRepositoryBase(mongoClient), IOngoingMatchesCache
 {
+    private readonly TracingService _tracingService = tracingService; // Unused for now, will be used in the future
     private List<OnGoingMatchup> _values = [];
     private readonly object _lock = new();
 

--- a/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
@@ -9,6 +9,8 @@ using W3C.Contracts.Matchmaking;
 using W3C.Contracts.GameObjects;
 using Moq;
 using W3ChampionsStatisticService.Services;
+using Microsoft.AspNetCore.Http;
+using System.Diagnostics;
 
 namespace WC3ChampionsStatisticService.Tests;
 
@@ -318,6 +320,22 @@ public static class TestDtoHelper
     public static Mock<ITrackingService> CreateMockTrackingService()
     {
         return new Mock<ITrackingService>();
+    }
+
+    public static Mock<TracingService> CreateMockedTracingService()
+    {
+        // Create a real ActivitySource for testing
+        var activitySource = new ActivitySource("TestActivitySource");
+
+        // Mock the IHttpContextAccessor
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+
+        // Create a partial mock of TracingService - this allows you to verify calls and override specific methods
+        // while keeping the real implementation for methods you don't explicitly mock
+        return new Mock<TracingService>(activitySource, mockHttpContextAccessor.Object)
+        {
+            CallBase = true // This ensures unmocked methods use the real implementation
+        };
     }
 
     public static MatchCanceledEvent CreateFakeMatchCanceledEvent()

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
@@ -3,19 +3,29 @@ using MongoDB.Bson;
 using NUnit.Framework;
 using W3ChampionsStatisticService.Matches;
 using W3C.Contracts.GameObjects;
+using Moq;
+using W3ChampionsStatisticService.Services;
 
 namespace WC3ChampionsStatisticService.Tests.Matchups;
 
 [TestFixture]
 public class MatchupDetailTests : IntegrationTestBase
 {
+    private MatchRepository matchRepository;
+    private Mock<TracingService> tracingService;
+    [SetUp]
+    public void SetupSut()
+    {
+        tracingService = TestDtoHelper.CreateMockedTracingService();
+        matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient, tracingService.Object));
+    }
+
     [Test]
     public async Task LoadDetails_NotDetailsAvailable()
     {
         var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent.match.id = "nmhcCLaRc7";
         matchFinishedEvent.Id = ObjectId.GenerateNewId();
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
@@ -33,8 +43,6 @@ public class MatchupDetailTests : IntegrationTestBase
         matchFinishedEvent.result.players[1].heroes[0].icon = "warden";
 
         await InsertMatchEvent(matchFinishedEvent);
-
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
@@ -57,8 +65,6 @@ public class MatchupDetailTests : IntegrationTestBase
         matchFinishedEvent.match.players.Find(p => p.battleTag == matchFinishedEvent.result.players[0].battleTag).race = Race.RnD;
 
         await InsertMatchEvent(matchFinishedEvent);
-
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
@@ -84,8 +90,6 @@ public class MatchupDetailTests : IntegrationTestBase
 
         await InsertMatchEvent(matchFinishedEvent);
 
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
         var result = await matchRepository.LoadDetails(matchFinishedEvent.Id);
@@ -109,8 +113,6 @@ public class MatchupDetailTests : IntegrationTestBase
         matchFinishedEvent.match.players[0].race = Race.RnD;
 
         await InsertMatchEvent(matchFinishedEvent);
-
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -7,24 +7,27 @@ using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.Matches;
 using W3C.Contracts.GameObjects;
 using W3ChampionsStatisticService.Ladder;
+using Moq;
+using W3ChampionsStatisticService.Services;
 
 namespace WC3ChampionsStatisticService.Tests.Matchups;
 
 [TestFixture]
 public class MatchupRepoTests : IntegrationTestBase
 {
+    private MatchRepository matchRepository;
+    private Mock<TracingService> tracingService;
     [SetUp]
     public async Task SetupSut()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        tracingService = TestDtoHelper.CreateMockedTracingService();
+        matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient, tracingService.Object));
         await matchRepository.EnsureIndices();
     }
 
     [Test]
     public async Task LoadAndSave()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
 
@@ -38,8 +41,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task LoadWithHeroFilter()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent.result.players.First().heroes = TestDtoHelper.CreateHeroList(
             new List<W3ChampionsStatisticService.Heroes.HeroType>
@@ -100,8 +101,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task LoadWithHeroFilterNoResults()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent.result.players.First().heroes = TestDtoHelper.CreateHeroList(
             new List<W3ChampionsStatisticService.Heroes.HeroType>
@@ -149,8 +148,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task LoadAndSearch()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent1.match.players[1].battleTag = "KOMISCHER#123";
@@ -173,8 +170,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task LoadAndSearch_InvalidString()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent1.match.season = 1;
@@ -191,8 +186,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task Upsert()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
@@ -209,8 +202,6 @@ public class MatchupRepoTests : IntegrationTestBase
         {
             Console.WriteLine($"https://www.test.w3champions.com:{i}/login");
         }
-
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
 
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
@@ -239,8 +230,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForPlayerAndOpponent()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
 
@@ -264,8 +253,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForPlayerAndOpponent_FilterByGateway()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
 
@@ -292,8 +279,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForPlayerAndOppoRace()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent3 = TestDtoHelper.CreateFakeEvent();
@@ -320,8 +305,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [TestCase(0, "wolf#456")]
     public async Task SearchForPlayerAndOpponent_FilterBySeason(int season, string playerTwo)
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
 
@@ -347,8 +330,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [TestCase(0)]
     public async Task SearchForPlayerAndOpponent_FilterBySeason_NoResults(int season)
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
 
         matchFinishedEvent1.match.season = season ^ 1;
@@ -365,8 +346,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForPlayerAndOpponent_2v2_SameTeam()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent1 = TestDtoHelper.CreateFake2v2AtEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
 
@@ -391,8 +370,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForPlayerAndOpponent_2v2()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent1 = TestDtoHelper.CreateFake2v2AtEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent1.match.season = 1;
@@ -423,8 +400,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForPlayerAndOpponent_2v2And1V1()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent1 = TestDtoHelper.CreateFake2v2AtEvent();
         var matchFinishedEvent2 = TestDtoHelper.CreateFakeEvent();
 
@@ -456,7 +431,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForGameMode2v2_NotFound()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent1.match.gameMode = GameMode.GM_1v1;
 
@@ -469,7 +443,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForGameMode2v2_Found()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent1.match.gameMode = GameMode.GM_2v2_AT;
 
@@ -482,7 +455,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task SearchForGameMode2v2_LoadDefault()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
         matchFinishedEvent1.match.gameMode = GameMode.GM_2v2_AT;
 
@@ -495,8 +467,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task ReforgedIconGetsReplaced()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var matchFinishedEvent1 = TestDtoHelper.CreateFakeEvent();
 
         matchFinishedEvent1.match.players[0].battleTag = "peter#123";
@@ -518,7 +488,7 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task Cache_AllOngoingMatches()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+
 
         var storedEvent = TestDtoHelper.CreateFakeStartedEvent();
         await matchRepository.InsertOnGoingMatch(OnGoingMatchup.Create(storedEvent));
@@ -548,8 +518,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task Cache_ByPlayerId()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var storedEvent = TestDtoHelper.CreateFakeStartedEvent();
         await matchRepository.InsertOnGoingMatch(OnGoingMatchup.Create(storedEvent));
 
@@ -575,8 +543,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task Cache_ByPlayerId_OneTeamEmpty()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
-
         var storedEvent = TestDtoHelper.Create1v1StartedEvent();
 
         await matchRepository.InsertOnGoingMatch(OnGoingMatchup.Create(storedEvent));
@@ -603,7 +569,6 @@ public class MatchupRepoTests : IntegrationTestBase
     [Test]
     public async Task LoadLastSeason()
     {
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
         var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
         await rankRepository.UpsertSeason(new Season(1));
         await rankRepository.UpsertSeason(new Season(2));

--- a/WC3ChampionsStatisticService.UnitTests/Performance/DBPerformanceTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Performance/DBPerformanceTest.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using Moq;
+using NUnit.Framework;
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -6,6 +7,7 @@ using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.Matches;
 using W3ChampionsStatisticService.PlayerProfiles;
+using W3ChampionsStatisticService.Services;
 using W3ChampionsStatisticService.W3ChampionsStats;
 
 namespace WC3ChampionsStatisticService.Tests.Performance;
@@ -14,6 +16,16 @@ namespace WC3ChampionsStatisticService.Tests.Performance;
 [Ignore("Use only when performance testing DB")]
 public class DBPerformanceTest : IntegrationTestBase
 {
+    private MatchRepository matchesRepository;
+    private Mock<TracingService> tracingService;
+    [SetUp]
+    public async Task SetupSut()
+    {
+        tracingService = TestDtoHelper.CreateMockedTracingService();
+        matchesRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient, tracingService.Object));
+        await matchesRepository.EnsureIndices();
+    }
+
     [Test]
     public async Task PopularHours_TimeslotsAreSetCorrectlyAfterLoad()
     {
@@ -32,7 +44,6 @@ public class DBPerformanceTest : IntegrationTestBase
     [Test]
     public async Task LoadMatchesColorful()
     {
-        var matchesRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
         Stopwatch sw = new();
         sw.Start();
         string playerId = "COLORFUL#5214";
@@ -56,7 +67,6 @@ public class DBPerformanceTest : IntegrationTestBase
     [Test]
     public async Task LoadCountColorful()
     {
-        var matchesRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
         Stopwatch sw = new();
         sw.Start();
         string playerId = "COLORFUL#5214";
@@ -78,7 +88,6 @@ public class DBPerformanceTest : IntegrationTestBase
     [Test]
     public async Task LoadMatchesShaDe()
     {
-        var matchesRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
         Stopwatch sw = new();
         sw.Start();
         string playerId = "ShaDeFaDe#2441";
@@ -102,7 +111,6 @@ public class DBPerformanceTest : IntegrationTestBase
     [Test]
     public async Task LoadCountShaDe()
     {
-        var matchesRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
         Stopwatch sw = new();
         sw.Start();
         string playerId = "ShaDeFaDe#2441";

--- a/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchCanceledReadModelHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchCanceledReadModelHandlerTests.cs
@@ -130,7 +130,8 @@ public class MatchCanceledReadModelHandlerTests : IntegrationTestBase
 
         await InsertMatchCanceledEvents(new List<MatchCanceledEvent> { fakeEvent1, fakeEvent2, fakeEvent3, fakeEvent4, fakeEvent5 });
 
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var mockTracingService = TestDtoHelper.CreateMockedTracingService();
+        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient, mockTracingService.Object));
         var versionRepository = new VersionRepository(MongoClient);
         var trackingService = TestDtoHelper.CreateMockTrackingService();
 

--- a/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchFinishedReadModelHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchFinishedReadModelHandlerTests.cs
@@ -111,7 +111,8 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
         await InsertMatchEvents(new List<MatchFinishedEvent> { fakeEvent1, fakeEvent2, fakeEvent3, fakeEvent4, fakeEvent5 });
 
         var mockTrackingService = TestDtoHelper.CreateMockTrackingService();
-        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient));
+        var mockTracingService = TestDtoHelper.CreateMockedTracingService();
+        var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient, mockTracingService.Object));
         var versionRepository = new VersionRepository(MongoClient);
 
         var handler = new MatchFinishedReadModelHandler<OngoingRemovalMatchFinishedHandler>(


### PR DESCRIPTION
In preparation for the ongoing games cache improvements, make the tracing service testable by introducing a mocking helper.