### PR TITLE
Replace quantile float with double to match precision

### DIFF
--- a/W3C.Contracts/Matchmaking/Queue/QueueQuantiles.cs
+++ b/W3C.Contracts/Matchmaking/Queue/QueueQuantiles.cs
@@ -2,6 +2,6 @@
 
 public class QueueQuantiles
 {
-    public float quantile { get; set; }
-    public float activityQuantile { get; set; }
+    public double quantile { get; set; }
+    public double activityQuantile { get; set; }
 }

--- a/W3ChampionsStatisticService/Matches/PlayerOverviewMatches.cs
+++ b/W3ChampionsStatisticService/Matches/PlayerOverviewMatches.cs
@@ -9,7 +9,7 @@ public class PlayerOverviewMatches
     public Race Race { get; set; }
     public Race? RndRace { get; set; }
     public int OldMmr { get; set; }
-    public float? OldMmrQuantile { get; set; }
+    public double? OldMmrQuantile { get; set; }
     public int CurrentMmr { get; set; }
     public string BattleTag { get; set; }
     public string InviteName { get; set; }

--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGateway.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGateway.cs
@@ -35,7 +35,7 @@ public class PlayerGameModeStatPerGateway : WinLoss, IIdentifiable
     public int LeagueId { get; set; }
     public int LeagueOrder { get; set; }
     public int Division { get; set; }
-    public float? Quantile { get; set; }
+    public double? Quantile { get; set; }
 
     public RankProgression RankingPointsProgress
     {


### PR DESCRIPTION
The MMR system uses high precision doubles. Treating them as floats results in dataloss which the DB drives does not like.