### PR TITLE
Exclude fake match finished events from match state validation

### DIFF
--- a/W3ChampionsStatisticService/ReadModelBase/MatchFinishedReadModelHandler.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/MatchFinishedReadModelHandler.cs
@@ -20,7 +20,7 @@ public class MatchFinishedReadModelHandler<T>(
 
     protected override void ValidateMatchState(MatchFinishedEvent matchEvent)
     {
-        if (matchEvent.match.state != EMatchState.FINISHED)
+        if (!matchEvent.WasFakeEvent && matchEvent.match.state != EMatchState.FINISHED)
         {
             throw new InvalidOperationException($"Received match with illegal state {matchEvent.match.state} within the MatchFinishedReadModelHandler");
         }


### PR DESCRIPTION
Fake events did not always have the state properly set, hence excluding them from the state validation. This is in line with the previous implementation; this strict validation is new.