### PR TITLE
Enhance MatchRepository Insert Method and GameLengthStat Handling

### DIFF
--- a/W3ChampionsStatisticService/Matches/MatchRepository.cs
+++ b/W3ChampionsStatisticService/Matches/MatchRepository.cs
@@ -23,9 +23,32 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
 {
     private readonly IOngoingMatchesCache _cache = cache;
 
-    public Task Insert(Matchup matchup)
+    public async Task Insert(Matchup matchup)
     {
-        return Upsert(matchup, m => m.MatchId == matchup.MatchId);
+        try
+        {
+            // Clear the Id to let MongoDB assign it for new documents, or it will be set by the upsert if document exists
+            matchup.Id = ObjectId.Empty;
+            await Upsert(matchup, m => m.MatchId == matchup.MatchId);
+        }
+        catch (MongoCommandException ex) when (ex.Message.Contains("immutable") && ex.Message.Contains("_id"))
+        {
+            Log.Warning("MongoDB _id modification error for match {MatchId}. This should not happen with ObjectId.Empty. Investigating...", matchup.MatchId);
+            
+            // This shouldn't happen if we set Id to Empty, but if it does, let's handle it
+            var existingMatch = await LoadFirst<Matchup>(m => m.MatchId == matchup.MatchId);
+            if (existingMatch != null)
+            {
+                Log.Information("Found existing match {MatchId} with different _id. Document already exists, operation should be idempotent.", matchup.MatchId);
+                // Match already exists, this is effectively a no-op which is what we want
+                return;
+            }
+            else
+            {
+                Log.Error("No existing match found for {MatchId} but got _id immutable error. This indicates a MongoDB driver issue.", matchup.MatchId);
+                throw;
+            }
+        }
     }
 
     public async Task<List<Matchup>> LoadFor(

--- a/W3ChampionsStatisticService/Matches/MatchRepository.cs
+++ b/W3ChampionsStatisticService/Matches/MatchRepository.cs
@@ -34,7 +34,7 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
         catch (MongoCommandException ex) when (ex.Message.Contains("immutable") && ex.Message.Contains("_id"))
         {
             Log.Warning("MongoDB _id modification error for match {MatchId}. This should not happen with ObjectId.Empty. Investigating...", matchup.MatchId);
-            
+
             // This shouldn't happen if we set Id to Empty, but if it does, let's handle it
             var existingMatch = await LoadFirst<Matchup>(m => m.MatchId == matchup.MatchId);
             if (existingMatch != null)

--- a/W3ChampionsStatisticService/W3ChampionsStats/GameLengths/GameLengthStat.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/GameLengths/GameLengthStat.cs
@@ -14,7 +14,17 @@ public class GameLengthStat : IIdentifiable
 
     public void Record(TimeSpan duration)
     {
+        if (duration.TotalSeconds <= 0)
+        {
+            return;
+        }
+
         var gameLengths = Lengths.Where(m => m.Seconds < duration.TotalSeconds);
+        if (!gameLengths.Any())
+        {
+            return;
+        }
+
         var ordered = gameLengths.OrderBy(m => m.Seconds);
         var gameLength = ordered.Last();
         gameLength.AddGame();

--- a/W3ChampionsStatisticService/W3ChampionsStats/GameLengths/GameLengthStatHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/GameLengths/GameLengthStatHandler.cs
@@ -18,7 +18,7 @@ public class GameLengthStatHandler(IW3StatsRepo w3Stats) : IMatchFinishedReadMod
     public async Task Update(MatchFinishedEvent nextEvent)
     {
         if (nextEvent.WasFakeEvent) return;
-        
+
         GameMode mode = nextEvent.match.gameMode;
         var stat = await _w3Stats.LoadGameLengths(mode) ?? GameLengthStat.Create(mode);
         var endTime = DateTimeOffset.FromUnixTimeMilliseconds(nextEvent.match.endTime);
@@ -27,7 +27,7 @@ public class GameLengthStatHandler(IW3StatsRepo w3Stats) : IMatchFinishedReadMod
 
         if (duration.TotalSeconds <= 0)
         {
-            Log.Debug("Skipping game length recording for match {MatchId} with zero or negative duration: {Duration} seconds", 
+            Log.Debug("Skipping game length recording for match {MatchId} with zero or negative duration: {Duration} seconds",
                 nextEvent.match.id, duration.TotalSeconds);
             return;
         }

--- a/W3ChampionsStatisticService/W3ChampionsStats/GameLengths/GameLengthStatHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/GameLengths/GameLengthStatHandler.cs
@@ -5,6 +5,7 @@ using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.Tracing;
+using Serilog;
 
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.GameLengths;
@@ -17,11 +18,20 @@ public class GameLengthStatHandler(IW3StatsRepo w3Stats) : IMatchFinishedReadMod
     public async Task Update(MatchFinishedEvent nextEvent)
     {
         if (nextEvent.WasFakeEvent) return;
+        
         GameMode mode = nextEvent.match.gameMode;
         var stat = await _w3Stats.LoadGameLengths(mode) ?? GameLengthStat.Create(mode);
         var endTime = DateTimeOffset.FromUnixTimeMilliseconds(nextEvent.match.endTime);
         var startTime = DateTimeOffset.FromUnixTimeMilliseconds(nextEvent.match.startTime);
         var duration = endTime - startTime;
+
+        if (duration.TotalSeconds <= 0)
+        {
+            Log.Debug("Skipping game length recording for match {MatchId} with zero or negative duration: {Duration} seconds", 
+                nextEvent.match.id, duration.TotalSeconds);
+            return;
+        }
+
         stat.Apply(duration);
         await _w3Stats.Save(stat);
     }


### PR DESCRIPTION
- Updated Insert method in MatchRepository to handle MongoDB _id modification errors gracefully, ensuring idempotency -> Necessary due to duplicate insertions

- Improved GameLengthStat to skip recording for zero or negative durations -> Necessart due to new cancelled matches having 0 duration
