### PR TITLE
Protect public replay endpoints via Cloudflare Turnstile

### DIFF
--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -187,6 +187,11 @@ builder.Services.AddInterceptedTransient<CheckIfBattleTagIsAdminFilter>();
 builder.Services.AddInterceptedTransient<InjectActingPlayerFromAuthCodeFilter>();
 builder.Services.AddInterceptedTransient<BearerHasPermissionFilter>();
 builder.Services.AddInterceptedTransient<InjectAuthTokenFilter>();
+builder.Services.AddInterceptedTransient<TurnstileVerificationFilter>();
+
+// Turnstile service for captcha verification
+builder.Services.AddHttpClient<ITurnstileService, TurnstileService>();
+builder.Services.AddMemoryCache();
 
 builder.Services.AddInterceptedSingleton<MatchmakingServiceClient>();
 builder.Services.AddInterceptedSingleton<UpdateServiceClient>();

--- a/W3ChampionsStatisticService/Replays/ReplaysController.cs
+++ b/W3ChampionsStatisticService/Replays/ReplaysController.cs
@@ -19,6 +19,7 @@ public class ReplaysController(
     private readonly IMatchRepository _matchRepository = matchRepository;
 
     [HttpGet("{gameId}")]
+    [TurnstileVerification]
     public async Task<IActionResult> GetReplay(string gameId)
     {
         var floMatchId = await _matchRepository.GetFloIdFromId(gameId);
@@ -44,6 +45,7 @@ public class ReplaysController(
     }
 
     [HttpGet("by-flo-id/{floMatchId}")]
+    [TurnstileVerification]
     public async Task<IActionResult> GetReplay(int floMatchId)
     {
         if (floMatchId == 0)

--- a/W3ChampionsStatisticService/Services/TurnstileService.cs
+++ b/W3ChampionsStatisticService/Services/TurnstileService.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using W3C.Domain.Tracing;
+
+namespace W3ChampionsStatisticService.Services;
+
+public interface ITurnstileService
+{
+    Task<bool> VerifyTokenAsync(string token, string remoteIp = null);
+    bool IsEnabled { get; }
+}
+
+public class TurnstileVerificationException : Exception
+{
+    public TurnstileVerificationException(string message) : base(message) { }
+    public TurnstileVerificationException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+public class TurnstileService : ITurnstileService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IMemoryCache _cache;
+    private readonly ILogger<TurnstileService> _logger;
+    private readonly string _secretKey;
+    private const string TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+    private const int CACHE_DURATION_MINUTES = 5;
+
+    public bool IsEnabled { get; }
+
+    public TurnstileService(HttpClient httpClient, IMemoryCache cache, ILogger<TurnstileService> logger)
+    {
+        _httpClient = httpClient;
+        _cache = cache;
+        _logger = logger;
+        _secretKey = Environment.GetEnvironmentVariable("TURNSTILE_SECRET_KEY");
+        IsEnabled = !string.IsNullOrEmpty(_secretKey);
+
+        if (!IsEnabled)
+        {
+            _logger.LogWarning("TURNSTILE_SECRET_KEY is not set. Turnstile verification is disabled.");
+        }
+    }
+
+    [Trace]
+    public async Task<bool> VerifyTokenAsync(string token, string remoteIp = null)
+    {
+        // Skip verification if not enabled
+        if (!IsEnabled)
+        {
+            _logger.LogDebug("Turnstile verification is disabled (no secret key configured)");
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            _logger.LogDebug("Turnstile token is empty or null");
+            return false;  // This is a validation failure, not an error
+        }
+
+        // Check cache first
+        var cacheKey = $"turnstile_token_{token}";
+        if (_cache.TryGetValue<bool>(cacheKey, out var cachedResult))
+        {
+            _logger.LogDebug("Turnstile token found in cache");
+            return cachedResult;
+        }
+
+        try
+        {
+            var formData = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("secret", _secretKey),
+                new KeyValuePair<string, string>("response", token),
+                new KeyValuePair<string, string>("remoteip", remoteIp ?? string.Empty)
+            });
+
+            var response = await _httpClient.PostAsync(TURNSTILE_VERIFY_URL, formData);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var content = await response.Content.ReadAsStringAsync();
+                throw new TurnstileVerificationException(
+                    $"Turnstile API returned status code {response.StatusCode}: {content}");
+            }
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+            var result = JsonSerializer.Deserialize<TurnstileResponse>(jsonResponse, options);
+
+            if (result == null)
+            {
+                throw new TurnstileVerificationException("Failed to deserialize Turnstile response");
+            }
+
+            if (result.Success)
+            {
+                // Cache successful verification
+                _cache.Set(cacheKey, true, TimeSpan.FromMinutes(CACHE_DURATION_MINUTES));
+                _logger.LogDebug("Turnstile token verified successfully");
+                return true;
+            }
+
+            // Token verification failed (invalid token, expired, already used, etc.)
+            if (result.ErrorCodes != null && result.ErrorCodes.Count > 0)
+            {
+                _logger.LogDebug($"Turnstile verification failed: {string.Join(", ", result.ErrorCodes)}");
+            }
+
+            return false;
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new TurnstileVerificationException("Failed to connect to Turnstile API", ex);
+        }
+        catch (TaskCanceledException ex)
+        {
+            throw new TurnstileVerificationException("Turnstile API request timed out", ex);
+        }
+        catch (TurnstileVerificationException)
+        {
+            throw;  // Re-throw our custom exceptions
+        }
+        catch (Exception ex)
+        {
+            throw new TurnstileVerificationException("Unexpected error during Turnstile verification", ex);
+        }
+    }
+
+    private class TurnstileResponse
+    {
+        public bool Success { get; set; }
+
+        [JsonPropertyName("challenge_ts")]
+        public DateTime? ChallengeTs { get; set; }
+
+        public string Hostname { get; set; }
+
+        [JsonPropertyName("error-codes")]
+        public List<string> ErrorCodes { get; set; }
+
+        public string Action { get; set; }
+
+        public string CData { get; set; }
+    }
+}

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/TurnstileVerificationAttribute.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/TurnstileVerificationAttribute.cs
@@ -1,0 +1,16 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace W3ChampionsStatisticService.WebApi.ActionFilters;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+public class TurnstileVerificationAttribute : Attribute, IFilterFactory
+{
+    public bool IsReusable => false;
+
+    public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)
+    {
+        return serviceProvider.GetRequiredService<TurnstileVerificationFilter>();
+    }
+}

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/TurnstileVerificationFilter.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/TurnstileVerificationFilter.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.Services;
+
+namespace W3ChampionsStatisticService.WebApi.ActionFilters;
+
+public class TurnstileVerificationFilter(ITurnstileService turnstileService, ILogger<TurnstileVerificationFilter> logger) : IAsyncActionFilter
+{
+    private readonly ITurnstileService _turnstileService = turnstileService;
+    private readonly ILogger<TurnstileVerificationFilter> _logger = logger;
+    private const string TURNSTILE_HEADER = "X-Turnstile-Token";
+
+    [Trace]
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        // Skip if Turnstile is not enabled
+        if (!_turnstileService.IsEnabled)
+        {
+            await next.Invoke();
+            return;
+        }
+
+        var endpoint = context.HttpContext.Request.Path;
+        var method = context.HttpContext.Request.Method;
+        var userAgent = context.HttpContext.Request.Headers["User-Agent"].ToString();
+        var remoteIp = GetRemoteIpAddress(context);
+
+        // Extract token from header
+        if (!context.HttpContext.Request.Headers.TryGetValue(TURNSTILE_HEADER, out var tokenValue))
+        {
+            _logger.LogWarning("Turnstile token missing from request. Endpoint: {Method} {Endpoint}, IP: {RemoteIp}, User-Agent: {UserAgent}",
+                method, endpoint, remoteIp, userAgent);
+            context.Result = new UnauthorizedObjectResult(new
+            {
+                StatusCode = HttpStatusCode.Unauthorized,
+                Error = "TURNSTILE_TOKEN_MISSING",
+                Message = "Turnstile verification token is required"
+            });
+            return;
+        }
+
+        var token = tokenValue.ToString();
+
+        try
+        {
+            var isValid = await _turnstileService.VerifyTokenAsync(token, remoteIp);
+
+            if (!isValid)
+            {
+                _logger.LogInformation("Invalid Turnstile token. Endpoint: {Method} {Endpoint}, IP: {RemoteIp}, User-Agent: {UserAgent}",
+                    method, endpoint, remoteIp, userAgent);
+                context.Result = new UnauthorizedObjectResult(new
+                {
+                    StatusCode = HttpStatusCode.Unauthorized,
+                    Error = "TURNSTILE_VERIFICATION_FAILED",
+                    Message = "Turnstile verification failed. Please refresh and try again."
+                });
+                return;
+            }
+
+            _logger.LogDebug("Turnstile verification successful. Endpoint: {Method} {Endpoint}, IP: {RemoteIp}",
+                method, endpoint, remoteIp);
+
+            // Token is valid, proceed with the action
+            await next.Invoke();
+        }
+        catch (TurnstileVerificationException ex)
+        {
+            _logger.LogError(ex, "Turnstile verification service error. Endpoint: {Method} {Endpoint}, IP: {RemoteIp}, User-Agent: {UserAgent}",
+                method, endpoint, remoteIp, userAgent);
+            context.Result = new ObjectResult(new
+            {
+                StatusCode = HttpStatusCode.ServiceUnavailable,
+                Error = "TURNSTILE_SERVICE_ERROR",
+                Message = "Unable to verify captcha at this time. Please try again later."
+            })
+            {
+                StatusCode = (int)HttpStatusCode.ServiceUnavailable
+            };
+        }
+    }
+
+    private string GetRemoteIpAddress(ActionExecutingContext context)
+    {
+        // Check for Cloudflare's CF-Connecting-IP header first
+        if (context.HttpContext.Request.Headers.TryGetValue("CF-Connecting-IP", out var cfIp))
+        {
+            return cfIp.ToString();
+        }
+
+        // Then check X-Forwarded-For
+        if (context.HttpContext.Request.Headers.TryGetValue("X-Forwarded-For", out var forwardedFor))
+        {
+            // X-Forwarded-For can contain multiple IPs, take the first one
+            var ips = forwardedFor.ToString().Split(',');
+            if (ips.Length > 0)
+            {
+                return ips[0].Trim();
+            }
+        }
+
+        // Fall back to remote IP address
+        return context.HttpContext.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+    }
+}

--- a/docs/TURNSTILE_INTEGRATION.md
+++ b/docs/TURNSTILE_INTEGRATION.md
@@ -1,0 +1,115 @@
+# Cloudflare Turnstile Integration
+
+This document describes the Cloudflare Turnstile captcha integration for protecting endpoints from abuse.
+
+## Configuration
+
+### Backend
+Set the Turnstile secret key environment variable:
+```bash
+export TURNSTILE_SECRET_KEY="your-secret-key-here"
+```
+
+If this environment variable is not set, Turnstile verification will be disabled and all requests will pass through.
+
+### Frontend
+Set the Turnstile site key in `public/env.js`:
+```javascript
+window._env_ = {
+  // ... other config
+  TURNSTILE_SITE_KEY: "your-site-key-here",
+};
+```
+
+## Protected Endpoints
+
+Currently, the following endpoints are protected with Turnstile:
+- `GET /api/replays/{gameId}` - Download replay by game ID
+- `GET /api/replays/by-flo-id/{floMatchId}` - Download replay by FLO match ID
+
+## How It Works
+
+### Backend Flow
+1. Client sends request with `X-Turnstile-Token` header
+2. `TurnstileVerificationFilter` intercepts the request
+3. Token is verified with Cloudflare's API
+4. Successful verifications are cached for 5 minutes
+5. Invalid tokens return 401 Unauthorized
+6. Service errors return 503 Service Unavailable
+
+### Frontend Flow
+1. User clicks download button
+2. TurnstileService checks if enabled
+3. If enabled, shows Turnstile widget
+4. User completes challenge
+5. Token is sent with download request
+6. File downloads on success
+
+## Adding Turnstile to New Endpoints
+
+### Backend
+Add the `[TurnstileVerification]` attribute to any controller method:
+
+```csharp
+[HttpGet("protected-endpoint")]
+[TurnstileVerification]
+public async Task<IActionResult> ProtectedEndpoint()
+{
+    // Your code here
+}
+```
+
+### Frontend
+Use the TurnstileService to get a token before making API calls:
+
+```typescript
+import { TurnstileService } from "@/services/TurnstileService";
+
+const turnstileService = TurnstileService.getInstance();
+
+// Check if Turnstile is enabled
+if (turnstileService.isEnabled()) {
+  // Get token (will show widget if needed)
+  const token = await turnstileService.getToken("action-name");
+  
+  if (token) {
+    // Make API call with token
+    const response = await fetch(url, {
+      headers: {
+        "X-Turnstile-Token": token,
+      },
+    });
+  }
+}
+```
+
+## Logging
+
+The backend logs all Turnstile verification attempts including:
+- Endpoint being accessed
+- Client IP address
+- User agent
+- Verification result
+
+Failed verifications and missing tokens are logged at the Warning level.
+Service errors are logged at the Error level.
+
+## Development Mode
+
+When `TURNSTILE_SECRET_KEY` is not set, Turnstile verification is automatically disabled, allowing for easier local development and testing.
+
+## Troubleshooting
+
+### "Turnstile token missing from request"
+- Ensure the frontend is sending the `X-Turnstile-Token` header
+- Check that Turnstile is enabled in the frontend (site key is set)
+
+### "Turnstile verification failed"
+- Token may be expired (tokens are valid for 5 minutes)
+- Token may have already been used
+- User may have failed the challenge
+
+### "Unable to verify captcha at this time"
+- Cloudflare's API may be unavailable
+- Network issues between server and Cloudflare
+- Invalid secret key configuration


### PR DESCRIPTION
Block crawlers from downloading replays