### PR TITLE
Treat missing endTime as 0

### DIFF
--- a/W3C.Domain/MatchmakingService/MatchEventDtos.cs
+++ b/W3C.Domain/MatchmakingService/MatchEventDtos.cs
@@ -115,6 +115,7 @@ public class Match : IMatchServerInfo
     [BsonElement("_id")]
     public string id { get; set; }
     public int? floGameId { get; set; }
+    [BsonDefaultValue(0)]
     public long endTime { get; set; }
     public List<IMatchPlayerServerInfo> PlayersServerInfo
     {


### PR DESCRIPTION
Classic case of serialization issues when working across programming languages. For CanceledMatches, the endTime in matchmaking-service is set to 0. Javascript serializes 0 to null. C# does not serialize null to 0. Hence setting the default to 0

matchmaking-service:
![image](https://github.com/user-attachments/assets/f8a6c1b3-aaaf-4a28-8821-f97505f814cc)

website-backend:
![image](https://github.com/user-attachments/assets/9175c955-e30e-4e34-b9bd-db71e9dda300)
