### PR TITLE
Fix null pointer exception for player quantiles when the player is not ranked.

### DIFF
--- a/W3ChampionsStatisticService/Services/PlayerService.cs
+++ b/W3ChampionsStatisticService/Services/PlayerService.cs
@@ -24,18 +24,16 @@ public class PlayerService(IPlayerRepository playerRepository, ICachedDataProvid
     {
         var seasonRanks =
             await _mmrCachedDataProvider.GetCachedOrRequestAsync(async () => await FetchMmrRanks(season), season.ToString());
-        var gatewayGameModeRanks = seasonRanks.First(x => x.Gateway == gateWay && x.GameMode == gameMode);
-
         var rankKey = GetRankKey(playerIds, gameMode, race);
-        if (gatewayGameModeRanks.Ranks.ContainsKey(rankKey))
-        {
-            var foundRank = gatewayGameModeRanks.Ranks[rankKey];
+        var gatewayGameModeRanks = seasonRanks.FirstOrDefault(x => x.Gateway == gateWay && x.GameMode == gameMode);
 
-            var numberOfPlayersAfter = gatewayGameModeRanks.Ranks.Count - foundRank.Rank;
-            return numberOfPlayersAfter / (float)gatewayGameModeRanks.Ranks.Count;
+        if (gatewayGameModeRanks == null || !gatewayGameModeRanks.Ranks.TryGetValue(rankKey, out PlayerMmrRank foundRank))
+        {
+            return null;
         }
 
-        return null;
+        var numberOfPlayersAfter = gatewayGameModeRanks.Ranks.Count - foundRank.Rank;
+        return numberOfPlayersAfter / (float)gatewayGameModeRanks.Ranks.Count;
     }
 
     private async Task<List<MmrRank>> FetchMmrRanks(int season)


### PR DESCRIPTION
For unranked players, we are erroring out on missing data due to the usage of `First` instead of `FirstOrDefault`.