### PR TITLE
Make DateTimeOffset backwards compatible

### DIFF
--- a/W3C.Domain/Repositories/MongoDbRepositoryBase.cs
+++ b/W3C.Domain/Repositories/MongoDbRepositoryBase.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver;
 using W3C.Domain.Tracing;
 
@@ -120,5 +122,6 @@ public interface IIdentifiable
 
 public interface IVersionable
 {
+    [BsonRepresentation(BsonType.Array)]
     public DateTimeOffset LastUpdated { get; set; }
 }

--- a/W3ChampionsStatisticService/Clans/ClanMembership.cs
+++ b/W3ChampionsStatisticService/Clans/ClanMembership.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 using W3C.Domain.Repositories;
 using W3C.Domain.Tracing;
 
@@ -13,6 +15,8 @@ public class ClanMembership : IIdentifiable, IVersionable
     public string ClanId { get; set; }
     public string PendingInviteFromClan { get; set; }
     public string ClanName { get; set; }
+
+    [BsonRepresentation(BsonType.Array)]
     public DateTimeOffset LastUpdated { get; set; }
 
     [JsonIgnore]

--- a/W3ChampionsStatisticService/Matches/Matchup.cs
+++ b/W3ChampionsStatisticService/Matches/Matchup.cs
@@ -9,6 +9,7 @@ using W3C.Domain.MatchmakingService;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.GameModes;
 using W3C.Domain.Tracing;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace W3ChampionsStatisticService.Matches;
 
@@ -32,7 +33,11 @@ public class Matchup
     [JsonIgnore]
     public TimeSpan Duration { get; set; }
     public long DurationInSeconds => (long)Duration.TotalSeconds;
+
+    [BsonRepresentation(BsonType.Array)]
     public DateTimeOffset StartTime { get; set; }
+
+    [BsonRepresentation(BsonType.Array)]
     public DateTimeOffset EndTime { get; set; }
     public GameMode GameMode { get; set; }
     public IList<Team> Teams { get; set; } = new List<Team>();

--- a/W3ChampionsStatisticService/PersonalSettings/PersonalSetting.cs
+++ b/W3ChampionsStatisticService/PersonalSettings/PersonalSetting.cs
@@ -8,6 +8,7 @@ using W3C.Domain.CommonValueObjects;
 using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.PlayerProfiles;
 using W3C.Domain.Tracing;
+using MongoDB.Bson;
 
 namespace W3ChampionsStatisticService.PersonalSettings;
 
@@ -135,6 +136,7 @@ public class PersonalSetting : IVersionable, IIdentifiable
         AliasSettings = dto.AliasSettings;
     }
 
+    [BsonRepresentation(BsonType.Array)]
     public DateTimeOffset LastUpdated { get; set; }
 
     [BsonIgnore]

--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/RankProgression.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/RankProgression.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Text.Json.Serialization;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
 
@@ -16,6 +18,7 @@ public class RankProgression
     }
 
     [JsonIgnore]
+    [BsonRepresentation(BsonType.Array)]
     public DateTimeOffset Date { get; set; }
     public double RankingPoints { get; set; }
     public double MMR { get; set; }

--- a/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrRpTimeline.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrRpTimeline.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.Repositories;
@@ -96,6 +98,8 @@ public class MmrRpAtDate(int mmr, double? rp, DateTimeOffset date) : IComparable
 {
     public int Mmr { get; set; } = mmr;
     public double? Rp { get; set; } = rp;
+
+    [BsonRepresentation(BsonType.Array)]
     public DateTimeOffset Date { get; set; } = date;
 
     public Boolean HasSameYearMonthDayAs(MmrRpAtDate mRAT2)

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
@@ -10,6 +10,8 @@ using W3ChampionsStatisticService.WebApi.ActionFilters;
 using W3ChampionsStatisticService.Services;
 using W3C.Contracts.GameObjects;
 using W3C.Domain.Tracing;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 namespace W3ChampionsStatisticService.PlayerProfiles;
 
 [ApiController]
@@ -178,6 +180,7 @@ public class PlayersController(
 
 public class ProfilePictureDto(DateTimeOffset lastUpdated, ProfilePicture profilePicture)
 {
+    [BsonRepresentation(BsonType.Array)]
     public DateTimeOffset LastUpdated { get; } = lastUpdated;
     public ProfilePicture ProfilePicture { get; } = profilePicture;
 }
@@ -186,6 +189,8 @@ public class ClanMemberhipDto(string battleTag, string clanId, in DateTimeOffset
 {
     public string BattleTag { get; } = battleTag;
     public string ClanId { get; } = clanId;
+
+    [BsonRepresentation(BsonType.Array)]
     public DateTimeOffset LastUpdated { get; } = lastUpdated;
 }
 

--- a/W3ChampionsStatisticService/W3ChampionsStats/DistinctPlayersPerDays/DistinctPlayersPerDay.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/DistinctPlayersPerDays/DistinctPlayersPerDay.cs
@@ -2,11 +2,15 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using W3C.Domain.Repositories;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.DistinctPlayersPerDays;
 
 public class DistinctPlayersPerDay : IIdentifiable
 {
+    [BsonRepresentation(BsonType.Array)]
     public DateTimeOffset Date { get; set; }
     public long DistinctPlayers => Players.Count;
     [JsonIgnore]

--- a/W3ChampionsStatisticService/W3ChampionsStats/GamesPerDays/GamesPerDay.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/GamesPerDays/GamesPerDay.cs
@@ -1,4 +1,6 @@
 using System;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.Repositories;
 
@@ -6,6 +8,7 @@ namespace W3ChampionsStatisticService.W3ChampionsStats.GamesPerDays;
 
 public class GamesPerDay : IIdentifiable
 {
+    [BsonRepresentation(BsonType.Array)]
     public DateTimeOffset Date { get; set; }
     public long GamesPlayed { get; set; }
     public string Id => $"{GateWay}_{GameMode}_{Date:yyyy-MM-dd}";


### PR DESCRIPTION
Address this from the migration guide:
> By default, the driver serializes DateTimeOffset values as BSON documents. In previous versions of the driver, the driver serialized these values as BSON arrays by default. To serialize a DateTimeOffset value as an array in v3.0, apply the [BsonRepresentation(BsonType.Array)] attribute to the field.