### PR TITLE
Rewrite basic auth for metrics endpoint

### DIFF
--- a/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
+++ b/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <ItemGroup>
     <PackageReference Include="Aliyun.OSS.SDK.NetCore" />
-    <PackageReference Include="AspNetCore.Authentication.Basic" />
     <PackageReference Include="AWSSDK.S3" />
     <PackageReference Include="Castle.Core" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />

--- a/W3ChampionsStatisticService/WebApi/Authorization/BasicAuthConfiguration.cs
+++ b/W3ChampionsStatisticService/WebApi/Authorization/BasicAuthConfiguration.cs
@@ -1,6 +1,9 @@
-using AspNetCore.Authentication.Basic;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Security.Claims;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace W3ChampionsStatisticService.WebApi.Authorization;
@@ -8,49 +11,76 @@ namespace W3ChampionsStatisticService.WebApi.Authorization;
 public static class BasicAuthConfiguration
 {
     public const string ReadMetricsPolicy = "ReadMetrics";
-    public const string BasicAuthScheme = "BasicAuthentication";
 
     public static IServiceCollection AddBasicAuthForMetrics(this IServiceCollection services)
     {
-        // Get credentials from environment variables or fallback to defaults
-        string username = Environment.GetEnvironmentVariable("METRICS_ENDPOINT_AUTH_USERNAME") ?? "admin";
-        string password = Environment.GetEnvironmentVariable("METRICS_ENDPOINT_AUTH_PASSWORD") ?? "admin";
-
-        // Add BasicAuth as a named scheme, not the default
-        services.AddAuthentication()
-            .AddBasic(BasicAuthScheme, options =>
-            {
-                options.Realm = "W3Champions Metrics";
-                options.Events = new BasicEvents
-                {
-                    OnValidateCredentials = (context) =>
-                    {
-                        if (context.Username == username && context.Password == password)
-                        {
-                            var claims = new[] { new System.Security.Claims.Claim("role", "MetricsReader") };
-                            context.Principal = new System.Security.Claims.ClaimsPrincipal(
-                                new System.Security.Claims.ClaimsIdentity(claims, context.Scheme.Name));
-                            context.Success();
-                        }
-                        else
-                        {
-                            context.Fail("Invalid username or password");
-                        }
-                        return Task.CompletedTask;
-                    }
-                };
-            });
-
-        // Add authorization policy for metrics that requires the BasicAuth scheme
+        // Add authorization policy for metrics
         services.AddAuthorization(options =>
         {
             options.AddPolicy(ReadMetricsPolicy, policy =>
             {
-                policy.RequireAuthenticatedUser();
-                policy.AddAuthenticationSchemes(BasicAuthScheme);
+                policy.Requirements.Add(new MetricsBasicAuthRequirement());
             });
         });
 
+        services.AddSingleton<IAuthorizationHandler, MetricsBasicAuthHandler>();
+
         return services;
+    }
+}
+
+public class MetricsBasicAuthRequirement : IAuthorizationRequirement
+{
+}
+
+public class MetricsBasicAuthHandler : AuthorizationHandler<MetricsBasicAuthRequirement>
+{
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, MetricsBasicAuthRequirement requirement)
+    {
+        if (context.Resource is HttpContext httpContext)
+        {
+            // Get credentials from environment variables or fallback to defaults
+            string expectedUsername = Environment.GetEnvironmentVariable("METRICS_ENDPOINT_AUTH_USERNAME") ?? "admin";
+            string expectedPassword = Environment.GetEnvironmentVariable("METRICS_ENDPOINT_AUTH_PASSWORD") ?? "admin";
+
+            var authHeader = httpContext.Request.Headers["Authorization"].ToString();
+            
+            if (string.IsNullOrEmpty(authHeader) || !authHeader.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+            {
+                // No Basic auth header, fail silently without logging warnings about Bearer tokens
+                context.Fail();
+                return Task.CompletedTask;
+            }
+
+            try
+            {
+                var encodedCredentials = authHeader.Substring("Basic ".Length).Trim();
+                var decodedCredentials = Encoding.UTF8.GetString(Convert.FromBase64String(encodedCredentials));
+                var credentials = decodedCredentials.Split(':', 2);
+
+                if (credentials.Length == 2 && credentials[0] == expectedUsername && credentials[1] == expectedPassword)
+                {
+                    // Create and set the user principal on the HttpContext
+                    var claims = new[] { new Claim("role", "MetricsReader") };
+                    var identity = new ClaimsIdentity(claims, "BasicAuthentication");
+                    httpContext.User = new ClaimsPrincipal(identity);
+                    context.Succeed(requirement);
+                }
+                else
+                {
+                    context.Fail();
+                }
+            }
+            catch
+            {
+                context.Fail();
+            }
+        }
+        else
+        {
+            context.Fail();
+        }
+
+        return Task.CompletedTask;
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Auth/BasicAuthTest.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Auth/BasicAuthTest.cs
@@ -1,0 +1,135 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using System;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using W3ChampionsStatisticService.WebApi.Authorization;
+
+namespace WC3ChampionsStatisticService.Tests.Auth;
+
+[TestFixture]
+public class BasicAuthTest
+{
+    private MetricsBasicAuthHandler _handler;
+    private MetricsBasicAuthRequirement _requirement;
+
+    [SetUp]
+    public void Setup()
+    {
+        _handler = new MetricsBasicAuthHandler();
+        _requirement = new MetricsBasicAuthRequirement();
+    }
+
+    [Test]
+    public async Task BasicAuth_ValidCredentials_Success()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes("admin:admin"));
+        httpContext.Request.Headers["Authorization"] = $"Basic {credentials}";
+
+        var context = new AuthorizationHandlerContext(
+            new[] { _requirement },
+            new ClaimsPrincipal(),
+            httpContext);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.IsTrue(context.HasSucceeded);
+        Assert.IsTrue(httpContext.User.Identity.IsAuthenticated);
+        Assert.AreEqual("BasicAuthentication", httpContext.User.Identity.AuthenticationType);
+    }
+
+    [Test]
+    public async Task BasicAuth_InvalidCredentials_Failure()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes("wrong:password"));
+        httpContext.Request.Headers["Authorization"] = $"Basic {credentials}";
+
+        var context = new AuthorizationHandlerContext(
+            new[] { _requirement },
+            new ClaimsPrincipal(),
+            httpContext);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.IsFalse(context.HasSucceeded);
+        Assert.IsFalse(httpContext.User.Identity.IsAuthenticated);
+    }
+
+    [Test]
+    public async Task BasicAuth_BearerToken_FailsSilently()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Authorization"] = "Bearer some-jwt-token";
+
+        var context = new AuthorizationHandlerContext(
+            new[] { _requirement },
+            new ClaimsPrincipal(),
+            httpContext);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.IsFalse(context.HasSucceeded);
+        Assert.IsFalse(httpContext.User.Identity.IsAuthenticated);
+        // This should fail silently without logging warnings about Bearer tokens
+    }
+
+    [Test]
+    public async Task BasicAuth_NoAuthHeader_Failure()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+
+        var context = new AuthorizationHandlerContext(
+            new[] { _requirement },
+            new ClaimsPrincipal(),
+            httpContext);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.IsFalse(context.HasSucceeded);
+        Assert.IsFalse(httpContext.User.Identity.IsAuthenticated);
+    }
+
+    [Test]
+    public async Task BasicAuth_CustomCredentials_Success()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("METRICS_ENDPOINT_AUTH_USERNAME", "testuser");
+        Environment.SetEnvironmentVariable("METRICS_ENDPOINT_AUTH_PASSWORD", "testpass");
+
+        var httpContext = new DefaultHttpContext();
+        var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes("testuser:testpass"));
+        httpContext.Request.Headers["Authorization"] = $"Basic {credentials}";
+
+        var context = new AuthorizationHandlerContext(
+            new[] { _requirement },
+            new ClaimsPrincipal(),
+            httpContext);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.IsTrue(context.HasSucceeded);
+        Assert.IsTrue(httpContext.User.Identity.IsAuthenticated);
+
+        // Cleanup
+        Environment.SetEnvironmentVariable("METRICS_ENDPOINT_AUTH_USERNAME", null);
+        Environment.SetEnvironmentVariable("METRICS_ENDPOINT_AUTH_PASSWORD", null);
+    }
+} 


### PR DESCRIPTION
Rewrites the metrics auth to fix the `Authorization' header found but the scheme is not a 'Basic' scheme.` error that's spamming the logs