### PR TITLE
use singleton instead of scoped for rate limiting service

### DIFF
--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -195,8 +195,8 @@ builder.Services.AddHttpClient<ITurnstileService, TurnstileService>();
 builder.Services.AddMemoryCache();
 
 // Rate limiting services
-builder.Services.AddInterceptedScoped<W3ChampionsStatisticService.RateLimiting.Repositories.IApiTokenRepository, W3ChampionsStatisticService.RateLimiting.Repositories.ApiTokenRepository>();
-builder.Services.AddInterceptedScoped<W3ChampionsStatisticService.RateLimiting.Services.IApiTokenService, W3ChampionsStatisticService.RateLimiting.Services.ApiTokenService>();
+builder.Services.AddInterceptedSingleton<W3ChampionsStatisticService.RateLimiting.Repositories.IApiTokenRepository, W3ChampionsStatisticService.RateLimiting.Repositories.ApiTokenRepository>();
+builder.Services.AddInterceptedSingleton<W3ChampionsStatisticService.RateLimiting.Services.IApiTokenService, W3ChampionsStatisticService.RateLimiting.Services.ApiTokenService>();
 builder.Services.AddInterceptedSingleton<W3ChampionsStatisticService.RateLimiting.Services.IRateLimitService, W3ChampionsStatisticService.RateLimiting.Services.RateLimitService>();
 builder.Services.AddInterceptedSingleton<W3ChampionsStatisticService.RateLimiting.Services.IRateLimitBucketService, W3ChampionsStatisticService.RateLimiting.Services.RateLimitBucketService>();
 


### PR DESCRIPTION
I can't start website-backend locally because `IApiTokenService` and `IApiTokenRepository` are scoped services which are consumed by singletons.

```
Unhandled exception. System.AggregateException: Some services are not able to be constructed (Error while validating the service descriptor 'ServiceType: W3ChampionsStatisticService.RateLimiting.Services.RateLimitService Lifetime: Singleton ImplementationType: W3ChampionsStatisticService.RateLimiting.Services.RateLimitService': Cannot consume scoped service 'W3ChampionsStatisticService.RateLimiting.Services.IApiTokenService' from singleton 'W3ChampionsStatisticService.RateLimiting.Services.RateLimitService'.)
 ---> System.InvalidOperationException: Error while validating the service descriptor 'ServiceType: W3ChampionsStatisticService.RateLimiting.Services.RateLimitService Lifetime: Singleton ImplementationType: W3ChampionsStatisticService.RateLimiting.Services.RateLimitService': Cannot consume scoped service 'W3ChampionsStatisticService.RateLimiting.Services.IApiTokenService' from singleton 'W3ChampionsStatisticService.RateLimiting.Services.RateLimitService'.
 ---> System.InvalidOperationException: Cannot consume scoped service 'W3ChampionsStatisticService.RateLimiting.Services.IApiTokenService' from singleton 'W3ChampionsStatisticService.RateLimiting.Services.RateLimitService'.
 ```