### PR TITLE
Add match duration filtering to /api/matches (Issue #472)

### DIFF
--- a/W3ChampionsStatisticService/Matches/MatchRepository.cs
+++ b/W3ChampionsStatisticService/Matches/MatchRepository.cs
@@ -233,11 +233,11 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
             playerBlizzard.teamIndex);
     }
 
-    public async Task<List<Matchup>> Load(int season, GameMode gameMode, int offset = 0, int pageSize = 100, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null)
+    public async Task<List<Matchup>> Load(int season, GameMode gameMode, int offset = 0, int pageSize = 100, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null, int? minDuration = null, int? maxDuration = null)
     {
         if (maxMmr == null) maxMmr = MmrConstants.MaxMmrPerGameMode[gameMode];
         var mongoCollection = CreateCollection<Matchup>();
-        var filter = GetLoadFilter(season, gameMode, hero, minMmr, maxMmr);
+        var filter = GetLoadFilter(season, gameMode, hero, minMmr, maxMmr, minDuration, maxDuration);
         var results = await mongoCollection.Find(filter).SortByDescending(s => s.EndTime).Skip(offset).Limit(pageSize).ToListAsync();
         PlayersObfuscator.ObfuscateMmr(results);
         return results;
@@ -250,14 +250,14 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
         return (match == null || match.FloMatchId == null) ? 0 : match.FloMatchId.Value;
     }
 
-    public Task<long> Count(int season, GameMode gameMode, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null)
+    public Task<long> Count(int season, GameMode gameMode, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null, int? minDuration = null, int? maxDuration = null)
     {
         if (maxMmr == null) maxMmr = MmrConstants.MaxMmrPerGameMode[gameMode];
-        var filter = GetLoadFilter(season, gameMode, hero, minMmr, maxMmr);
+        var filter = GetLoadFilter(season, gameMode, hero, minMmr, maxMmr, minDuration, maxDuration);
         return CreateCollection<Matchup>().CountDocumentsAsync(filter);
     }
 
-    private FilterDefinition<Matchup> GetLoadFilter(int season, GameMode gameMode, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null)
+    private FilterDefinition<Matchup> GetLoadFilter(int season, GameMode gameMode, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null, int? minDuration = null, int? maxDuration = null)
     {
         if (maxMmr == null) maxMmr = MmrConstants.MaxMmrPerGameMode[gameMode];
         var builder = Builders<Matchup>.Filter;
@@ -277,6 +277,11 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
                 && player.CurrentMmr >= minMmr
                 && player.CurrentMmr <= maxMmr)));
         }
+        if (minDuration.HasValue)
+            filter &= builder.Gte(m => m.DurationInSeconds, minDuration.Value);
+
+        if (maxDuration.HasValue)
+            filter &= builder.Lte(m => m.DurationInSeconds, maxDuration.Value);
 
         return filter;
     }

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -64,7 +64,9 @@ public class MatchesController(
         int minMmr = 0,
         int? maxMmr = null,
         int? minPercentile = null,
-        int? maxPercentile = null
+        int? maxPercentile = null,
+        int? minDuration = null,
+        int? maxDuration = null
     )
     {
         if (maxMmr == null) maxMmr = MmrConstants.MaxMmrPerGameMode[gameMode];
@@ -84,9 +86,9 @@ public class MatchesController(
             season = lastSeason.Id;
         }
         if (pageSize > 100) pageSize = 100;
-        var matches = await _matchRepository.Load(season, gameMode, offset, pageSize, hero, minMmr, maxMmr);
+        var matches = await _matchRepository.Load(season, gameMode, offset, pageSize, hero, minMmr, maxMmr, minDuration, maxDuration);
         PlayersObfuscator.ObfuscateMmr(matches);
-        var count = await _matchRepository.Count(season, gameMode, hero, minMmr, maxMmr);
+        var count = await _matchRepository.Count(season, gameMode, hero, minMmr, maxMmr, minDuration, maxDuration);
         return Ok(new { matches, count });
     }
 

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -45,7 +45,9 @@ public class MatchesController(
     /// <param name="maxMmr">The maximum MMR filter.</param>
     /// <param name="minPercentile">The minimum percentile filter.</param>
     /// <param name="maxPercentile">The maximum percentile filter.</param>
-    /// <returns>
+    /// <param name="minDuration">The minimum match duration in seconds (recommended minimum: 300s).
+    /// <param name="maxDuration">The maximum match duration in seconds (recommended maximum: 99999s).
+    /// /// <returns>
     /// 200 OK: An object containing a list of matches and the total count.
     /// {
     ///   matches: List&lt;MatchFinishedEvent&gt;,

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -13,14 +13,17 @@ namespace W3ChampionsStatisticService.Ports;
 
 public interface IMatchRepository
 {
-    Task<List<Matchup>> Load(int season, GameMode gameMode, int offset = 0, int pageSize = 100, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null);
+    Task<List<Matchup>> Load(int season, GameMode gameMode, int offset = 0, int pageSize = 100, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null, int? minDuration = null, int? maxDuration = null);
 
     Task<long> Count(
         int season,
         GameMode gameMode,
         HeroType hero = HeroType.AllFilter,
         int minMmr = 0,
-        int? maxMmr = null);
+        int? maxMmr = null,
+        int? minDuration = null,
+        int? maxDuration = null
+);
 
     Task Insert(Matchup matchup);
 

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -107,7 +107,7 @@ builder.Services.AddSwaggerGen(f =>
 });
 
 // Configure and add MongoDB
-string mongoConnectionString = Environment.GetEnvironmentVariable("MONGO_CONNECTION_STRING") ?? "mongodb://157.90.1.251:3513"; // "mongodb://localhost:27017";
+var mongoConnectionString = Environment.GetEnvironmentVariable("MONGO_CONNECTION_STRING") ?? "mongodb://localhost:27017/w3champions";
 MongoClientSettings mongoSettings = MongoClientSettings.FromConnectionString(mongoConnectionString.Replace("'", ""));
 mongoSettings.ServerSelectionTimeout = TimeSpan.FromSeconds(5);
 mongoSettings.ConnectTimeout = TimeSpan.FromSeconds(5);

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -107,7 +107,7 @@ builder.Services.AddSwaggerGen(f =>
 });
 
 // Configure and add MongoDB
-var mongoConnectionString = Environment.GetEnvironmentVariable("MONGO_CONNECTION_STRING") ?? "mongodb://localhost:27017/w3champions";
+string mongoConnectionString = Environment.GetEnvironmentVariable("MONGO_CONNECTION_STRING") ?? "mongodb://157.90.1.251:3513"; // "mongodb://localhost:27017";
 MongoClientSettings mongoSettings = MongoClientSettings.FromConnectionString(mongoConnectionString.Replace("'", ""));
 mongoSettings.ServerSelectionTimeout = TimeSpan.FromSeconds(5);
 mongoSettings.ConnectTimeout = TimeSpan.FromSeconds(5);

--- a/W3ChampionsStatisticService/Services/BackgroundTasks/UpdateMaxMmrService.cs
+++ b/W3ChampionsStatisticService/Services/BackgroundTasks/UpdateMaxMmrService.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using W3ChampionsStatisticService.PlayerProfiles;
 
 namespace W3ChampionsStatisticService.Services.BackgroundTasks;
+
 public class UpdateMaxMmrService(ILogger<UpdateMaxMmrService> logger, PlayerRepository playerRepository) : BackgroundService
 {
     private readonly ILogger<UpdateMaxMmrService> _logger = logger;

--- a/W3ChampionsStatisticService/W3ChampionsStats/MatchupLengths/MatchupLength.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MatchupLengths/MatchupLength.cs
@@ -4,6 +4,7 @@ using W3C.Domain.Repositories;
 using W3ChampionsStatisticService.W3ChampionsStats.GameLengths;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.MatchupLengths;
+
 public class MatchupLength : IIdentifiable
 {
     public string Id => CompoundNormalizedId(Race1, Race2, Season);

--- a/W3ChampionsStatisticService/W3ChampionsStats/MmrDistribution/MmrDistributionHandler.cs
+++ b/W3ChampionsStatisticService/W3ChampionsStats/MmrDistribution/MmrDistributionHandler.cs
@@ -8,6 +8,7 @@ using W3C.Domain.Tracing;
 using W3ChampionsStatisticService.Common.Constants;
 
 namespace W3ChampionsStatisticService.W3ChampionsStats.MmrDistribution;
+
 using Microsoft.Extensions.Caching.Memory;
 
 [Trace]

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -62,7 +62,7 @@ public class MatchupRepoTests : IntegrationTestBase
         await matchRepository.Insert(matchupHigh);
 
         // Only mid MMR match should be returned
-        var matches = await matchRepository.Load(matchLowMmr.match.season, matchLowMmr.match.gameMode, minMmr: 1200, maxMmr: 2000);
+        var matches = await matchRepository.Load(matchLowMmr.match.season, matchLowMmr.match.gameMode, minMmr: 1200, maxMmr: 2000, minDuration: null, maxDuration: null );
         Assert.AreEqual(1, matches.Count);
         Assert.IsTrue(matches.All(m => m.Teams.SelectMany(t => t.Players).Any(p => p.CurrentMmr >= 1200 && p.CurrentMmr <= 2000)));
 

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -62,7 +62,7 @@ public class MatchupRepoTests : IntegrationTestBase
         await matchRepository.Insert(matchupHigh);
 
         // Only mid MMR match should be returned
-        var matches = await matchRepository.Load(matchLowMmr.match.season, matchLowMmr.match.gameMode, minMmr: 1200, maxMmr: 2000, minDuration: null, maxDuration: null );
+        var matches = await matchRepository.Load(matchLowMmr.match.season, matchLowMmr.match.gameMode, minMmr: 1200, maxMmr: 2000, minDuration: null, maxDuration: null);
         Assert.AreEqual(1, matches.Count);
         Assert.IsTrue(matches.All(m => m.Teams.SelectMany(t => t.Players).Any(p => p.CurrentMmr >= 1200 && p.CurrentMmr <= 2000)));
 

--- a/WC3ChampionsStatisticService.UnitTests/Statistics/MmrDistributionHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Statistics/MmrDistributionHandlerTests.cs
@@ -8,6 +8,7 @@ using W3C.Contracts.Matchmaking;
 using Moq;
 
 namespace WC3ChampionsStatisticService.Statistics;
+
 [TestFixture]
 public class MmrDistributionHandlerTests
 {


### PR DESCRIPTION
This PR implements the backend portion of Issue #472 by adding optional match duration filtering to the /api/matches endpoint.

Changes:
- Added minDuration and maxDuration parameters to MatchesController.GetMatches
- Updated MatchRepository.Load to apply duration filters
- Updated MatchRepository.Count to include duration filters
- Updated GetLoadFilter to support duration range
- Updated unit tests to match new method signatures

Notes:
- Backend implementation is complete and tested.
- Frontend changes are required in the website repo to expose the new filters.

Closes #472
Would need a new item created for the front end. If granted access can try to finish.