### PR TITLE
Rename OngoingRemovalMatchFinishedHandler stay in line with versioning history

### DIFF
--- a/W3ChampionsStatisticService/Matches/MatchReadModelHandler.cs
+++ b/W3ChampionsStatisticService/Matches/MatchReadModelHandler.cs
@@ -9,7 +9,7 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Matches;
 
 [Trace]
-public class OngoingRemovalMatchFinishedHandler(IMatchRepository matchRepository) : IMatchFinishedReadModelHandler
+public class MatchReadModelHandler(IMatchRepository matchRepository) : IMatchFinishedReadModelHandler
 {
     private readonly IMatchRepository _matchRepository = matchRepository;
 

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -230,7 +230,7 @@ if (startHandlers == "true")
     builder.Services.AddMatchFinishedReadModelService<OverallHeroWinRatePerHeroModelHandler>();
 
     // Ladder Syncs
-    builder.Services.AddMatchFinishedReadModelService<OngoingRemovalMatchFinishedHandler>();
+    builder.Services.AddMatchFinishedReadModelService<MatchReadModelHandler>();
 
     // On going matches
     builder.Services.AddUnversionedReadModelService<StartedMatchIntoOngoingMatchesHandler>();

--- a/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchFinishedReadModelHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchFinishedReadModelHandlerTests.cs
@@ -35,10 +35,10 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
 
         var versionRepository = new VersionRepository(MongoClient);
 
-        var handler = new MatchFinishedReadModelHandler<OngoingRemovalMatchFinishedHandler>(
+        var handler = new MatchFinishedReadModelHandler<MatchReadModelHandler>(
             mockEvents.Object,
             versionRepository,
-            new OngoingRemovalMatchFinishedHandler(mockMatchRepo.Object),
+            new MatchReadModelHandler(mockMatchRepo.Object),
             mockTrackingService.Object);
 
         await handler.Update();
@@ -63,10 +63,10 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
 
         var versionRepository = new VersionRepository(MongoClient);
 
-        var handler = new MatchFinishedReadModelHandler<OngoingRemovalMatchFinishedHandler>(
+        var handler = new MatchFinishedReadModelHandler<MatchReadModelHandler>(
             mockEvents.Object,
             versionRepository,
-            new OngoingRemovalMatchFinishedHandler(mockMatchRepo.Object),
+            new MatchReadModelHandler(mockMatchRepo.Object),
             mockTrackingService.Object);
 
         Assert.ThrowsAsync<InvalidOperationException>(() => handler.Update());
@@ -117,15 +117,15 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
         var matchRepository = new MatchRepository(MongoClient, new OngoingMatchesCache(MongoClient, mockTracingService.Object));
         var versionRepository = new VersionRepository(MongoClient);
 
-        var handler = new MatchFinishedReadModelHandler<OngoingRemovalMatchFinishedHandler>(
+        var handler = new MatchFinishedReadModelHandler<MatchReadModelHandler>(
             new MatchEventRepository(MongoClient),
             versionRepository,
-            new OngoingRemovalMatchFinishedHandler(matchRepository),
+            new MatchReadModelHandler(matchRepository),
             mockTrackingService.Object);
 
         await handler.Update();
 
-        var version = await versionRepository.GetLastVersion<OngoingRemovalMatchFinishedHandler>();
+        var version = await versionRepository.GetLastVersion<MatchReadModelHandler>();
 
         var matches = await matchRepository.Load(1, GameMode.GM_1v1);
 


### PR DESCRIPTION
Since we derive the handler name for versioning directly from the class name, rename `OngoingRemovalMatchFinishedHandler` back to `MatchReadModelHandler`