### PR TITLE
Reapply "Add risk europe ladder (#416)" (#417)

### DIFF
--- a/W3C.Contracts/Matchmaking/GameMode.cs
+++ b/W3C.Contracts/Matchmaking/GameMode.cs
@@ -48,4 +48,6 @@ public enum GameMode
 
     GM_CF = 1301,
     GM_CF_AT = 1302,
+
+    GM_RISK_EUROPE = 1401,
 }


### PR DESCRIPTION
This reverts commit 96bedb938c1091c54c71d58132f5e144582c94b6.

With https://github.com/w3champions/website-backend/pull/420 in place, we can now safely add new game modes to the enum without it showing up anywhere unless the mode is active.