### PR TITLE
Add chat icon and color for chat service

### DIFF
--- a/W3ChampionsStatisticService/PersonalSettings/PersonalSettingDTO.cs
+++ b/W3ChampionsStatisticService/PersonalSettings/PersonalSettingDTO.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using W3ChampionsStatisticService.PlayerProfiles;
 
 namespace W3ChampionsStatisticService.PersonalSettings;
 
@@ -17,9 +18,7 @@ public class PersonalSettingsDTO
     public string HomePage { get; set; }
     public string Country { get; set; }
     public string CountryCode { get; set; }
-    public List<string> ChatColors { get; set; }
-    public List<string> ChatIcons { get; set; }
-    public string SelectedChatColor { get; set; }
-    public List<string> SelectedChatIcons { get; set; }
+    public ChatColor SelectedChatColor { get; set; }
+    public List<ChatIcon> SelectedChatIcons { get; set; }
     public AkaSettings AliasSettings { get; set; }
 }

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
@@ -12,6 +12,7 @@ using Serilog;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace W3ChampionsStatisticService.PlayerProfiles;
 
@@ -80,7 +81,7 @@ public class PlayersController(
             Log.Information($"{battleTag} has no personal settings. Using a default.");
             profilePic = ProfilePicture.Default();
         }
-        return Ok(new ChatDetailsDto(playersClan?.ClanId, profilePic));
+        return Ok(new ChatDetailsDto(playersClan?.ClanId, profilePic, settings?.SelectedChatColor, settings?.SelectedChatIcons));
     }
 
     [HttpGet("clan-memberships")]
@@ -199,10 +200,13 @@ public class ClanMemberhipDto(string battleTag, string clanId, in DateTimeOffset
     public DateTimeOffset LastUpdated { get; } = lastUpdated;
 }
 
-public class ChatDetailsDto(string clanId, ProfilePicture profilePicture)
+public class ChatDetailsDto(string clanId, ProfilePicture profilePicture, ChatColor chatColor, List<ChatIcon> chatIcons)
 {
     public string ClanId { get; } = clanId;
     public ProfilePicture ProfilePicture { get; } = profilePicture;
+
+    public ChatColor ChatColor { get; } = chatColor;
+    public List<ChatIcon> ChatIcons { get; } = chatIcons;
 }
 
 public class UserBrief(string battleTag, ProfilePicture profilePicture)
@@ -210,4 +214,51 @@ public class UserBrief(string battleTag, ProfilePicture profilePicture)
     public string BattleTag { get; } = battleTag;
     public string Name { get; } = battleTag.Split("#")[0];
     public ProfilePicture ProfilePicture { get; } = profilePicture;
+}
+
+public class ChatColor(string colorId) : IEquatable<ChatColor>
+{
+    public static readonly ChatColor AdminColor = new("chat_color_admin");
+    // We use an ID instead of a hex code because we want to allow users to configure the selected one themselves.
+    // The ID allows us to show localized names and descriptions. The value is resolved on the frontend.
+    public string ColorId { get; } = colorId;
+
+    public bool Equals(ChatColor other)
+    {
+        return ColorId == other.ColorId;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return Equals(obj as ChatColor);
+    }
+
+    public override int GetHashCode()
+    {
+        return ColorId.GetHashCode();
+    }
+}
+
+public class ChatIcon(string iconId) : IEquatable<ChatIcon>
+{
+    public static readonly ChatIcon AdminIcon = new("chat_icon_admin");
+
+    // We use an ID instead of a hex code because we want to allow users to configure the selected one themselves.
+    // The ID allows us to show localized names and descriptions. The value is resolved on the frontend.
+    public string IconId { get; } = iconId;
+
+    public bool Equals(ChatIcon other)
+    {
+        return IconId == other.IconId;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return Equals(obj as ChatIcon);
+    }
+
+    public override int GetHashCode()
+    {
+        return IconId.GetHashCode();
+    }
 }

--- a/W3ChampionsStatisticService/Rewards/Modules/ChatIconRewardModule.cs
+++ b/W3ChampionsStatisticService/Rewards/Modules/ChatIconRewardModule.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using W3C.Domain.Rewards.Abstractions;
 using W3ChampionsStatisticService.PersonalSettings;
+using W3ChampionsStatisticService.PlayerProfiles;
 using W3ChampionsStatisticService.Ports;
 using Serilog;
 
@@ -38,23 +39,24 @@ public class ChatIconRewardModule(
 
         if (settings.ChatIcons == null)
         {
-            settings.ChatIcons = new List<string>();
+            settings.ChatIcons = new List<ChatIcon>();
         }
 
-        if (!settings.ChatIcons.Contains(iconId))
+        var chatIcon = new ChatIcon(iconId);
+        if (!settings.ChatIcons.Any(i => i.IconId == iconId))
         {
-            settings.ChatIcons.Add(iconId);
+            settings.ChatIcons.Add(chatIcon);
 
             // Auto-select the icon if less than 3 icons are currently selected
             if (settings.SelectedChatIcons == null)
             {
-                settings.SelectedChatIcons = new List<string>();
+                settings.SelectedChatIcons = new List<ChatIcon>();
             }
 
             var autoSelected = false;
-            if (settings.SelectedChatIcons.Count < 3 && !settings.SelectedChatIcons.Contains(iconId))
+            if (settings.SelectedChatIcons.Count < 3 && !settings.SelectedChatIcons.Any(i => i.IconId == iconId))
             {
-                settings.SelectedChatIcons.Add(iconId);
+                settings.SelectedChatIcons.Add(chatIcon);
                 autoSelected = true;
                 Log.Information("Auto-selected chat icon {IconId} for user {UserId} (has {SelectedCount} icons selected)",
                     iconId, context.UserId, settings.SelectedChatIcons.Count - 1);
@@ -101,14 +103,14 @@ public class ChatIconRewardModule(
         }
 
         var settings = await _personalSettingsRepo.Load(context.UserId);
-        if (settings?.ChatIcons != null && settings.ChatIcons.Contains(iconId))
+        if (settings?.ChatIcons != null && settings.ChatIcons.Any(i => i.IconId == iconId))
         {
-            settings.ChatIcons.Remove(iconId);
+            settings.ChatIcons.RemoveAll(i => i.IconId == iconId);
 
             // Remove from selected icons if it was selected
-            if (settings.SelectedChatIcons != null && settings.SelectedChatIcons.Contains(iconId))
+            if (settings.SelectedChatIcons != null && settings.SelectedChatIcons.Any(i => i.IconId == iconId))
             {
-                settings.SelectedChatIcons.Remove(iconId);
+                settings.SelectedChatIcons.RemoveAll(i => i.IconId == iconId);
                 Log.Information("Removed {IconId} from selected chat icons for user {UserId}", iconId, context.UserId);
             }
 


### PR DESCRIPTION
Refactor PersonalSetting and PersonalSettingsDTO to use ChatColor and ChatIcon types for improved type safety. Implement validation methods for selected chat colors and icons in PersonalSetting. Update PlayersController and reward modules to accommodate new types and ensure proper handling of chat color and icon selections.