### PR TITLE
Supress basic schema log

### DIFF
--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -81,6 +81,7 @@ Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
     .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
     .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+    .MinimumLevel.Override("AspNetCore.Authentication.Basic.BasicHandler", LogEventLevel.Warning) // Temporarily filter out the Basic auth schema log. We should add central JWT though.
     .MinimumLevel.Override("System.Net.Http.HttpClient", LogEventLevel.Warning) // Filter out verbose HTTP client logs
     .MinimumLevel.Override("System.Net.Http", LogEventLevel.Warning) // Filter out verbose System.Net.Http logs
     .WriteTo.Console(new JsonFormatter(), restrictedToMinimumLevel: LogEventLevel.Information) // Write to Console to allow log scraping


### PR DESCRIPTION
We currently have a lot of these logs:

> 'Authorization' header found but the scheme is not a 'Basic' scheme."

The root cause is that because I added authentication for BasicAuth and we are running JWT via a custom method rather than a middleware, the basicauth middleware complains because it detects no other handler to handle the authorization header.

We should move JWT into the middleware. For now, we silence the logs though.