### PR TITLE
Enhance Turnstile verification with max age support

### DIFF
--- a/W3ChampionsStatisticService/Replays/ReplaysController.cs
+++ b/W3ChampionsStatisticService/Replays/ReplaysController.cs
@@ -19,7 +19,7 @@ public class ReplaysController(
     private readonly IMatchRepository _matchRepository = matchRepository;
 
     [HttpGet("{gameId}")]
-    [TurnstileVerification]
+    [TurnstileVerification(MaxAgeSeconds = 10)] // Token must be less than 10 seconds old, combating captcha solvers
     public async Task<IActionResult> GetReplay(string gameId)
     {
         var floMatchId = await _matchRepository.GetFloIdFromId(gameId);
@@ -45,7 +45,7 @@ public class ReplaysController(
     }
 
     [HttpGet("by-flo-id/{floMatchId}")]
-    [TurnstileVerification]
+    [TurnstileVerification(MaxAgeSeconds = 10)] // Token must be less than 10 seconds old, combating captcha solvers
     public async Task<IActionResult> GetReplay(int floMatchId)
     {
         if (floMatchId == 0)

--- a/W3ChampionsStatisticService/Services/TurnstileService.cs
+++ b/W3ChampionsStatisticService/Services/TurnstileService.cs
@@ -13,7 +13,58 @@ namespace W3ChampionsStatisticService.Services;
 public interface ITurnstileService
 {
     Task<bool> VerifyTokenAsync(string token, string remoteIp = null);
+    Task<TurnstileVerificationResult> VerifyTokenAsync(string token, string remoteIp = null, int? maxAgeSeconds = null);
     bool IsEnabled { get; }
+}
+
+public class TurnstileVerificationResult
+{
+    public bool IsValid { get; set; }
+    public DateTime? ChallengeTimestamp { get; set; }
+    public bool IsExpiredByAge { get; set; }
+    public string ErrorMessage { get; set; }
+    
+    /// <summary>
+    /// Creates a successful verification result
+    /// </summary>
+    public static TurnstileVerificationResult Success(DateTime? challengeTimestamp)
+    {
+        return new TurnstileVerificationResult
+        {
+            IsValid = true,
+            ChallengeTimestamp = challengeTimestamp,
+            IsExpiredByAge = false,
+            ErrorMessage = null
+        };
+    }
+    
+    /// <summary>
+    /// Creates a failed verification result
+    /// </summary>
+    public static TurnstileVerificationResult Failed(string errorMessage)
+    {
+        return new TurnstileVerificationResult
+        {
+            IsValid = false,
+            ChallengeTimestamp = null,
+            IsExpiredByAge = false,
+            ErrorMessage = errorMessage
+        };
+    }
+    
+    /// <summary>
+    /// Creates a result for token that is too old
+    /// </summary>
+    public static TurnstileVerificationResult ExpiredByAge(DateTime challengeTimestamp)
+    {
+        return new TurnstileVerificationResult
+        {
+            IsValid = false,
+            ChallengeTimestamp = challengeTimestamp,
+            IsExpiredByAge = true,
+            ErrorMessage = "Token has expired. Please refresh and try again."
+        };
+    }
 }
 
 public class TurnstileVerificationException : Exception
@@ -50,24 +101,43 @@ public class TurnstileService : ITurnstileService
     [Trace]
     public async Task<bool> VerifyTokenAsync(string token, string remoteIp = null)
     {
+        var result = await VerifyTokenAsync(token, remoteIp, null);
+        return result.IsValid;
+    }
+    
+    [Trace]
+    public async Task<TurnstileVerificationResult> VerifyTokenAsync(string token, string remoteIp = null, int? maxAgeSeconds = null)
+    {
         // Skip verification if not enabled
         if (!IsEnabled)
         {
             _logger.LogDebug("Turnstile verification is disabled (no secret key configured)");
-            return true;
+            return TurnstileVerificationResult.Success(null);
         }
 
         if (string.IsNullOrWhiteSpace(token))
         {
             _logger.LogDebug("Turnstile token is empty or null");
-            return false;  // This is a validation failure, not an error
+            return TurnstileVerificationResult.Failed("Token is missing");
         }
 
         // Check cache first
         var cacheKey = $"turnstile_token_{token}";
-        if (_cache.TryGetValue<bool>(cacheKey, out var cachedResult))
+        if (_cache.TryGetValue<TurnstileVerificationResult>(cacheKey, out var cachedResult))
         {
             _logger.LogDebug("Turnstile token found in cache");
+            
+            // Check age if max age is specified and we have a cached timestamp
+            if (maxAgeSeconds.HasValue && cachedResult.ChallengeTimestamp.HasValue)
+            {
+                var ageSeconds = (DateTime.UtcNow - cachedResult.ChallengeTimestamp.Value).TotalSeconds;
+                if (ageSeconds > maxAgeSeconds.Value)
+                {
+                    _logger.LogInformation($"Cached token exceeds max age. Age: {ageSeconds:F0} seconds, max allowed: {maxAgeSeconds.Value} seconds, IP: {remoteIp}");
+                    return TurnstileVerificationResult.ExpiredByAge(cachedResult.ChallengeTimestamp.Value);
+                }
+            }
+            
             return cachedResult;
         }
 
@@ -103,19 +173,32 @@ public class TurnstileService : ITurnstileService
 
             if (result.Success)
             {
+                var verificationResult = TurnstileVerificationResult.Success(result.ChallengeTs);
+                
+                // Check age if max age is specified
+                if (maxAgeSeconds.HasValue && result.ChallengeTs.HasValue)
+                {
+                    var ageSeconds = (DateTime.UtcNow - result.ChallengeTs.Value).TotalSeconds;
+                    if (ageSeconds > maxAgeSeconds.Value)
+                    {
+                        _logger.LogInformation($"Token exceeds max age. Age: {ageSeconds:F0} seconds, max allowed: {maxAgeSeconds.Value} seconds, IP: {remoteIp}");
+                        return TurnstileVerificationResult.ExpiredByAge(result.ChallengeTs.Value);
+                    }
+                }
+                
                 // Cache successful verification
-                _cache.Set(cacheKey, true, TimeSpan.FromMinutes(CACHE_DURATION_MINUTES));
-                _logger.LogDebug("Turnstile token verified successfully");
-                return true;
+                _cache.Set(cacheKey, verificationResult, TimeSpan.FromMinutes(CACHE_DURATION_MINUTES));
+                _logger.LogDebug($"Turnstile token verified successfully. IP: {remoteIp}");
+                return verificationResult;
             }
 
             // Token verification failed (invalid token, expired, already used, etc.)
             if (result.ErrorCodes != null && result.ErrorCodes.Count > 0)
             {
-                _logger.LogDebug($"Turnstile verification failed: {string.Join(", ", result.ErrorCodes)}");
+                _logger.LogDebug($"Turnstile verification failed: {string.Join(", ", result.ErrorCodes)}, IP: {remoteIp}");
             }
 
-            return false;
+            return TurnstileVerificationResult.Failed("Token verification failed");
         }
         catch (HttpRequestException ex)
         {

--- a/W3ChampionsStatisticService/Services/TurnstileService.cs
+++ b/W3ChampionsStatisticService/Services/TurnstileService.cs
@@ -23,7 +23,7 @@ public class TurnstileVerificationResult
     public DateTime? ChallengeTimestamp { get; set; }
     public bool IsExpiredByAge { get; set; }
     public string ErrorMessage { get; set; }
-    
+
     /// <summary>
     /// Creates a successful verification result
     /// </summary>
@@ -37,7 +37,7 @@ public class TurnstileVerificationResult
             ErrorMessage = null
         };
     }
-    
+
     /// <summary>
     /// Creates a failed verification result
     /// </summary>
@@ -51,7 +51,7 @@ public class TurnstileVerificationResult
             ErrorMessage = errorMessage
         };
     }
-    
+
     /// <summary>
     /// Creates a result for token that is too old
     /// </summary>
@@ -104,7 +104,7 @@ public class TurnstileService : ITurnstileService
         var result = await VerifyTokenAsync(token, remoteIp, null);
         return result.IsValid;
     }
-    
+
     [Trace]
     public async Task<TurnstileVerificationResult> VerifyTokenAsync(string token, string remoteIp = null, int? maxAgeSeconds = null)
     {
@@ -126,7 +126,7 @@ public class TurnstileService : ITurnstileService
         if (_cache.TryGetValue<TurnstileVerificationResult>(cacheKey, out var cachedResult))
         {
             _logger.LogDebug("Turnstile token found in cache");
-            
+
             // Check age if max age is specified and we have a cached timestamp
             if (maxAgeSeconds.HasValue && cachedResult.ChallengeTimestamp.HasValue)
             {
@@ -137,7 +137,7 @@ public class TurnstileService : ITurnstileService
                     return TurnstileVerificationResult.ExpiredByAge(cachedResult.ChallengeTimestamp.Value);
                 }
             }
-            
+
             return cachedResult;
         }
 
@@ -174,7 +174,7 @@ public class TurnstileService : ITurnstileService
             if (result.Success)
             {
                 var verificationResult = TurnstileVerificationResult.Success(result.ChallengeTs);
-                
+
                 // Check age if max age is specified
                 if (maxAgeSeconds.HasValue && result.ChallengeTs.HasValue)
                 {
@@ -185,7 +185,7 @@ public class TurnstileService : ITurnstileService
                         return TurnstileVerificationResult.ExpiredByAge(result.ChallengeTs.Value);
                     }
                 }
-                
+
                 // Cache successful verification
                 _cache.Set(cacheKey, verificationResult, TimeSpan.FromMinutes(CACHE_DURATION_MINUTES));
                 _logger.LogDebug($"Turnstile token verified successfully. IP: {remoteIp}");

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/TurnstileVerificationAttribute.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/TurnstileVerificationAttribute.cs
@@ -7,10 +7,19 @@ namespace W3ChampionsStatisticService.WebApi.ActionFilters;
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
 public class TurnstileVerificationAttribute : Attribute, IFilterFactory
 {
+    /// <summary>
+    /// Optional: Maximum age of the token in seconds. 
+    /// If specified (value > 0), tokens older than this will be rejected.
+    /// Set to 0 or negative to disable age check.
+    /// </summary>
+    public int MaxAgeSeconds { get; set; }
+    
     public bool IsReusable => false;
 
     public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)
     {
-        return serviceProvider.GetRequiredService<TurnstileVerificationFilter>();
+        var filter = serviceProvider.GetRequiredService<TurnstileVerificationFilter>();
+        filter.MaxAgeSeconds = MaxAgeSeconds;
+        return filter;
     }
 }

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/TurnstileVerificationAttribute.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/TurnstileVerificationAttribute.cs
@@ -13,7 +13,7 @@ public class TurnstileVerificationAttribute : Attribute, IFilterFactory
     /// Set to 0 or negative to disable age check.
     /// </summary>
     public int MaxAgeSeconds { get; set; }
-    
+
     public bool IsReusable => false;
 
     public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/TurnstileVerificationFilter.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/TurnstileVerificationFilter.cs
@@ -14,7 +14,7 @@ public class TurnstileVerificationFilter(ITurnstileService turnstileService, ILo
     private readonly ITurnstileService _turnstileService = turnstileService;
     private readonly ILogger<TurnstileVerificationFilter> _logger = logger;
     private const string TURNSTILE_HEADER = "X-Turnstile-Token";
-    
+
     /// <summary>
     /// Optional: Maximum age of the token in seconds. Set by the attribute.
     /// Value of 0 or negative means no age check.
@@ -55,7 +55,7 @@ public class TurnstileVerificationFilter(ITurnstileService turnstileService, ILo
         try
         {
             var result = await _turnstileService.VerifyTokenAsync(token, remoteIp, MaxAgeSeconds > 0 ? MaxAgeSeconds : null);
-            
+
             if (!result.IsValid)
             {
                 if (result.IsExpiredByAge)
@@ -68,7 +68,7 @@ public class TurnstileVerificationFilter(ITurnstileService turnstileService, ILo
                     _logger.LogInformation("Invalid Turnstile token. Endpoint: {Method} {Endpoint}, IP: {RemoteIp}, User-Agent: {UserAgent}",
                         method, endpoint, remoteIp, userAgent);
                 }
-                
+
                 context.Result = new UnauthorizedObjectResult(new
                 {
                     StatusCode = HttpStatusCode.Unauthorized,

--- a/WC3ChampionsStatisticService.UnitTests/Services/TurnstileServiceTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Services/TurnstileServiceTests.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+using W3ChampionsStatisticService.Services;
+
+namespace WC3ChampionsStatisticService.Tests.Services;
+
+[TestFixture]
+public class TurnstileServiceTests
+{
+    private Mock<HttpMessageHandler> _httpMessageHandlerMock;
+    private HttpClient _httpClient;
+    private IMemoryCache _memoryCache;
+    private Mock<ILogger<TurnstileService>> _loggerMock;
+    private TurnstileService _turnstileService;
+    private const string TestSecretKey = "test-secret-key";
+    private const string TestToken = "test-token-123";
+    private const string TestRemoteIp = "192.168.1.1";
+
+    [SetUp]
+    public void SetUp()
+    {
+        Environment.SetEnvironmentVariable("TURNSTILE_SECRET_KEY", TestSecretKey);
+        
+        _httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+        _httpClient = new HttpClient(_httpMessageHandlerMock.Object);
+        _memoryCache = new MemoryCache(new MemoryCacheOptions());
+        _loggerMock = new Mock<ILogger<TurnstileService>>();
+        
+        _turnstileService = new TurnstileService(_httpClient, _memoryCache, _loggerMock.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable("TURNSTILE_SECRET_KEY", null);
+        _httpClient?.Dispose();
+        _memoryCache?.Dispose();
+    }
+
+    [Test]
+    public async Task VerifyTokenAsync_WithValidToken_ReturnsSuccess()
+    {
+        // Arrange
+        var challengeTimestamp = DateTime.UtcNow.AddSeconds(-30);
+        var responseJson = $@"{{
+            ""success"": true,
+            ""challenge_ts"": ""{challengeTimestamp:yyyy-MM-dd'T'HH:mm:ss.fff'Z'}"",
+            ""hostname"": ""example.com""
+        }}";
+
+        SetupHttpResponse(HttpStatusCode.OK, responseJson);
+
+        // Act
+        var result = await _turnstileService.VerifyTokenAsync(TestToken, TestRemoteIp, maxAgeSeconds: null);
+
+        // Assert
+        Assert.IsTrue(result.IsValid);
+        Assert.IsFalse(result.IsExpiredByAge);
+        Assert.IsNotNull(result.ChallengeTimestamp);
+        Assert.IsNull(result.ErrorMessage);
+    }
+
+    [Test]
+    public async Task VerifyTokenAsync_WithInvalidToken_ReturnsFailure()
+    {
+        // Arrange
+        var responseJson = @"{
+            ""success"": false,
+            ""error-codes"": [""invalid-input-response""]
+        }";
+
+        SetupHttpResponse(HttpStatusCode.OK, responseJson);
+
+        // Act
+        var result = await _turnstileService.VerifyTokenAsync(TestToken, TestRemoteIp, maxAgeSeconds: null);
+
+        // Assert
+        Assert.IsFalse(result.IsValid);
+        Assert.IsFalse(result.IsExpiredByAge);
+        Assert.IsNull(result.ChallengeTimestamp);
+        Assert.AreEqual("Token verification failed", result.ErrorMessage);
+    }
+
+    [Test]
+    public async Task VerifyTokenAsync_WithMaxAge_TokenTooOld_ReturnsExpired()
+    {
+        // Arrange
+        var challengeTimestamp = DateTime.UtcNow.AddMinutes(-10); // 10 minutes old
+        var maxAgeSeconds = 300; // 5 minutes max
+        
+        var responseJson = $@"{{
+            ""success"": true,
+            ""challenge_ts"": ""{challengeTimestamp:yyyy-MM-dd'T'HH:mm:ss.fff'Z'}"",
+            ""hostname"": ""example.com""
+        }}";
+
+        SetupHttpResponse(HttpStatusCode.OK, responseJson);
+
+        // Act
+        var result = await _turnstileService.VerifyTokenAsync(TestToken, TestRemoteIp, maxAgeSeconds);
+
+        // Assert
+        Assert.IsFalse(result.IsValid);
+        Assert.IsTrue(result.IsExpiredByAge);
+        Assert.IsNotNull(result.ChallengeTimestamp);
+        Assert.AreEqual("Token has expired. Please refresh and try again.", result.ErrorMessage);
+        
+        // Verify logging
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Token exceeds max age")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task VerifyTokenAsync_WithMaxAge_TokenWithinAge_ReturnsSuccess()
+    {
+        // Arrange
+        var challengeTimestamp = DateTime.UtcNow.AddMinutes(-2); // 2 minutes old
+        var maxAgeSeconds = 300; // 5 minutes max
+        
+        var responseJson = $@"{{
+            ""success"": true,
+            ""challenge_ts"": ""{challengeTimestamp:yyyy-MM-dd'T'HH:mm:ss.fff'Z'}"",
+            ""hostname"": ""example.com""
+        }}";
+
+        SetupHttpResponse(HttpStatusCode.OK, responseJson);
+
+        // Act
+        var result = await _turnstileService.VerifyTokenAsync(TestToken, TestRemoteIp, maxAgeSeconds);
+
+        // Assert
+        Assert.IsTrue(result.IsValid);
+        Assert.IsFalse(result.IsExpiredByAge);
+        Assert.IsNotNull(result.ChallengeTimestamp);
+        Assert.IsNull(result.ErrorMessage);
+    }
+
+    [Test]
+    public async Task VerifyTokenAsync_CachedToken_WithMaxAge_RechecksAge()
+    {
+        // Arrange - First request with fresh token
+        var challengeTimestamp = DateTime.UtcNow.AddMinutes(-2);
+        var responseJson = $@"{{
+            ""success"": true,
+            ""challenge_ts"": ""{challengeTimestamp:yyyy-MM-dd'T'HH:mm:ss.fff'Z'}"",
+            ""hostname"": ""example.com""
+        }}";
+
+        SetupHttpResponse(HttpStatusCode.OK, responseJson);
+
+        // Act 1 - First verification (should cache)
+        var result1 = await _turnstileService.VerifyTokenAsync(TestToken, TestRemoteIp, maxAgeSeconds: 300);
+        Assert.IsTrue(result1.IsValid);
+
+        // Simulate time passing (we can't actually change the cached timestamp, 
+        // but we can verify the cache is used)
+        
+        // Act 2 - Second verification should use cache
+        var result2 = await _turnstileService.VerifyTokenAsync(TestToken, TestRemoteIp, maxAgeSeconds: 300);
+        
+        // Assert
+        Assert.IsTrue(result2.IsValid);
+        Assert.AreEqual(result1.ChallengeTimestamp, result2.ChallengeTimestamp);
+        
+        // Verify HTTP was called only once (cache was used)
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>()
+        );
+    }
+
+    [Test]
+    public async Task VerifyTokenAsync_WithEmptyToken_ReturnsFailure()
+    {
+        // Act
+        var result = await _turnstileService.VerifyTokenAsync("", TestRemoteIp, maxAgeSeconds: null);
+
+        // Assert
+        Assert.IsFalse(result.IsValid);
+        Assert.AreEqual("Token is missing", result.ErrorMessage);
+        
+        // Verify no HTTP call was made
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>()
+        );
+    }
+
+    [Test]
+    public async Task VerifyTokenAsync_WhenDisabled_ReturnsSuccess()
+    {
+        // Arrange - Disable by removing secret key
+        Environment.SetEnvironmentVariable("TURNSTILE_SECRET_KEY", null);
+        var service = new TurnstileService(_httpClient, _memoryCache, _loggerMock.Object);
+
+        // Act
+        var result = await service.VerifyTokenAsync(TestToken, TestRemoteIp, maxAgeSeconds: 60);
+
+        // Assert
+        Assert.IsTrue(result.IsValid);
+        Assert.IsNull(result.ChallengeTimestamp);
+        Assert.IsFalse(service.IsEnabled);
+        
+        // Verify no HTTP call was made
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>()
+        );
+    }
+
+    [Test]
+    public async Task VerifyTokenAsync_BackwardCompatibility_BooleanOverload()
+    {
+        // Arrange
+        var responseJson = @"{
+            ""success"": true,
+            ""challenge_ts"": ""2025-01-01T12:00:00.000Z"",
+            ""hostname"": ""example.com""
+        }";
+
+        SetupHttpResponse(HttpStatusCode.OK, responseJson);
+
+        // Act - Use the boolean overload
+        var result = await _turnstileService.VerifyTokenAsync(TestToken, TestRemoteIp);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [Test]
+    public void VerifyTokenAsync_ApiError_ThrowsTurnstileVerificationException()
+    {
+        // Arrange
+        SetupHttpResponse(HttpStatusCode.ServiceUnavailable, "Service Unavailable");
+
+        // Act & Assert
+        var ex = Assert.ThrowsAsync<TurnstileVerificationException>(
+            async () => await _turnstileService.VerifyTokenAsync(TestToken, TestRemoteIp, maxAgeSeconds: null)
+        );
+        
+        Assert.That(ex.Message, Does.Contain("Turnstile API returned status code ServiceUnavailable"));
+    }
+
+    private void SetupHttpResponse(HttpStatusCode statusCode, string content)
+    {
+        var responseMessage = new HttpResponseMessage
+        {
+            StatusCode = statusCode,
+            Content = new StringContent(content)
+        };
+
+        _httpMessageHandlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(responseMessage);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Services/TurnstileServiceTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Services/TurnstileServiceTests.cs
@@ -28,12 +28,12 @@ public class TurnstileServiceTests
     public void SetUp()
     {
         Environment.SetEnvironmentVariable("TURNSTILE_SECRET_KEY", TestSecretKey);
-        
+
         _httpMessageHandlerMock = new Mock<HttpMessageHandler>();
         _httpClient = new HttpClient(_httpMessageHandlerMock.Object);
         _memoryCache = new MemoryCache(new MemoryCacheOptions());
         _loggerMock = new Mock<ILogger<TurnstileService>>();
-        
+
         _turnstileService = new TurnstileService(_httpClient, _memoryCache, _loggerMock.Object);
     }
 
@@ -95,7 +95,7 @@ public class TurnstileServiceTests
         // Arrange
         var challengeTimestamp = DateTime.UtcNow.AddMinutes(-10); // 10 minutes old
         var maxAgeSeconds = 300; // 5 minutes max
-        
+
         var responseJson = $@"{{
             ""success"": true,
             ""challenge_ts"": ""{challengeTimestamp:yyyy-MM-dd'T'HH:mm:ss.fff'Z'}"",
@@ -112,7 +112,7 @@ public class TurnstileServiceTests
         Assert.IsTrue(result.IsExpiredByAge);
         Assert.IsNotNull(result.ChallengeTimestamp);
         Assert.AreEqual("Token has expired. Please refresh and try again.", result.ErrorMessage);
-        
+
         // Verify logging
         _loggerMock.Verify(
             x => x.Log(
@@ -130,7 +130,7 @@ public class TurnstileServiceTests
         // Arrange
         var challengeTimestamp = DateTime.UtcNow.AddMinutes(-2); // 2 minutes old
         var maxAgeSeconds = 300; // 5 minutes max
-        
+
         var responseJson = $@"{{
             ""success"": true,
             ""challenge_ts"": ""{challengeTimestamp:yyyy-MM-dd'T'HH:mm:ss.fff'Z'}"",
@@ -168,14 +168,14 @@ public class TurnstileServiceTests
 
         // Simulate time passing (we can't actually change the cached timestamp, 
         // but we can verify the cache is used)
-        
+
         // Act 2 - Second verification should use cache
         var result2 = await _turnstileService.VerifyTokenAsync(TestToken, TestRemoteIp, maxAgeSeconds: 300);
-        
+
         // Assert
         Assert.IsTrue(result2.IsValid);
         Assert.AreEqual(result1.ChallengeTimestamp, result2.ChallengeTimestamp);
-        
+
         // Verify HTTP was called only once (cache was used)
         _httpMessageHandlerMock.Protected().Verify(
             "SendAsync",
@@ -194,7 +194,7 @@ public class TurnstileServiceTests
         // Assert
         Assert.IsFalse(result.IsValid);
         Assert.AreEqual("Token is missing", result.ErrorMessage);
-        
+
         // Verify no HTTP call was made
         _httpMessageHandlerMock.Protected().Verify(
             "SendAsync",
@@ -218,7 +218,7 @@ public class TurnstileServiceTests
         Assert.IsTrue(result.IsValid);
         Assert.IsNull(result.ChallengeTimestamp);
         Assert.IsFalse(service.IsEnabled);
-        
+
         // Verify no HTTP call was made
         _httpMessageHandlerMock.Protected().Verify(
             "SendAsync",
@@ -257,7 +257,7 @@ public class TurnstileServiceTests
         var ex = Assert.ThrowsAsync<TurnstileVerificationException>(
             async () => await _turnstileService.VerifyTokenAsync(TestToken, TestRemoteIp, maxAgeSeconds: null)
         );
-        
+
         Assert.That(ex.Message, Does.Contain("Turnstile API returned status code ServiceUnavailable"));
     }
 


### PR DESCRIPTION

- Updated TurnstileVerification attribute to include MaxAgeSeconds property for token age validation.
- Modified ReplaysController to enforce a maximum token age of 10 seconds for replay retrieval.
- Enhanced TurnstileService to return detailed verification results, including expiration status.
- Updated TurnstileVerificationFilter to log specific messages for expired tokens.
- Added unit tests for TurnstileService to cover new functionality and edge cases.