### PR TITLE
Skip processing match for mmr rp timeline if the player was in AT

### DIFF
--- a/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrRpTimelineHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerMmrRpTimelineHandler.cs
@@ -18,7 +18,7 @@ public class PlayerMmrRpTimelineHandler(IPlayerRepository playerRepository) : IM
 
         foreach (var player in match.players)
         {
-            if (player.updatedMmr == null || match.endTime == 0) { return; }
+            if (player.IsAt || player.updatedMmr == null || match.endTime == 0) { continue; }
             var mmrRpTimeline = await _playerRepository.LoadPlayerMmrRpTimeline(player.battleTag, player.race, match.gateway, match.season, match.gameMode)
                         ?? new PlayerMmrRpTimeline(player.battleTag, player.race, match.gateway, match.season, match.gameMode);
             mmrRpTimeline.UpdateTimeline(new MmrRpAtDate(


### PR DESCRIPTION
Prevent this:
![image](https://github.com/user-attachments/assets/46e40bd9-df19-4a1c-be28-030bf4ec6f64)

Also used continue instead of return - no need to abort the entire loop - doesn't hurt to do it like this.