### PR TITLE
Rewrite Ongoing Matches Cache

### DIFF
--- a/W3C.Contracts/Matchmaking/MatchSortMethod.cs
+++ b/W3C.Contracts/Matchmaking/MatchSortMethod.cs
@@ -1,0 +1,18 @@
+using System.Runtime.Serialization;
+
+namespace W3C.Contracts.Matchmaking;
+
+public enum MatchSortMethod
+{
+    [EnumMember(Value = "startTimeDescending")]
+    StartTimeDescending,
+
+    [EnumMember(Value = "startTimeAscending")]
+    StartTimeAscending, // Currently not used, but adding it for future use
+
+    [EnumMember(Value = "mmrDescending")]
+    MmrDescending,
+
+    [EnumMember(Value = "mmrAscending")]
+    MmrAscending,  // Currently not used, but adding it for future use
+}

--- a/W3ChampionsStatisticService/Matches/MatchRepository.cs
+++ b/W3ChampionsStatisticService/Matches/MatchRepository.cs
@@ -224,7 +224,7 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
     public async Task DeleteOnGoingMatch(Matchup matchup)
     {
         await Delete<OnGoingMatchup>(x => x.MatchId == matchup.MatchId);
-        _cache.Delete(matchup.MatchId);
+        await _cache.Delete(matchup);
     }
 
     public Task<List<OnGoingMatchup>> LoadOnGoingMatches(
@@ -235,7 +235,7 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
         string map = "Overall",
         int minMmr = 0,
         int maxMmr = 3000,
-        string sort = "startTimeDescending")
+        MatchSortMethod sort = MatchSortMethod.StartTimeDescending)
     {
         return _cache.LoadOnGoingMatches(gameMode, gateWay, offset, pageSize, map, minMmr, maxMmr, sort);
     }

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -91,7 +91,7 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
         string map = "Overall",
         int minMmr = 0,
         int maxMmr = 3000,
-        string sort = "startTimeDescending"
+        MatchSortMethod sort = MatchSortMethod.StartTimeDescending
         )
     {
         if (pageSize > 200) pageSize = 200;

--- a/W3ChampionsStatisticService/Matches/OngoingMatchesCache.cs
+++ b/W3ChampionsStatisticService/Matches/OngoingMatchesCache.cs
@@ -1,6 +1,10 @@
-﻿using MongoDB.Driver;
+﻿using Microsoft.AspNetCore.Mvc.TagHelpers.Cache;
+using Microsoft.Extensions.Caching.Memory;
+using MongoDB.Driver;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
 using W3C.Contracts.Matchmaking;
@@ -10,12 +14,73 @@ using W3ChampionsStatisticService.Services;
 
 namespace W3ChampionsStatisticService.Matches;
 
-[Trace]
 public class OngoingMatchesCache(MongoClient mongoClient, TracingService tracingService) : MongoDbRepositoryBase(mongoClient), IOngoingMatchesCache
 {
-    private readonly TracingService _tracingService = tracingService; // Unused for now, will be used in the future
-    private List<OnGoingMatchup> _values = [];
-    private readonly object _lock = new();
+    private readonly TracingService _tracingService = tracingService;
+    private readonly object _dictLock = new();
+    private ConcurrentDictionary<string, OnGoingMatchup> _ongoingMatchesCache = new();
+    private ConcurrentDictionary<string, OnGoingMatchup> _loadOnGoingMatchForPlayerCache = new();
+    // TODO: emit cache metrics
+
+    private MemoryCache _countOngoingMatchesCache = new(new MemoryCacheOptions { SizeLimit = 5000 });
+    private readonly MemoryCacheEntryOptions _countOngoingMatchesCacheOptions = new MemoryCacheEntryOptions
+    {
+        AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(1),
+        Size = 1
+    };
+    private MemoryCache _loadOngoingMatchesCache = new(new MemoryCacheOptions { SizeLimit = 5000 });
+    private readonly MemoryCacheEntryOptions _loadOngoingMatchesCacheOptions = new MemoryCacheEntryOptions
+    {
+        AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(1),
+        Size = 1
+    };
+
+    private bool _cachesInitialized = false;
+
+    public class CacheResult<T>
+    {
+#nullable enable
+        public T? Value { get; set; }
+        public bool IsNegativeCache => Value == null;
+#nullable disable
+    }
+
+    [Trace]
+    private async Task RepopulateCaches()
+    {
+        var mongoCollection = CreateCollection<OnGoingMatchup>();
+
+        // We're creating new dictionaries to avoid locking during population
+        var tempOngoingMatches = new ConcurrentDictionary<string, OnGoingMatchup>();
+        var tempOngoingMatchesForPlayer = new ConcurrentDictionary<string, OnGoingMatchup>();
+
+        await mongoCollection.Find(r => true).ForEachAsync(matchup =>
+        {
+            tempOngoingMatches.TryAdd(matchup.MatchId, matchup);
+            foreach (var playerBattleTag in matchup.Teams.SelectMany(t => t.Players.Select(p => p.BattleTag).Distinct()))
+            {
+                tempOngoingMatchesForPlayer.TryAdd(playerBattleTag, matchup);
+            }
+        });
+
+        lock (_dictLock)
+        {
+            if (!_cachesInitialized)
+            {
+                _ongoingMatchesCache = tempOngoingMatches;
+                _loadOnGoingMatchForPlayerCache = tempOngoingMatchesForPlayer;
+                _cachesInitialized = true;
+            }
+        }
+    }
+
+    private async Task EnsureCachesInitialized()
+    {
+        if (!_cachesInitialized)
+        {
+            await RepopulateCaches();
+        }
+    }
 
     public async Task<long> CountOnGoingMatches(
         GameMode gameMode,
@@ -24,12 +89,31 @@ public class OngoingMatchesCache(MongoClient mongoClient, TracingService tracing
         int minMmr,
         int maxMmr)
     {
-        await UpdateCacheIfNeeded();
-        return _values.Count(m => (gameMode == GameMode.Undefined || m.GameMode == gameMode)
-                                    && (gateWay == GateWay.Undefined || m.GateWay == gateWay)
-                                    && (map == "Overall" || m.Map == map)
-                                    && (minMmr == 0 || !m.Teams.Any(team => team.Players.Any(player => player.OldMmr < minMmr)))
-                                    && (maxMmr == 3000 || !m.Teams.Any(team => team.Players.Any(player => player.OldMmr > maxMmr))));
+        var cacheKey = string.Join("|", gameMode, gateWay, map, minMmr, maxMmr);
+        if (_countOngoingMatchesCache.Get(cacheKey) is CacheResult<long> cachedValue)
+        {
+            if (cachedValue.IsNegativeCache)
+            {
+                return 0L;
+            }
+
+            return cachedValue.Value;
+        }
+
+        return await _tracingService.ExecuteWithSpanAsync(this, async () =>
+        {
+            await EnsureCachesInitialized();
+
+            var count = _ongoingMatchesCache
+            .Count(m => (gameMode == GameMode.Undefined || m.Value.GameMode == gameMode)
+                        && (gateWay == GateWay.Undefined || m.Value.GateWay == gateWay)
+                        && (map == "Overall" || m.Value.Map == map)
+                        && (minMmr == 0 || !m.Value.Teams.Any(team => team.Players.Any(player => player.OldMmr < minMmr)))
+                        && (maxMmr == 3000 || !m.Value.Teams.Any(team => team.Players.Any(player => player.OldMmr > maxMmr))));
+
+            _countOngoingMatchesCache.Set(cacheKey, new CacheResult<long> { Value = count }, _countOngoingMatchesCacheOptions);
+            return count;
+        }, [new("gameMode", gameMode), new("gateWay", gateWay), new("map", map), new("minMmr", minMmr), new("maxMmr", maxMmr)]);
     }
 
     public async Task<List<OnGoingMatchup>> LoadOnGoingMatches(
@@ -40,35 +124,60 @@ public class OngoingMatchesCache(MongoClient mongoClient, TracingService tracing
         string map,
         int minMmr,
         int maxMmr,
-        string sort)
+        MatchSortMethod sort)
     {
-        await UpdateCacheIfNeeded();
-
-        var matches = _values
-            .Where(m => (gameMode == GameMode.Undefined || m.GameMode == gameMode)
-                        && (gateWay == GateWay.Undefined || m.GateWay == gateWay)
-                        && (map == "Overall" || m.Map == map)
-                        && (minMmr == 0 || !m.Teams.Any(team => team.Players.Any(player => player.OldMmr < minMmr)))
-                        && (maxMmr == 3000 || !m.Teams.Any(team => team.Players.Any(player => player.OldMmr > maxMmr))));
-
-        if (sort == "mmrDescending")
+        var cacheKey = string.Join("|", gameMode, gateWay, map, minMmr, maxMmr, sort);
+        IEnumerable<OnGoingMatchup> matches;
+        if (_loadOngoingMatchesCache.Get(cacheKey) is CacheResult<List<OnGoingMatchup>> cachedValue)
         {
-            matches = matches.OrderByDescending(m => GetMaxMmrInMatch(m));
+            if (cachedValue.IsNegativeCache)
+            {
+                return new List<OnGoingMatchup>();
+            }
+
+            matches = cachedValue.Value;
+        }
+        else
+        {
+            return await _tracingService.ExecuteWithSpanAsync(this, async () =>
+            {
+                await EnsureCachesInitialized();
+                matches = _ongoingMatchesCache.Values
+                    .Where(m => (gameMode == GameMode.Undefined || m.GameMode == gameMode)
+                                && (gateWay == GateWay.Undefined || m.GateWay == gateWay)
+                            && (map == "Overall" || m.Map == map)
+                            && (minMmr == 0 || !m.Teams.Any(team => team.Players.Any(player => player.OldMmr < minMmr)))
+                            && (maxMmr == 3000 || !m.Teams.Any(team => team.Players.Any(player => player.OldMmr > maxMmr))));
+
+                matches = sort switch
+                {
+                    MatchSortMethod.MmrAscending => matches.OrderBy(GetMaxMmrInMatch),
+                    MatchSortMethod.MmrDescending => matches.OrderByDescending(GetMaxMmrInMatch),
+                    MatchSortMethod.StartTimeAscending => matches.OrderBy(m => m.StartTime),
+                    MatchSortMethod.StartTimeDescending => matches.OrderByDescending(m => m.StartTime),
+                    _ => throw new ArgumentException($"Invalid sort option: {sort}"),
+                };
+                var matchesList = matches.ToList();
+                matches = matchesList;
+
+                _loadOngoingMatchesCache.Set(cacheKey, new CacheResult<List<OnGoingMatchup>> { Value = matchesList }, _loadOngoingMatchesCacheOptions);
+                return matchesList;
+            }, [new("cacheKey", cacheKey), new("gameMode", gameMode), new("gateWay", gateWay), new("map", map), new("minMmr", minMmr), new("maxMmr", maxMmr), new("sort", sort)]);
         }
 
-        return matches
+        var result = matches
             .Skip(offset)
             .Take(pageSize)
             .ToList();
+
+        return result;
     }
 
-    [NoTrace]
     public int GetMaxMmrInTeam(Team team)
     {
         return team.Players.Max(p => p.OldMmr);
     }
 
-    [NoTrace]
     public int GetMaxMmrInMatch(OnGoingMatchup match)
     {
         return match.Teams.Max(t => GetMaxMmrInTeam(t));
@@ -76,43 +185,38 @@ public class OngoingMatchesCache(MongoClient mongoClient, TracingService tracing
 
     public async Task<OnGoingMatchup> LoadOnGoingMatchForPlayer(string playerId)
     {
-        await UpdateCacheIfNeeded();
-        return _values.FirstOrDefault(m => m.Team1Players != null && m.Team1Players.Contains(playerId)
-                                        || m.Team2Players != null && m.Team2Players.Contains(playerId)
-                                        || m.Team3Players != null && m.Team3Players.Contains(playerId)
-                                        || m.Team4Players != null && m.Team4Players.Contains(playerId));
-    }
+        await EnsureCachesInitialized();
 
-    public void Upsert(OnGoingMatchup matchup)
-    {
-        lock (_lock)
+        if (_loadOnGoingMatchForPlayerCache.TryGetValue(playerId, out var cachedValue))
         {
-            var orderByDescending = _values.Where(m => m.MatchId != matchup.MatchId);
-            _values = orderByDescending.Append(matchup).OrderByDescending(s => s.Id).ToList();
+            return cachedValue;
         }
 
+        return null;
     }
 
-    public void Delete(string matchId)
+    [Trace]
+    public async Task Upsert(OnGoingMatchup matchup)
     {
-        lock (_lock)
+        await EnsureCachesInitialized();
+
+        _ongoingMatchesCache.AddOrUpdate(matchup.MatchId, matchup, (key, oldValue) => matchup);
+        foreach (var playerBattleTag in matchup.Teams.SelectMany(t => t.Players.Select(p => p.BattleTag).Distinct()))
         {
-            _values = _values.Where(m => m.MatchId != matchId).ToList();
+            _loadOnGoingMatchForPlayerCache.AddOrUpdate(playerBattleTag, matchup, (key, oldValue) => matchup);
         }
     }
 
-    [NoTrace]
-    private async Task UpdateCacheIfNeeded()
+    [Trace]
+    public async Task Delete(Matchup matchup)
     {
-        if (_values.Count == 0)
+        await EnsureCachesInitialized();
+
+        foreach (var playerBattleTag in matchup.Teams.SelectMany(t => t.Players.Select(p => p.BattleTag).Distinct()))
         {
-            var mongoCollection = CreateCollection<OnGoingMatchup>();
-            var values = await mongoCollection.Find(r => true).SortByDescending(s => s.Id).ToListAsync();
-            lock (_lock)
-            {
-                _values = values;
-            }
+            _loadOnGoingMatchForPlayerCache.TryRemove(playerBattleTag, out _);
         }
+        _ongoingMatchesCache.TryRemove(matchup.MatchId, out _);
     }
 }
 
@@ -133,9 +237,9 @@ public interface IOngoingMatchesCache
         string map,
         int minMmr,
         int maxMmr,
-        string sort);
+        MatchSortMethod sort);
 
     Task<OnGoingMatchup> LoadOnGoingMatchForPlayer(string playerId);
-    void Upsert(OnGoingMatchup matchup);
-    void Delete(string matchId);
+    Task Upsert(OnGoingMatchup matchup);
+    Task Delete(Matchup matchup);
 }

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -56,7 +56,7 @@ public interface IMatchRepository
         string map = "Overall",
         int minMmr = 0,
         int maxMmr = 3000,
-        string sort = "startTimeDescending");
+        MatchSortMethod sort = MatchSortMethod.StartTimeDescending);
 
     Task<long> CountOnGoingMatches(
         GameMode gameMode = GameMode.Undefined,

--- a/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
@@ -224,7 +224,7 @@ public static class TestDtoHelper
         };
     }
 
-    public static MatchStartedEvent CreateFakeStartedEvent()
+    public static MatchStartedEvent CreateFakeStartedEvent(long startTime = 1000000, int mmr = 2500)
     {
         var fixture = new Fixture { RepeatCount = 4 };
         var fakeEvent = fixture.Build<MatchStartedEvent>().With(e => e.Id, ObjectId.GenerateNewId()).Create();
@@ -239,11 +239,17 @@ public static class TestDtoHelper
         fakeEvent.match.gateway = GateWay.America;
         fakeEvent.match.gameMode = GameMode.GM_2v2_AT;
         fakeEvent.match.season = 0;
+        fakeEvent.match.startTime = startTime;
 
         fakeEvent.match.players[0].battleTag = name1;
         fakeEvent.match.players[1].battleTag = name2;
         fakeEvent.match.players[2].battleTag = name3;
         fakeEvent.match.players[3].battleTag = name4;
+
+        fakeEvent.match.players[0].mmr.rating = mmr;
+        fakeEvent.match.players[1].mmr.rating = mmr;
+        fakeEvent.match.players[2].mmr.rating = mmr;
+        fakeEvent.match.players[3].mmr.rating = mmr;
 
         return fakeEvent;
     }

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -487,7 +487,7 @@ public class MatchupRepoTests : IntegrationTestBase
 
     [Test]
     public async Task Cache_AllOngoingMatches()
-    {  
+    {
         var storedEvent = TestDtoHelper.CreateFakeStartedEvent(500000, 2500);
         await matchRepository.InsertOnGoingMatch(OnGoingMatchup.Create(storedEvent));
 


### PR DESCRIPTION
The current caching solution has various issues that this PR is trying to address:
1. *Non-threadsafe data structure*: The List and Linq constructs we are using are not threadsafe. But we are having concurrent read and write operations on these datastructures which can have non-deterministic outcomes.
2. Re-enumeration on every request*. We are filtering and sorting the data on every single request. Considering point 1, we're amplifying the potential for concurrency issues. Aside from that, it is very inefficient.

This PR introduces two types of caches:
1. **ConcurrentDictionary**: This is basically our database lookup cache with either `MatchId` or `PlayerBattleTag` as key. 
2. **MemoryCache**: This is our query cache which stores the actually computed, filtered and ordered results.

The reason two different cache methods were used (I wanted to only use MemoryCache due to its timeout and cache eviction capabilities) is the fact that `MemoryCache` does not permit access to the values. Hence, we would not be able to do the aggregations we need to do.
On the other hand, I didn't want to only use ConcurrentDictionary as this would've meant that we have to manually maintain the cache lifecycle.

We should, in my opinion, evaluate whether we can't just push this down to a database rather than running all this ourselves - databases are hyper-optimized for exactly this use-case. But that can be a task for the future.

I have added a test for heroes in order to validate that we're properly respecting the cache keys.