### PR TITLE
Read ongoing match from the correct table during canceled game cleanup

### DIFF
--- a/W3ChampionsStatisticService/Matches/MatchRepository.cs
+++ b/W3ChampionsStatisticService/Matches/MatchRepository.cs
@@ -98,7 +98,7 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
             && (m.Season == season));
     }
 
-    public async Task<MatchupDetail> LoadDetails(ObjectId id)
+    public async Task<MatchupDetail> LoadFinishedMatchDetails(ObjectId id)
     {
         var originalMatch = await LoadFirst<MatchFinishedEvent>(t => t.Id == id);
         var match = await LoadFirst<Matchup>(t => t.Id == id);
@@ -110,7 +110,7 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
         };
     }
 
-    public async Task<MatchupDetail> LoadDetailsByOngoingMatchId(string id)
+    public async Task<MatchupDetail> LoadFinishedMatchDetailsByMatchId(string id)
     {
         var originalMatch = await LoadFirst<MatchFinishedEvent>(t => t.match.id == id);
         var match = await LoadFirst<Matchup>(t => t.MatchId == id);
@@ -122,8 +122,9 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
         };
     }
 
-    public async Task<MatchFinishedEvent> LoadDetailsByGameName(string gameName)
+    public async Task<MatchFinishedEvent> LoadMatchFinishedEventByGameName(string gameName)
     {
+        // TODO: Check how frequently this is called as this is not covered by an index.
         return await LoadFirst<MatchFinishedEvent>(t => t.match.gamename == gameName);
     }
 
@@ -202,6 +203,11 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
         return Upsert(matchup, m => m.MatchId == matchup.MatchId);
     }
 
+    public Task<OnGoingMatchup> LoadOnGoingMatchByMatchId(string matchId)
+    {
+        var mongoCollection = CreateCollection<OnGoingMatchup>();
+        return mongoCollection.Find(m => m.MatchId == matchId).FirstOrDefaultAsync();
+    }
 
     public Task<OnGoingMatchup> LoadOnGoingMatchForPlayer(string playerId)
     {

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -43,14 +43,14 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
     [HttpGet("{id}")]
     public async Task<IActionResult> GetMatchDetails(string id)
     {
-        var match = await _matchRepository.LoadDetails(new ObjectId(id));
+        var match = await _matchRepository.LoadFinishedMatchDetails(new ObjectId(id));
         return Ok(match);
     }
 
     [HttpGet("gameName/{gameName}")]
     public async Task<IActionResult> GetMatchIdFromGameName(string gameName)
     {
-        var match = await _matchRepository.LoadDetailsByGameName(gameName);
+        var match = await _matchRepository.LoadMatchFinishedEventByGameName(gameName);
         if (match == null) return NotFound();
         return Ok(match.Id.ToString());
     }
@@ -58,7 +58,7 @@ public class MatchesController(IMatchRepository matchRepository, MatchQueryHandl
     [HttpGet("by-ongoing-match-id/{id}")]
     public async Task<IActionResult> GetMatchDetailsByOngoingMatchId(string id)
     {
-        var match = await _matchRepository.LoadDetailsByOngoingMatchId(id);
+        var match = await _matchRepository.LoadFinishedMatchDetailsByMatchId(id);
         return Ok(match);
     }
 

--- a/W3ChampionsStatisticService/Matches/OngoingRemovalMatchCanceledHandler.cs
+++ b/W3ChampionsStatisticService/Matches/OngoingRemovalMatchCanceledHandler.cs
@@ -16,7 +16,7 @@ public class OngoingRemovalMatchCanceledHandler(IMatchRepository matchRepository
 
     public async Task Update(MatchCanceledEvent nextEvent)
     {
-        var ongoingMatch = await _matchRepository.LoadDetailsByOngoingMatchId(nextEvent.match.id);
+        var ongoingMatch = await _matchRepository.LoadOnGoingMatchByMatchId(nextEvent.match.id);
 
         if (ongoingMatch == null)
         {
@@ -27,15 +27,7 @@ public class OngoingRemovalMatchCanceledHandler(IMatchRepository matchRepository
             return;
         }
 
-        if (ongoingMatch.Match != null)
-        {
-            Log.Information($"Canceling ongoing match {ongoingMatch.Match.Id}");
-            await _matchRepository.DeleteOnGoingMatch(ongoingMatch.Match);
-        }
-        else
-        {
-            Log.Warning($"Canceled match detail had null Match property for {nextEvent.match.id}");
-            await _matchRepository.DeleteOnGoingMatch(new Matchup { MatchId = nextEvent.match.id });
-        }
+        Log.Information($"Canceling ongoing match {ongoingMatch.MatchId} ({ongoingMatch.Id})");
+        await _matchRepository.DeleteOnGoingMatch(ongoingMatch);
     }
 }

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -39,11 +39,12 @@ public interface IMatchRepository
         Race opponentRace = Race.Total,
         int season = 1);
 
-    Task<MatchupDetail> LoadDetails(ObjectId id);
-    Task<MatchupDetail> LoadDetailsByOngoingMatchId(string id);
-    Task<MatchFinishedEvent> LoadDetailsByGameName(string gameName);
+    Task<MatchupDetail> LoadFinishedMatchDetails(ObjectId id);
+    Task<MatchupDetail> LoadFinishedMatchDetailsByMatchId(string id);
+    Task<MatchFinishedEvent> LoadMatchFinishedEventByGameName(string gameName);
 
     Task InsertOnGoingMatch(OnGoingMatchup matchup);
+    Task<OnGoingMatchup> LoadOnGoingMatchByMatchId(string matchId);
     Task<OnGoingMatchup> LoadOnGoingMatchForPlayer(string playerId);
     Task<OnGoingMatchup> TryLoadOnGoingMatchForPlayer(string playerId);
     Task DeleteOnGoingMatch(Matchup matchup);

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupDetailTest.cs
@@ -29,7 +29,7 @@ public class MatchupDetailTests : IntegrationTestBase
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
-        var result = await matchRepository.LoadDetails(matchFinishedEvent.Id);
+        var result = await matchRepository.LoadFinishedMatchDetails(matchFinishedEvent.Id);
         Assert.AreEqual("nmhcCLaRc7", result.Match.MatchId);
     }
 
@@ -46,7 +46,7 @@ public class MatchupDetailTests : IntegrationTestBase
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
-        var result = await matchRepository.LoadDetails(matchFinishedEvent.Id);
+        var result = await matchRepository.LoadFinishedMatchDetails(matchFinishedEvent.Id);
 
         Assert.AreEqual("nmhcCLaRc7", result.Match.MatchId);
         Assert.AreEqual("archmage", result.PlayerScores[0].Heroes[0].Icon);
@@ -68,7 +68,7 @@ public class MatchupDetailTests : IntegrationTestBase
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
-        var result = await matchRepository.LoadDetails(matchFinishedEvent.Id);
+        var result = await matchRepository.LoadFinishedMatchDetails(matchFinishedEvent.Id);
 
         Assert.AreEqual("nmhcCLaRc7", result.Match.MatchId);
         Assert.AreEqual(Race.RnD, result.Match.Teams[0].Players[0].Race);
@@ -92,7 +92,7 @@ public class MatchupDetailTests : IntegrationTestBase
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
-        var result = await matchRepository.LoadDetails(matchFinishedEvent.Id);
+        var result = await matchRepository.LoadFinishedMatchDetails(matchFinishedEvent.Id);
 
         Assert.AreEqual("nmhcCLaRc7", result.Match.MatchId);
         Assert.AreEqual(Race.HU, result.Match.Teams[0].Players[0].Race);
@@ -116,7 +116,7 @@ public class MatchupDetailTests : IntegrationTestBase
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent));
 
-        var result = await matchRepository.LoadDetails(matchFinishedEvent.Id);
+        var result = await matchRepository.LoadFinishedMatchDetails(matchFinishedEvent.Id);
 
         Assert.AreEqual("nmhcCLaRc7", result.Match.MatchId);
         Assert.AreEqual(Race.RnD, result.Match.Teams[0].Players.Find(p => p.BattleTag == player.battleTag).Race);

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -480,7 +480,7 @@ public class MatchupRepoTests : IntegrationTestBase
 
         await matchRepository.Insert(Matchup.Create(matchFinishedEvent1));
 
-        var result = await matchRepository.LoadDetails(matchFinishedEvent1.Id);
+        var result = await matchRepository.LoadFinishedMatchDetails(matchFinishedEvent1.Id);
 
         Assert.AreEqual("archmage", result.PlayerScores[0].Heroes[0].Icon);
     }

--- a/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchCanceledReadModelHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchCanceledReadModelHandlerTests.cs
@@ -26,7 +26,7 @@ public class MatchCanceledReadModelHandlerTests : IntegrationTestBase
             .ReturnsAsync(new List<MatchCanceledEvent>());
 
         var mockMatchRepo = new Mock<IMatchRepository>();
-        mockMatchRepo.Setup(m => m.LoadDetailsByOngoingMatchId(It.IsAny<string>())).ReturnsAsync(new MatchupDetail());
+        mockMatchRepo.Setup(m => m.LoadOnGoingMatchByMatchId(It.IsAny<string>())).ReturnsAsync(new OnGoingMatchup());
 
         var versionRepository = new VersionRepository(MongoClient);
         var trackingService = TestDtoHelper.CreateMockTrackingService();
@@ -52,7 +52,7 @@ public class MatchCanceledReadModelHandlerTests : IntegrationTestBase
             .ReturnsAsync(new List<MatchCanceledEvent>());
 
         var mockMatchRepo = new Mock<IMatchRepository>();
-        mockMatchRepo.Setup(m => m.LoadDetailsByOngoingMatchId(It.IsAny<string>())).ReturnsAsync((MatchupDetail)null);
+        mockMatchRepo.Setup(m => m.LoadOnGoingMatchByMatchId(It.IsAny<string>())).ReturnsAsync((OnGoingMatchup)null);
 
         var versionRepository = new VersionRepository(MongoClient);
         var trackingService = TestDtoHelper.CreateMockTrackingService();


### PR DESCRIPTION
The existing functions were quite confusingly named, hence renamed them in order to clearly indicate their data source.