### PR TITLE
feat: lag report API, MongoDB storage, and flo-stats integration

### DIFF
--- a/W3ChampionsStatisticService/LagReports/FloStatsService.cs
+++ b/W3ChampionsStatisticService/LagReports/FloStatsService.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+using W3C.Domain.Tracing;
+
+namespace W3ChampionsStatisticService.LagReports;
+
+/// <summary>
+/// Fetches server-side ping data from the flo-stats-service GraphQL API via WebSocket.
+/// The stats service uses subscriptions only (no HTTP queries for game stats).
+/// We connect, get the initial GameSnapshotWithStats, then disconnect.
+/// Data is LRU-cached — may be unavailable for older games.
+/// </summary>
+public interface IFloStatsService
+{
+    Task<List<ServerSidePingData>> FetchGamePingData(int floGameId);
+    Task FetchAndStoreIfNeeded(int floGameId, LagReportRepository repo);
+}
+
+[Trace]
+public class FloStatsService : IFloStatsService
+{
+    private static readonly string WsEndpoint =
+        Environment.GetEnvironmentVariable("FLO_STATS_WS_URL") ?? "wss://stats.w3flo.com/ws";
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    // Coalesce concurrent fetches for the same game — avoids duplicate WebSocket connections.
+    // Entries are removed on completion, so size is bounded by concurrent game endings.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<int, Task<List<ServerSidePingData>>>
+        _inflightFetches = new();
+
+    /// <summary>
+    /// Fetch accumulated ping data for a game from flo-stats via WebSocket subscription.
+    /// Returns null if the game is not found (evicted from LRU) or on any error.
+    /// </summary>
+    public async Task<List<ServerSidePingData>> FetchGamePingData(int floGameId)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(Timeout);
+            using var ws = new ClientWebSocket();
+            ws.Options.AddSubProtocol("graphql-transport-ws");
+
+            await ws.ConnectAsync(new Uri(WsEndpoint), cts.Token);
+
+            // 1. connection_init
+            await SendJson(ws, new { type = "connection_init" }, cts.Token);
+
+            // 2. Wait for connection_ack
+            var ack = await ReceiveJson(ws, cts.Token);
+            if (ack?.GetProperty("type").GetString() != "connection_ack")
+            {
+                Log.Warning("FloStatsService: expected connection_ack, got {Type}", ack?.GetProperty("type").GetString());
+                return null;
+            }
+
+            // 3. Subscribe to GameUpdateSub
+            await SendJson(ws, new
+            {
+                id = "1",
+                type = "subscribe",
+                payload = new
+                {
+                    query = @"subscription GameUpdateSub($id: Int!) {
+                        gameUpdateEvents(id: $id) {
+                            __typename
+                            ... on GameSnapshotWithStats {
+                                stats { ping { time data { playerId min max avg } } }
+                                game { players { id name } }
+                            }
+                        }
+                    }",
+                    variables = new { id = floGameId },
+                }
+            }, cts.Token);
+
+            // 4. Read the first "next" message (initial snapshot with accumulated stats)
+            //    The server may also send "error" if game not found.
+            var msg = await ReceiveJson(ws, cts.Token);
+            var msgType = msg?.GetProperty("type").GetString();
+
+            if (msgType == "error" || msgType == "complete")
+            {
+                Log.Information("FloStatsService: game {GameId} not found in flo-stats (type={Type})", floGameId, msgType);
+                return null;
+            }
+
+            if (msgType != "next")
+            {
+                Log.Warning("FloStatsService: unexpected message type {Type} for game {GameId}", msgType, floGameId);
+                return null;
+            }
+
+            // 5. Parse the snapshot
+            var payload = msg.Value.GetProperty("payload").GetProperty("data").GetProperty("gameUpdateEvents");
+            var typeName = payload.GetProperty("__typename").GetString();
+
+            if (typeName != "GameSnapshotWithStats")
+            {
+                Log.Information("FloStatsService: first event for game {GameId} was {Type}, not snapshot", floGameId, typeName);
+                return null;
+            }
+
+            return ParsePingData(payload);
+        }
+        catch (OperationCanceledException)
+        {
+            Log.Warning("FloStatsService: timeout fetching ping data for game {GameId}", floGameId);
+            return null;
+        }
+        catch (WebSocketException ex)
+        {
+            Log.Warning(ex, "FloStatsService: WebSocket error for game {GameId}", floGameId);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "FloStatsService: failed to fetch ping data for game {GameId}", floGameId);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Fetch ping data and store it on the lag report if not already populated.
+    /// Concurrent calls for the same game share a single WebSocket fetch and a single write.
+    /// </summary>
+    public async Task FetchAndStoreIfNeeded(int floGameId, LagReportRepository repo)
+    {
+        var report = await repo.GetByFloGameId(floGameId);
+        if (report == null || report.ServerSidePing != null)
+        {
+            return;
+        }
+
+        // Coalesce: all concurrent callers for the same game share one fetch+store task
+        var task = _inflightFetches.GetOrAdd(floGameId, id => FetchAndStore(id, repo));
+        try
+        {
+            await task;
+        }
+        finally
+        {
+            _inflightFetches.TryRemove(floGameId, out _);
+        }
+    }
+
+    private async Task<List<ServerSidePingData>> FetchAndStore(int floGameId, LagReportRepository repo)
+    {
+        var pingData = await FetchGamePingData(floGameId);
+
+        var report = await repo.GetByFloGameId(floGameId);
+        if (report != null && report.ServerSidePing == null)
+        {
+            await repo.UpdateServerSidePing(report.Id, pingData ?? []);
+        }
+
+        return pingData;
+    }
+
+    private static List<ServerSidePingData> ParsePingData(JsonElement payload)
+    {
+        var playerNames = new Dictionary<int, string>();
+        if (payload.TryGetProperty("game", out var game) &&
+            game.TryGetProperty("players", out var players))
+        {
+            foreach (var p in players.EnumerateArray())
+            {
+                var id = p.GetProperty("id").GetInt32();
+                var name = p.GetProperty("name").GetString();
+                playerNames[id] = name;
+            }
+        }
+
+        var byPlayer = new Dictionary<int, List<ServerPingSample>>();
+
+        if (payload.TryGetProperty("stats", out var stats) &&
+            stats.TryGetProperty("ping", out var pingArray))
+        {
+            foreach (var entry in pingArray.EnumerateArray())
+            {
+                var time = entry.GetProperty("time").GetDouble();
+                if (!entry.TryGetProperty("data", out var dataArray)) continue;
+
+                foreach (var d in dataArray.EnumerateArray())
+                {
+                    var playerId = d.GetProperty("playerId").GetInt32();
+                    if (!byPlayer.ContainsKey(playerId))
+                    {
+                        byPlayer[playerId] = [];
+                    }
+                    byPlayer[playerId].Add(new ServerPingSample
+                    {
+                        Time = time,
+                        Min = d.TryGetProperty("min", out var min) && min.ValueKind == JsonValueKind.Number ? min.GetInt32() : null,
+                        Max = d.TryGetProperty("max", out var max) && max.ValueKind == JsonValueKind.Number ? max.GetInt32() : null,
+                        Avg = d.TryGetProperty("avg", out var avg) && avg.ValueKind == JsonValueKind.Number ? avg.GetInt32() : null,
+                    });
+                }
+            }
+        }
+
+        return byPlayer.Select(kv => new ServerSidePingData
+        {
+            PlayerId = kv.Key,
+            PlayerName = playerNames.GetValueOrDefault(kv.Key, $"Player {kv.Key}"),
+            Samples = kv.Value,
+        }).ToList();
+    }
+
+    private static async Task SendJson<T>(ClientWebSocket ws, T obj, CancellationToken ct)
+    {
+        var json = JsonSerializer.Serialize(obj);
+        var bytes = Encoding.UTF8.GetBytes(json);
+        await ws.SendAsync(bytes, WebSocketMessageType.Text, true, ct);
+    }
+
+    private static async Task<JsonElement?> ReceiveJson(ClientWebSocket ws, CancellationToken ct)
+    {
+        using var ms = new MemoryStream();
+        var buffer = ArrayPool<byte>.Shared.Rent(4096);
+        try
+        {
+            WebSocketReceiveResult result;
+            do
+            {
+                result = await ws.ReceiveAsync(buffer, ct);
+                ms.Write(buffer, 0, result.Count);
+            } while (!result.EndOfMessage);
+
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                return null;
+            }
+
+            ms.Position = 0;
+            var doc = await JsonDocument.ParseAsync(ms, cancellationToken: ct);
+            return doc.RootElement.Clone();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}

--- a/W3ChampionsStatisticService/LagReports/JsonStringEnumListConverter.cs
+++ b/W3ChampionsStatisticService/LagReports/JsonStringEnumListConverter.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace W3ChampionsStatisticService.LagReports;
+
+public class JsonStringEnumListConverter<TEnum> : JsonConverter<List<TEnum>> where TEnum : struct, Enum
+{
+    public override List<TEnum> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var list = new List<TEnum>();
+        if (reader.TokenType != JsonTokenType.StartArray)
+        {
+            throw new JsonException("Expected start of array");
+        }
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+        {
+            var value = reader.GetString();
+            if (Enum.TryParse<TEnum>(value, ignoreCase: true, out var parsed))
+            {
+                list.Add(parsed);
+            }
+        }
+        return list;
+    }
+
+    public override void Write(Utf8JsonWriter writer, List<TEnum> value, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray();
+        foreach (var item in value)
+        {
+            writer.WriteStringValue(item.ToString());
+        }
+        writer.WriteEndArray();
+    }
+}

--- a/W3ChampionsStatisticService/LagReports/LagReport.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReport.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using W3C.Domain.Repositories;
+
+namespace W3ChampionsStatisticService.LagReports;
+
+/// <summary>
+/// Root document — one per game. Multiple players' reports are merged
+/// into the same document via UpsertPlayerData.
+/// </summary>
+[BsonIgnoreExtraElements]
+public class LagReport : IIdentifiable
+{
+    [BsonId]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>W3C match ID (from matchmaking).</summary>
+    public int GameId { get; set; }
+
+    /// <summary>Flo game ID (from flo-controller).</summary>
+    public int FloGameId { get; set; }
+
+    public string GameName { get; set; }
+    public string MapPath { get; set; }
+
+    /// <summary>The flo-node that hosted this game.</summary>
+    public int ServerNodeId { get; set; }
+    public string ServerNodeName { get; set; }
+
+    /// <summary>True if at least one player explicitly submitted (clicked Submit).</summary>
+    public bool HasExplicitReport { get; set; }
+
+    public List<LagReportPlayer> Players { get; set; } = [];
+
+    /// <summary>
+    /// Server-side ping data fetched from flo-stats-service after the game ends.
+    /// Null until the match-finished handler populates it.
+    /// </summary>
+    public List<ServerSidePingData> ServerSidePing { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// Per-player data within a lag report.
+/// Each player in the game can submit independently (explicit or auto).
+/// </summary>
+public class LagReportPlayer
+{
+    public string BattleTag { get; set; }
+
+    /// <summary>Player's public IP at time of game (self-reported by launcher).</summary>
+    public string ClientIp { get; set; }
+
+    /// <summary>Whether the player connected directly or via a proxy node.</summary>
+    public EConnectionType ConnectionType { get; set; }
+
+    /// <summary>Name of the proxy node (null if direct).</summary>
+    public string ProxyName { get; set; }
+
+    /// <summary>IP of the proxy node (null if direct). Split from proxy_address for filtering.</summary>
+    public string ProxyIp { get; set; }
+
+    /// <summary>Port of the proxy node (null if direct).</summary>
+    public int? ProxyPort { get; set; }
+
+    /// <summary>True if the player explicitly clicked Submit (vs auto-submit on dismiss/close).</summary>
+    public bool IsExplicit { get; set; }
+
+    /// <summary>Issue categories selected by the player (e.g. SpikeLag, Reconnecting).</summary>
+    public List<EIssueCategory> IssueCategories { get; set; } = [];
+
+    /// <summary>Free-text description from the player.</summary>
+    public string FreeText { get; set; } = "";
+
+    /// <summary>Per-lag-event annotations added by the player in the post-game dialog.</summary>
+    public List<LagReportAnnotation> Annotations { get; set; } = [];
+
+    /// <summary>All diagnostics data collected by the flo client during the game.</summary>
+    public PlayerDiagnostics Diagnostics { get; set; }
+}
+
+/// <summary>
+/// Diagnostics measurements collected by the flo client for a single player.
+/// </summary>
+public class PlayerDiagnostics
+{
+    /// <summary>Lag events triggered by the player via !lag command.</summary>
+    public List<LagEvent> LagEvents { get; set; } = [];
+
+    /// <summary>MTR traces to the target/proxy: 60s continuous + 5s burst on events.</summary>
+    public List<TraceMeasurement> TargetMtr { get; set; } = [];
+
+    /// <summary>Baseline MTR to all servers at game start/end and on events.</summary>
+    public List<ServerBaseline> AllServerBaselines { get; set; } = [];
+
+    /// <summary>Reverse MTR from flo-node back to the player.</summary>
+    public List<TraceMeasurement> ReverseMtr { get; set; } = [];
+
+    /// <summary>Periodic ping snapshots (min/max/avg/stddev/loss) from the PingActor.</summary>
+    public List<PingSample> PingHistory { get; set; } = [];
+
+    /// <summary>Connection events: reconnects and disconnects.</summary>
+    public List<ConnectionEventData> ConnectionEvents { get; set; } = [];
+}
+
+/// <summary>A !lag event: the moment the player entered the command.</summary>
+public class LagEvent
+{
+    [BsonRepresentation(BsonType.Array)]
+    public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>Milliseconds since game start.</summary>
+    public long GameTimeOffsetMs { get; set; }
+
+    /// <summary>Player annotation added in post-game dialog (null if not annotated).</summary>
+    public string Annotation { get; set; }
+}
+
+/// <summary>A single MTR trace (forward to target or reverse from flo-node).</summary>
+public class TraceMeasurement
+{
+    [BsonRepresentation(BsonType.Array)]
+    public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>IP address of the trace target.</summary>
+    public string Target { get; set; }
+
+    public List<HopData> Hops { get; set; } = [];
+}
+
+/// <summary>Baseline MTR trace to a specific game server.</summary>
+public class ServerBaseline
+{
+    [BsonRepresentation(BsonType.Array)]
+    public DateTimeOffset Timestamp { get; set; }
+
+    public int ServerId { get; set; }
+    public string ServerName { get; set; }
+
+    /// <summary>IP address of the server.</summary>
+    public string Target { get; set; }
+
+    public List<HopData> Hops { get; set; } = [];
+}
+
+/// <summary>A single hop in an MTR trace.</summary>
+public class HopData
+{
+    public int HopNumber { get; set; }
+
+    /// <summary>IP address of the hop (null if no response / timeout).</summary>
+    public string Host { get; set; }
+
+    public double? AvgRttMs { get; set; }
+    public double? MinRttMs { get; set; }
+    public double? MaxRttMs { get; set; }
+    public double? StddevMs { get; set; }
+
+    /// <summary>Packet loss percentage (0–100).</summary>
+    public double LossPercent { get; set; }
+}
+
+/// <summary>A periodic ping snapshot from the flo client's PingActor.</summary>
+public class PingSample
+{
+    [BsonRepresentation(BsonType.Array)]
+    public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>Ping values in milliseconds.</summary>
+    public int? Min { get; set; }
+    public int? Max { get; set; }
+    public int? Avg { get; set; }
+    public float? Stddev { get; set; }
+    public int? Current { get; set; }
+
+    /// <summary>Packet loss rate (0.0–1.0).</summary>
+    public float LossRate { get; set; }
+}
+
+/// <summary>A connection event: reconnect or disconnect.</summary>
+public class ConnectionEventData
+{
+    [BsonRepresentation(BsonType.Array)]
+    public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>Milliseconds since game start. Frozen during disconnects (no ticks arrive).</summary>
+    public long GameTimeOffsetMs { get; set; }
+
+    public EConnectionEventType EventType { get; set; }
+
+    /// <summary>For reconnects: how long the disconnection lasted (ms). Null for disconnects.</summary>
+    public long? DurationMs { get; set; }
+}
+
+/// <summary>Player annotation for a specific lag event, keyed by game time offset.</summary>
+public class LagReportAnnotation
+{
+    /// <summary>Milliseconds since game start — matches the LagEvent it annotates.</summary>
+    public long GameTimeOffsetMs { get; set; }
+
+    public string Text { get; set; }
+}
+
+/// <summary>
+/// Server-side ping data for a player, fetched from flo-stats-service GraphQL
+/// after the game ends. Provides the server's view of ping (complements client-side PingSample).
+/// </summary>
+public class ServerSidePingData
+{
+    public int PlayerId { get; set; }
+    public string PlayerName { get; set; }
+    public List<ServerPingSample> Samples { get; set; } = [];
+}
+
+/// <summary>A single server-side ping snapshot from flo-stats.</summary>
+public class ServerPingSample
+{
+    /// <summary>Seconds since game start.</summary>
+    public double Time { get; set; }
+    public int? Min { get; set; }
+    public int? Max { get; set; }
+    public int? Avg { get; set; }
+}

--- a/W3ChampionsStatisticService/LagReports/LagReport.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReport.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using W3C.Domain.Repositories;
@@ -56,6 +57,7 @@ public class LagReportPlayer
     public string ClientIp { get; set; }
 
     /// <summary>Whether the player connected directly or via a proxy node.</summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public EConnectionType ConnectionType { get; set; }
 
     /// <summary>Name of the proxy node (null if direct).</summary>
@@ -71,6 +73,7 @@ public class LagReportPlayer
     public bool IsExplicit { get; set; }
 
     /// <summary>Issue categories selected by the player (e.g. SpikeLag, Reconnecting).</summary>
+    [JsonConverter(typeof(JsonStringEnumListConverter<EIssueCategory>))]
     public List<EIssueCategory> IssueCategories { get; set; } = [];
 
     /// <summary>Free-text description from the player.</summary>
@@ -190,6 +193,7 @@ public class ConnectionEventData
     /// <summary>Milliseconds since game start. Frozen during disconnects (no ticks arrive).</summary>
     public long GameTimeOffsetMs { get; set; }
 
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public EConnectionEventType EventType { get; set; }
 
     /// <summary>For reconnects: how long the disconnection lasted (ms). Null for disconnects.</summary>

--- a/W3ChampionsStatisticService/LagReports/LagReportController.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportController.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using W3C.Contracts.Admin.Permission;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.WebApi.ActionFilters;
+
+namespace W3ChampionsStatisticService.LagReports;
+
+[ApiController]
+[Route("api/lag-reports")]
+[Trace]
+public class LagReportController(LagReportRepository lagReportRepository, IFloStatsService floStatsService) : ControllerBase
+{
+    private readonly LagReportRepository _lagReportRepository = lagReportRepository;
+    private readonly IFloStatsService _floStatsService = floStatsService;
+
+    /// <summary>
+    /// Submit a lag report — called by the launcher for each player (explicit or auto).
+    /// Authenticated users only (any player, not admin-only).
+    /// </summary>
+    [HttpPost]
+    [InjectActingPlayerAuthCode]
+    public async Task<IActionResult> SubmitReport([FromBody] LagReportSubmissionDto dto, string actingPlayer)
+    {
+        var validationError = ValidateSubmission(dto);
+        if (validationError != null)
+        {
+            return BadRequest(new { Error = validationError });
+        }
+
+        var playerData = MapToPlayer(dto, actingPlayer);
+
+        var template = new LagReport
+        {
+            GameId = dto.GameMetadata.GameId,
+            FloGameId = dto.GameMetadata.FloGameId,
+            GameName = dto.GameMetadata.GameName,
+            MapPath = dto.GameMetadata.MapPath,
+            ServerNodeId = dto.ConnectionTopology.ServerNodeId,
+            ServerNodeName = dto.ConnectionTopology.ServerNodeName,
+        };
+
+        var reportId = await _lagReportRepository.UpsertPlayerData(
+            dto.GameMetadata.FloGameId,
+            playerData,
+            template
+        );
+
+        // Fire-and-forget: fetch server-side ping from flo-stats while data is still in LRU.
+        // The match-finished handler is a fallback, but often runs before any player submits.
+        _ = _floStatsService.FetchAndStoreIfNeeded(dto.GameMetadata.FloGameId, _lagReportRepository);
+
+        return Ok(new LagReportSubmissionResponse { ReportId = reportId });
+    }
+
+    /// <summary>Admin: list lag reports with filters and pagination.</summary>
+    [HttpGet]
+    [BearerHasPermissionFilter(Permission = EPermission.Proxies)]
+    public async Task<IActionResult> GetReports([FromQuery] LagReportQueryRequest req)
+    {
+        req.PageSize = Math.Clamp(req.PageSize, 1, 100);
+        req.Page = Math.Max(req.Page, 0);
+
+        var (items, total) = await _lagReportRepository.GetReports(req);
+
+        var listItems = items.Select(r => new LagReportListItem
+        {
+            Id = r.Id,
+            GameId = r.GameId,
+            FloGameId = r.FloGameId,
+            GameName = r.GameName,
+            MapPath = r.MapPath,
+            ServerNodeId = r.ServerNodeId,
+            ServerNodeName = r.ServerNodeName,
+            CreatedAt = r.CreatedAt,
+            HasExplicitReport = r.HasExplicitReport,
+            Players = r.Players.Select(p => new LagReportPlayerSummary
+            {
+                BattleTag = p.BattleTag,
+                IsExplicit = p.IsExplicit,
+                ConnectionType = p.ConnectionType,
+                ProxyName = p.ProxyName,
+                IssueCategories = p.IssueCategories,
+                LagEventCount = p.Diagnostics?.LagEvents?.Count ?? 0,
+                ConnectionEventCount = p.Diagnostics?.ConnectionEvents?.Count ?? 0,
+            }).ToList(),
+        }).ToList();
+
+        return Ok(new { Items = listItems, Total = total });
+    }
+
+    /// <summary>Admin: get a single lag report with full diagnostics data.</summary>
+    [HttpGet("{id}")]
+    [BearerHasPermissionFilter(Permission = EPermission.Proxies)]
+    public async Task<IActionResult> GetReport(string id)
+    {
+        var report = await _lagReportRepository.GetById(id);
+        if (report == null)
+        {
+            return NotFound();
+        }
+        return Ok(report);
+    }
+
+    internal static string ValidateSubmission(LagReportSubmissionDto dto)
+    {
+        if (dto.Diagnostics == null) return "Missing diagnostics";
+        if (dto.GameMetadata == null) return "Missing game_metadata";
+        if (dto.ConnectionTopology == null) return "Missing connection_topology";
+
+        var diag = dto.Diagnostics;
+        if ((diag.LagEvents?.Count ?? 0) > 200) return "Too many lag_events";
+        if ((diag.TargetMtr?.Count ?? 0) > 500) return "Too many target_mtr";
+        if ((diag.AllServerBaselines?.Count ?? 0) > 1000) return "Too many all_server_baselines";
+        if ((diag.ReverseMtr?.Count ?? 0) > 500) return "Too many reverse_mtr";
+        if ((diag.PingHistory?.Count ?? 0) > 5000) return "Too many ping_history";
+        if ((diag.ConnectionEvents?.Count ?? 0) > 200) return "Too many connection_events";
+        if ((dto.Annotations?.Count ?? 0) > 200) return "Too many annotations";
+        if ((dto.Categories?.Count ?? 0) > 20) return "Too many categories";
+
+        if (dto.FreeText?.Length > 5000) return "free_text too long";
+        if (dto.GameMetadata.GameName?.Length > 500) return "game_name too long";
+        if (dto.GameMetadata.MapPath?.Length > 500) return "map_path too long";
+        if (dto.ConnectionTopology.ServerNodeName?.Length > 500) return "server_node_name too long";
+        if (dto.ConnectionTopology.ProxyName?.Length > 500) return "proxy_name too long";
+        if (dto.ConnectionTopology.ProxyAddress?.Length > 500) return "proxy_address too long";
+        if (dto.ConnectionTopology.ClientIp?.Length > 100) return "client_ip too long";
+
+        foreach (var trace in (diag.TargetMtr ?? []).Concat(diag.ReverseMtr ?? []))
+        {
+            if (trace.Trace?.Hops?.Count > 64) return "Too many hops in trace";
+        }
+        foreach (var baseline in diag.AllServerBaselines ?? [])
+        {
+            if (baseline.Trace?.Hops?.Count > 64) return "Too many hops in baseline";
+        }
+        foreach (var annotation in dto.Annotations ?? [])
+        {
+            if (annotation.Text?.Length > 1000) return "Annotation text too long";
+        }
+        foreach (var lagEvent in diag.LagEvents ?? [])
+        {
+            if (lagEvent.Annotation?.Length > 1000) return "Lag event annotation too long";
+        }
+
+        return null;
+    }
+
+    internal static LagReportPlayer MapToPlayer(LagReportSubmissionDto dto, string battleTag)
+    {
+        var topo = dto.ConnectionTopology;
+
+        // Parse "ip:port" into separate fields
+        string proxyIp = null;
+        int? proxyPort = null;
+        if (!string.IsNullOrEmpty(topo.ProxyAddress))
+        {
+            var lastColon = topo.ProxyAddress.LastIndexOf(':');
+            if (lastColon > 0)
+            {
+                proxyIp = topo.ProxyAddress[..lastColon];
+                if (int.TryParse(topo.ProxyAddress[(lastColon + 1)..], out var port))
+                {
+                    proxyPort = port;
+                }
+            }
+            else
+            {
+                proxyIp = topo.ProxyAddress;
+            }
+        }
+
+        var diag = dto.Diagnostics;
+
+        // Merge annotations into lag events
+        var annotationsByOffset = (dto.Annotations ?? [])
+            .ToDictionary(a => a.GameTimeOffsetMs, a => a.Text);
+
+        return new LagReportPlayer
+        {
+            BattleTag = battleTag,
+            ClientIp = topo.ClientIp,
+            ConnectionType = topo.ConnectionType,
+            ProxyName = topo.ProxyName,
+            ProxyIp = proxyIp,
+            ProxyPort = proxyPort,
+            IsExplicit = dto.IsExplicit,
+            IssueCategories = dto.Categories ?? [],
+            FreeText = dto.FreeText ?? "",
+            Annotations = (dto.Annotations ?? []).Select(a => new LagReportAnnotation
+            {
+                GameTimeOffsetMs = a.GameTimeOffsetMs,
+                Text = a.Text,
+            }).ToList(),
+            Diagnostics = new PlayerDiagnostics
+            {
+                LagEvents = (diag.LagEvents ?? []).Select(e => new LagEvent
+                {
+                    Timestamp = e.Timestamp,
+                    GameTimeOffsetMs = e.GameTimeOffsetMs,
+                    Annotation = annotationsByOffset.GetValueOrDefault(e.GameTimeOffsetMs),
+                }).ToList(),
+                TargetMtr = (diag.TargetMtr ?? []).Where(t => t.Trace != null).Select(MapTrace).ToList(),
+                AllServerBaselines = (diag.AllServerBaselines ?? []).Where(s => s.Trace != null).Select(s => new ServerBaseline
+                {
+                    Timestamp = s.Timestamp,
+                    ServerId = s.ServerId,
+                    ServerName = s.ServerName,
+                    Target = s.Trace.Target,
+                    Hops = (s.Trace.Hops ?? []).Select(MapHop).ToList(),
+                }).ToList(),
+                ReverseMtr = (diag.ReverseMtr ?? []).Where(t => t.Trace != null).Select(MapTrace).ToList(),
+                PingHistory = (diag.PingHistory ?? []).Select(p => new PingSample
+                {
+                    Timestamp = p.Timestamp,
+                    Min = (int?)p.Stats.Min,
+                    Max = (int?)p.Stats.Max,
+                    Avg = (int?)p.Stats.Avg,
+                    Stddev = (float?)p.Stats.Stddev,
+                    Current = (int?)p.Stats.Current,
+                    LossRate = (float)p.Stats.LossRate,
+                }).ToList(),
+                ConnectionEvents = (diag.ConnectionEvents ?? []).Select(c => new ConnectionEventData
+                {
+                    Timestamp = c.Timestamp,
+                    GameTimeOffsetMs = c.GameTimeOffsetMs,
+                    EventType = c.EventType,
+                    DurationMs = c.DurationMs,
+                }).ToList(),
+            },
+        };
+    }
+
+    private static TraceMeasurement MapTrace(TimedTraceDto t) => new()
+    {
+        Timestamp = t.Timestamp,
+        Target = t.Trace.Target,
+        Hops = (t.Trace.Hops ?? []).Select(MapHop).ToList(),
+    };
+
+    private static HopData MapHop(HopDto h) => new()
+    {
+        HopNumber = h.HopNumber,
+        Host = h.Host,
+        AvgRttMs = h.AvgRttMs,
+        MinRttMs = h.MinRttMs,
+        MaxRttMs = h.MaxRttMs,
+        StddevMs = h.StddevMs,
+        LossPercent = h.LossPercent,
+    };
+}

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -235,8 +235,8 @@ public class LagReportSubmissionResponse
 public class LagReportQueryRequest
 {
     public string BattleTag { get; set; }
-    public int? GameId { get; set; }
-    public int? ServerNodeId { get; set; }
+    public string GameSearch { get; set; }
+    public string ServerName { get; set; }
     public string ProxyName { get; set; }
     public string ProxyIp { get; set; }
     public string DateFrom { get; set; }

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace W3ChampionsStatisticService.LagReports;
+
+// ── Submission DTOs (match launcher snake_case JSON) ──────────────────
+
+public class LagReportSubmissionDto
+{
+    [JsonPropertyName("diagnostics")]
+    public DiagnosticsDataDto Diagnostics { get; set; }
+
+    [JsonPropertyName("game_metadata")]
+    public GameMetadataDto GameMetadata { get; set; }
+
+    [JsonPropertyName("connection_topology")]
+    public ConnectionTopologyDto ConnectionTopology { get; set; }
+
+    [JsonPropertyName("is_explicit")]
+    public bool IsExplicit { get; set; }
+
+    [JsonPropertyName("annotations")]
+    public List<AnnotationDto> Annotations { get; set; } = [];
+
+    [JsonPropertyName("categories")]
+    [JsonConverter(typeof(JsonStringEnumListConverter<EIssueCategory>))]
+    public List<EIssueCategory> Categories { get; set; } = [];
+
+    [JsonPropertyName("free_text")]
+    public string FreeText { get; set; } = "";
+}
+
+public class GameMetadataDto
+{
+    [JsonPropertyName("game_id")]
+    public int GameId { get; set; }
+
+    [JsonPropertyName("flo_game_id")]
+    public int FloGameId { get; set; }
+
+    [JsonPropertyName("map_path")]
+    public string MapPath { get; set; } = "";
+
+    [JsonPropertyName("game_name")]
+    public string GameName { get; set; } = "";
+}
+
+public class ConnectionTopologyDto
+{
+    [JsonPropertyName("server_node_id")]
+    public int ServerNodeId { get; set; }
+
+    [JsonPropertyName("server_node_name")]
+    public string ServerNodeName { get; set; } = "";
+
+    [JsonPropertyName("proxy_name")]
+    public string ProxyName { get; set; }
+
+    [JsonPropertyName("proxy_address")]
+    public string ProxyAddress { get; set; }
+
+    [JsonPropertyName("connection_type")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public EConnectionType ConnectionType { get; set; } = EConnectionType.Direct;
+
+    [JsonPropertyName("client_ip")]
+    public string ClientIp { get; set; }
+}
+
+public class DiagnosticsDataDto
+{
+    [JsonPropertyName("game_id")]
+    public int GameId { get; set; }
+
+    [JsonPropertyName("player_id")]
+    public int PlayerId { get; set; }
+
+    [JsonPropertyName("lag_events")]
+    public List<LagEventDto> LagEvents { get; set; } = [];
+
+    [JsonPropertyName("target_mtr")]
+    public List<TimedTraceDto> TargetMtr { get; set; } = [];
+
+    [JsonPropertyName("all_server_baselines")]
+    public List<ServerTraceDto> AllServerBaselines { get; set; } = [];
+
+    [JsonPropertyName("reverse_mtr")]
+    public List<TimedTraceDto> ReverseMtr { get; set; } = [];
+
+    [JsonPropertyName("ping_history")]
+    public List<TimedPingStatsDto> PingHistory { get; set; } = [];
+
+    [JsonPropertyName("connection_events")]
+    public List<ConnectionEventDto> ConnectionEvents { get; set; } = [];
+}
+
+public class LagEventDto
+{
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; set; }
+
+    [JsonPropertyName("game_time_offset")]
+    public long GameTimeOffsetMs { get; set; }
+
+    [JsonPropertyName("annotation")]
+    public string Annotation { get; set; }
+}
+
+public class TimedTraceDto
+{
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; set; }
+
+    [JsonPropertyName("trace")]
+    public TraceResultDto Trace { get; set; }
+}
+
+public class ServerTraceDto
+{
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; set; }
+
+    [JsonPropertyName("server_id")]
+    public int ServerId { get; set; }
+
+    [JsonPropertyName("server_name")]
+    public string ServerName { get; set; }
+
+    [JsonPropertyName("trace")]
+    public TraceResultDto Trace { get; set; }
+}
+
+public class TraceResultDto
+{
+    [JsonPropertyName("target")]
+    public string Target { get; set; }
+
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; set; }
+
+    [JsonPropertyName("hops")]
+    public List<HopDto> Hops { get; set; } = [];
+}
+
+public class HopDto
+{
+    [JsonPropertyName("hop_number")]
+    public int HopNumber { get; set; }
+
+    [JsonPropertyName("host")]
+    public string Host { get; set; }
+
+    [JsonPropertyName("avg_rtt_ms")]
+    public double? AvgRttMs { get; set; }
+
+    [JsonPropertyName("min_rtt_ms")]
+    public double? MinRttMs { get; set; }
+
+    [JsonPropertyName("max_rtt_ms")]
+    public double? MaxRttMs { get; set; }
+
+    [JsonPropertyName("stddev_ms")]
+    public double? StddevMs { get; set; }
+
+    [JsonPropertyName("loss_percent")]
+    public double LossPercent { get; set; }
+}
+
+public class TimedPingStatsDto
+{
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; set; }
+
+    [JsonPropertyName("stats")]
+    public PingStatsDto Stats { get; set; }
+}
+
+public class PingStatsDto
+{
+    [JsonPropertyName("min")]
+    public double? Min { get; set; }
+
+    [JsonPropertyName("max")]
+    public double? Max { get; set; }
+
+    [JsonPropertyName("avg")]
+    public double? Avg { get; set; }
+
+    [JsonPropertyName("stddev")]
+    public double? Stddev { get; set; }
+
+    [JsonPropertyName("current")]
+    public double? Current { get; set; }
+
+    [JsonPropertyName("loss_rate")]
+    public double LossRate { get; set; }
+}
+
+public class ConnectionEventDto
+{
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; set; }
+
+    [JsonPropertyName("game_time_offset")]
+    public long GameTimeOffsetMs { get; set; }
+
+    [JsonPropertyName("event_type")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public EConnectionEventType EventType { get; set; }
+
+    [JsonPropertyName("duration")]
+    public long? DurationMs { get; set; }
+}
+
+public class AnnotationDto
+{
+    [JsonPropertyName("game_time_offset")]
+    public long GameTimeOffsetMs { get; set; }
+
+    [JsonPropertyName("text")]
+    public string Text { get; set; }
+}
+
+// ── Response ──────────────────────────────────────────────────────────
+
+public class LagReportSubmissionResponse
+{
+    [JsonPropertyName("report_id")]
+    public string ReportId { get; set; }
+}
+
+// ── Admin query request ───────────────────────────────────────────────
+
+public class LagReportQueryRequest
+{
+    public string BattleTag { get; set; }
+    public int? GameId { get; set; }
+    public int? ServerNodeId { get; set; }
+    public string ProxyName { get; set; }
+    public string ProxyIp { get; set; }
+    public string DateFrom { get; set; }
+    public string DateTo { get; set; }
+    public string IssueCategory { get; set; }
+    public bool? ExplicitOnly { get; set; }
+    public int Page { get; set; } = 0;
+    public int PageSize { get; set; } = 20;
+}
+
+// ── Admin list item ───────────────────────────────────────────────────
+
+public class LagReportListItem
+{
+    public string Id { get; set; }
+    public int GameId { get; set; }
+    public int FloGameId { get; set; }
+    public string GameName { get; set; }
+    public string MapPath { get; set; }
+    public int ServerNodeId { get; set; }
+    public string ServerNodeName { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public bool HasExplicitReport { get; set; }
+    public List<LagReportPlayerSummary> Players { get; set; } = [];
+}
+
+public class LagReportPlayerSummary
+{
+    public string BattleTag { get; set; }
+    public bool IsExplicit { get; set; }
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public EConnectionType ConnectionType { get; set; }
+    public string ProxyName { get; set; }
+    [JsonConverter(typeof(JsonStringEnumListConverter<EIssueCategory>))]
+    public List<EIssueCategory> IssueCategories { get; set; } = [];
+    public int LagEventCount { get; set; }
+    public int ConnectionEventCount { get; set; }
+}

--- a/W3ChampionsStatisticService/LagReports/LagReportEnums.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportEnums.cs
@@ -12,6 +12,7 @@ public enum EIssueCategory
     FullDisconnect,
     Desync,
     FpsDrops,
+    GameCrashed,
     Other,
 }
 
@@ -19,6 +20,7 @@ public enum EConnectionEventType
 {
     Reconnect,
     FailureDisconnect,
+    GameCrashed,
 }
 
 public enum EConnectionType

--- a/W3ChampionsStatisticService/LagReports/LagReportEnums.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportEnums.cs
@@ -1,0 +1,28 @@
+namespace W3ChampionsStatisticService.LagReports;
+
+public enum EIssueCategory
+{
+    InputDelay,
+    GameStutter,
+    WaitingForPlayers,
+    RubberBanding,
+    SpikeLag,
+    ConsistentLag,
+    Reconnecting,
+    FullDisconnect,
+    Desync,
+    FpsDrops,
+    Other,
+}
+
+public enum EConnectionEventType
+{
+    Reconnect,
+    FailureDisconnect,
+}
+
+public enum EConnectionType
+{
+    Direct,
+    Proxied,
+}

--- a/W3ChampionsStatisticService/LagReports/LagReportEnums.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportEnums.cs
@@ -21,6 +21,10 @@ public enum EConnectionEventType
     Reconnect,
     FailureDisconnect,
     GameCrashed,
+    GamePaused,
+    GameResumed,
+    StartLag,
+    StopLag,
 }
 
 public enum EConnectionType

--- a/W3ChampionsStatisticService/LagReports/LagReportMatchCanceledHandler.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportMatchCanceledHandler.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using W3C.Domain.MatchmakingService;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.ReadModelBase;
+
+namespace W3ChampionsStatisticService.LagReports;
+
+/// <summary>
+/// When a match is canceled, check if a lag report exists for that game
+/// and fetch server-side ping data from flo-stats if needed.
+/// Canceled games (e.g. disconnects) are often the most interesting for diagnostics.
+/// </summary>
+[Trace]
+public class LagReportMatchCanceledHandler(
+    LagReportRepository lagReportRepository,
+    IFloStatsService floStatsService
+) : IMatchCanceledReadModelHandler
+{
+    public async Task Update(MatchCanceledEvent nextEvent)
+    {
+        var floGameId = nextEvent.match.floGameId;
+        if (floGameId == null)
+        {
+            return;
+        }
+
+        await floStatsService.FetchAndStoreIfNeeded(floGameId.Value, lagReportRepository);
+    }
+}

--- a/W3ChampionsStatisticService/LagReports/LagReportMatchFinishedHandler.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportMatchFinishedHandler.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using W3C.Domain.MatchmakingService;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.ReadModelBase;
+
+namespace W3ChampionsStatisticService.LagReports;
+
+/// <summary>
+/// When a match finishes, check if a lag report exists for that game
+/// and fetch server-side ping data from flo-stats if needed.
+/// </summary>
+[Trace]
+public class LagReportMatchFinishedHandler(
+    LagReportRepository lagReportRepository,
+    IFloStatsService floStatsService
+) : IMatchFinishedReadModelHandler
+{
+    public async Task Update(MatchFinishedEvent nextEvent)
+    {
+        var floGameId = nextEvent.match.floGameId;
+        if (floGameId == null)
+        {
+            return;
+        }
+
+        await floStatsService.FetchAndStoreIfNeeded(floGameId.Value, lagReportRepository);
+    }
+}

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using W3C.Domain.Repositories;
 using W3C.Domain.Tracing;
@@ -28,6 +30,12 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
 
             // Server filter
             new(Builders<LagReport>.IndexKeys.Ascending(r => r.ServerNodeId)),
+
+            // Server name filter (partial match)
+            new(Builders<LagReport>.IndexKeys.Ascending(r => r.ServerNodeName)),
+
+            // Game name filter (partial match)
+            new(Builders<LagReport>.IndexKeys.Ascending(r => r.GameName)),
 
             // Player battle tag filter (inside nested array)
             new(Builders<LagReport>.IndexKeys.Ascending("Players.BattleTag")),
@@ -145,27 +153,47 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
 
         if (!string.IsNullOrEmpty(req.BattleTag))
         {
-            filters.Add(builder.ElemMatch(r => r.Players, p => p.BattleTag == req.BattleTag));
+            var pattern = new BsonRegularExpression(Regex.Escape(req.BattleTag), "i");
+            filters.Add(builder.ElemMatch(r => r.Players,
+                Builders<LagReportPlayer>.Filter.Regex(p => p.BattleTag, pattern)));
         }
 
-        if (req.GameId.HasValue)
+        if (!string.IsNullOrEmpty(req.GameSearch))
         {
-            filters.Add(builder.Eq(r => r.GameId, req.GameId.Value));
+            var gameFilters = new List<FilterDefinition<LagReport>>();
+
+            // Match GameId or FloGameId if the search term is numeric
+            if (int.TryParse(req.GameSearch, out var gameIdNum))
+            {
+                gameFilters.Add(builder.Eq(r => r.GameId, gameIdNum));
+                gameFilters.Add(builder.Eq(r => r.FloGameId, gameIdNum));
+            }
+
+            // Always also match GameName as partial (case-insensitive)
+            var namePattern = new BsonRegularExpression(Regex.Escape(req.GameSearch), "i");
+            gameFilters.Add(builder.Regex(r => r.GameName, namePattern));
+
+            filters.Add(builder.Or(gameFilters));
         }
 
-        if (req.ServerNodeId.HasValue)
+        if (!string.IsNullOrEmpty(req.ServerName))
         {
-            filters.Add(builder.Eq(r => r.ServerNodeId, req.ServerNodeId.Value));
+            var pattern = new BsonRegularExpression(Regex.Escape(req.ServerName), "i");
+            filters.Add(builder.Regex(r => r.ServerNodeName, pattern));
         }
 
         if (!string.IsNullOrEmpty(req.ProxyName))
         {
-            filters.Add(builder.ElemMatch(r => r.Players, p => p.ProxyName == req.ProxyName));
+            var pattern = new BsonRegularExpression(Regex.Escape(req.ProxyName), "i");
+            filters.Add(builder.ElemMatch(r => r.Players,
+                Builders<LagReportPlayer>.Filter.Regex(p => p.ProxyName, pattern)));
         }
 
         if (!string.IsNullOrEmpty(req.ProxyIp))
         {
-            filters.Add(builder.ElemMatch(r => r.Players, p => p.ProxyIp == req.ProxyIp));
+            var pattern = new BsonRegularExpression(Regex.Escape(req.ProxyIp), "i");
+            filters.Add(builder.ElemMatch(r => r.Players,
+                Builders<LagReportPlayer>.Filter.Regex(p => p.ProxyIp, pattern)));
         }
 
         if (!string.IsNullOrEmpty(req.DateFrom) && DateTimeOffset.TryParse(req.DateFrom, out var dateFrom))

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
+
+namespace W3ChampionsStatisticService.LagReports;
+
+[Trace]
+public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IRequiresIndexes
+{
+    public string CollectionName => "LagReport";
+
+    public async Task EnsureIndexesAsync()
+    {
+        var collection = CreateCollection<LagReport>();
+
+        var indexes = new List<CreateIndexModel<LagReport>>
+        {
+            // Upsert lookup + game filter — one report per flo game
+            new(Builders<LagReport>.IndexKeys.Ascending(r => r.FloGameId),
+                new CreateIndexOptions { Unique = true }),
+
+            // W3C match ID filter
+            new(Builders<LagReport>.IndexKeys.Ascending(r => r.GameId),
+                new CreateIndexOptions { Unique = true }),
+
+            // Server filter
+            new(Builders<LagReport>.IndexKeys.Ascending(r => r.ServerNodeId)),
+
+            // Player battle tag filter (inside nested array)
+            new(Builders<LagReport>.IndexKeys.Ascending("Players.BattleTag")),
+
+            // Proxy name filter (inside nested array)
+            new(Builders<LagReport>.IndexKeys.Ascending("Players.ProxyName")),
+
+            // Proxy IP filter (inside nested array)
+            new(Builders<LagReport>.IndexKeys.Ascending("Players.ProxyIp")),
+
+            // Issue category filter (inside nested array)
+            new(Builders<LagReport>.IndexKeys.Ascending("Players.IssueCategories")),
+
+            // Explicit filter — most reports are auto-submitted, admins typically filter to explicit only
+            new(Builders<LagReport>.IndexKeys.Ascending(r => r.HasExplicitReport)),
+
+            // Default list sort + date range filter
+            new(Builders<LagReport>.IndexKeys.Descending(r => r.CreatedAt)),
+
+            // TTL: auto-expire documents 90 days after last update
+            new(Builders<LagReport>.IndexKeys.Ascending(r => r.UpdatedAt),
+                new CreateIndexOptions { ExpireAfter = TimeSpan.FromDays(90) }),
+        };
+
+        await collection.Indexes.CreateManyAsync(indexes);
+    }
+
+    /// <summary>
+    /// Upsert a player's data into the per-game lag report document.
+    /// Creates the document on first player submission; subsequent players
+    /// are pushed into the Players array.
+    /// Returns the document ID.
+    /// </summary>
+    public async Task<string> UpsertPlayerData(int floGameId, LagReportPlayer playerData, LagReport template)
+    {
+        var collection = CreateCollection<LagReport>();
+
+        var filter = Builders<LagReport>.Filter.Eq(r => r.FloGameId, floGameId);
+
+        // Atomic upsert: push the player and set UpdatedAt on every call,
+        // $setOnInsert the template fields only when creating a new document.
+        var update = Builders<LagReport>.Update
+            .Push(r => r.Players, playerData)
+            .Set(r => r.UpdatedAt, DateTime.UtcNow)
+            .SetOnInsert(r => r.Id, template.Id)
+            .SetOnInsert(r => r.GameId, template.GameId)
+            .SetOnInsert(r => r.FloGameId, template.FloGameId)
+            .SetOnInsert(r => r.GameName, template.GameName)
+            .SetOnInsert(r => r.MapPath, template.MapPath)
+            .SetOnInsert(r => r.ServerNodeId, template.ServerNodeId)
+            .SetOnInsert(r => r.ServerNodeName, template.ServerNodeName)
+            .SetOnInsert(r => r.CreatedAt, DateTime.UtcNow);
+
+        if (playerData.IsExplicit)
+        {
+            update = update.Set(r => r.HasExplicitReport, true);
+        }
+
+        var result = await collection.FindOneAndUpdateAsync(
+            filter,
+            update,
+            new FindOneAndUpdateOptions<LagReport>
+            {
+                IsUpsert = true,
+                ReturnDocument = ReturnDocument.After,
+                Projection = Builders<LagReport>.Projection.Include(r => r.Id),
+            }
+        );
+
+        return result.Id;
+    }
+
+    public async Task<LagReport> GetById(string id)
+    {
+        return await LoadFirst<LagReport>(r => r.Id == id);
+    }
+
+    public async Task<LagReport> GetByFloGameId(int floGameId)
+    {
+        return await LoadFirst<LagReport>(r => r.FloGameId == floGameId);
+    }
+
+    public async Task UpdateServerSidePing(string reportId, List<ServerSidePingData> pingData)
+    {
+        var collection = CreateCollection<LagReport>();
+        var filter = Builders<LagReport>.Filter.Eq(r => r.Id, reportId);
+        var update = Builders<LagReport>.Update
+            .Set(r => r.ServerSidePing, pingData)
+            .Set(r => r.UpdatedAt, DateTime.UtcNow);
+        await collection.UpdateOneAsync(filter, update);
+    }
+
+    public async Task<(List<LagReport> Items, long Total)> GetReports(LagReportQueryRequest req)
+    {
+        var collection = CreateCollection<LagReport>();
+        var filter = BuildFilter(req);
+
+        var total = await collection.CountDocumentsAsync(filter);
+
+        var sort = Builders<LagReport>.Sort.Descending(r => r.CreatedAt);
+
+        var items = await collection.Find(filter)
+            .Sort(sort)
+            .Skip(req.Page * req.PageSize)
+            .Limit(req.PageSize)
+            .ToListAsync();
+
+        return (items, total);
+    }
+
+    private static FilterDefinition<LagReport> BuildFilter(LagReportQueryRequest req)
+    {
+        var builder = Builders<LagReport>.Filter;
+        var filters = new List<FilterDefinition<LagReport>>();
+
+        if (!string.IsNullOrEmpty(req.BattleTag))
+        {
+            filters.Add(builder.ElemMatch(r => r.Players, p => p.BattleTag == req.BattleTag));
+        }
+
+        if (req.GameId.HasValue)
+        {
+            filters.Add(builder.Eq(r => r.GameId, req.GameId.Value));
+        }
+
+        if (req.ServerNodeId.HasValue)
+        {
+            filters.Add(builder.Eq(r => r.ServerNodeId, req.ServerNodeId.Value));
+        }
+
+        if (!string.IsNullOrEmpty(req.ProxyName))
+        {
+            filters.Add(builder.ElemMatch(r => r.Players, p => p.ProxyName == req.ProxyName));
+        }
+
+        if (!string.IsNullOrEmpty(req.ProxyIp))
+        {
+            filters.Add(builder.ElemMatch(r => r.Players, p => p.ProxyIp == req.ProxyIp));
+        }
+
+        if (!string.IsNullOrEmpty(req.DateFrom) && DateTimeOffset.TryParse(req.DateFrom, out var dateFrom))
+        {
+            filters.Add(builder.Gte(r => r.CreatedAt, dateFrom));
+        }
+
+        if (!string.IsNullOrEmpty(req.DateTo) && DateTimeOffset.TryParse(req.DateTo, out var dateTo))
+        {
+            filters.Add(builder.Lte(r => r.CreatedAt, dateTo));
+        }
+
+        if (!string.IsNullOrEmpty(req.IssueCategory) && Enum.TryParse<EIssueCategory>(req.IssueCategory, out var category))
+        {
+            filters.Add(builder.ElemMatch(r => r.Players, p => p.IssueCategories.Contains(category)));
+        }
+
+        if (req.ExplicitOnly == true)
+        {
+            filters.Add(builder.Eq(r => r.HasExplicitReport, true));
+        }
+
+        return filters.Count > 0 ? builder.And(filters) : builder.Empty;
+    }
+}

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -168,6 +168,9 @@ builder.Services.AddInterceptedTransient<IPlayerStatsRepository, PlayerStatsRepo
 builder.Services.AddInterceptedTransient<IW3StatsRepo, W3StatsRepo>();
 builder.Services.AddInterceptedTransient<IPatchRepository, PatchRepository>();
 builder.Services.AddInterceptedTransient<IAdminRepository, AdminRepository>();
+builder.Services.AddInterceptedTransient<W3ChampionsStatisticService.LagReports.LagReportRepository>();
+builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexes, W3ChampionsStatisticService.LagReports.LagReportRepository>();
+builder.Services.AddInterceptedSingleton<W3ChampionsStatisticService.LagReports.IFloStatsService, W3ChampionsStatisticService.LagReports.FloStatsService>();
 builder.Services.AddInterceptedTransient<IPersonalSettingsRepository, PersonalSettingsRepository>();
 builder.Services.AddInterceptedTransient<IW3CAuthenticationService, W3CAuthenticationService>();
 builder.Services.AddInterceptedSingleton<IOngoingMatchesCache, OngoingMatchesCache>();
@@ -271,6 +274,10 @@ if (startHandlers == "true")
     // On going matches
     builder.Services.AddUnversionedReadModelService<StartedMatchIntoOngoingMatchesHandler>();
     builder.Services.AddMatchCanceledReadModelService<OngoingRemovalMatchCanceledHandler>();
+
+    // Lag reports — fetch server-side ping from flo-stats on match end
+    builder.Services.AddMatchFinishedReadModelService<W3ChampionsStatisticService.LagReports.LagReportMatchFinishedHandler>();
+    builder.Services.AddMatchCanceledReadModelService<W3ChampionsStatisticService.LagReports.LagReportMatchCanceledHandler>();
 
     builder.Services.AddUnversionedReadModelService<RankSyncHandler>();
     builder.Services.AddUnversionedReadModelService<LeagueSyncHandler>();

--- a/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
+++ b/W3ChampionsStatisticService/W3ChampionsStatisticService.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <ItemGroup>
+    <InternalsVisibleTo Include="WC3ChampionsStatisticService.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Aliyun.OSS.SDK.NetCore" />
     <PackageReference Include="AspNetCore.Authentication.Basic" />
     <PackageReference Include="AWSSDK.S3" />

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using W3ChampionsStatisticService.LagReports;
+
+namespace WC3ChampionsStatisticService.Tests.LagReports;
+
+[TestFixture]
+public class LagReportControllerTests
+{
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private static LagReportSubmissionDto CreateValidDto() => new()
+    {
+        Diagnostics = new DiagnosticsDataDto
+        {
+            GameId = 1001,
+            PlayerId = 1,
+            LagEvents = [new LagEventDto { Timestamp = DateTimeOffset.UtcNow, GameTimeOffsetMs = 300000 }],
+            TargetMtr = [new TimedTraceDto
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                Trace = new TraceResultDto
+                {
+                    Target = "185.60.112.157",
+                    Timestamp = DateTimeOffset.UtcNow,
+                    Hops = [new HopDto { HopNumber = 1, Host = "192.168.1.1", AvgRttMs = 1.2, LossPercent = 0 }],
+                }
+            }],
+            AllServerBaselines = [],
+            ReverseMtr = [],
+            PingHistory = [new TimedPingStatsDto
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                Stats = new PingStatsDto { Avg = 25, LossRate = 0 },
+            }],
+            ConnectionEvents = [],
+        },
+        GameMetadata = new GameMetadataDto
+        {
+            GameId = 5001,
+            FloGameId = 1001,
+            GameName = "test-game",
+            MapPath = "(2)EchoIsles.w3x",
+        },
+        ConnectionTopology = new ConnectionTopologyDto
+        {
+            ServerNodeId = 1,
+            ServerNodeName = "EU West",
+            ConnectionType = EConnectionType.Direct,
+            ClientIp = "203.0.113.1",
+        },
+        IsExplicit = true,
+        Categories = [EIssueCategory.SpikeLag],
+        FreeText = "Lag spike at 5 min",
+        Annotations = [new AnnotationDto { GameTimeOffsetMs = 300000, Text = "Froze for 2 seconds" }],
+    };
+
+    // ── Validation tests ──────────────────────────────────────────────
+
+    [Test]
+    public void Validate_ValidDto_ReturnsNull()
+    {
+        var dto = CreateValidDto();
+        Assert.IsNull(LagReportController.ValidateSubmission(dto));
+    }
+
+    [Test]
+    public void Validate_MissingDiagnostics_ReturnsError()
+    {
+        var dto = CreateValidDto();
+        dto.Diagnostics = null;
+        Assert.AreEqual("Missing diagnostics", LagReportController.ValidateSubmission(dto));
+    }
+
+    [Test]
+    public void Validate_MissingGameMetadata_ReturnsError()
+    {
+        var dto = CreateValidDto();
+        dto.GameMetadata = null;
+        Assert.AreEqual("Missing game_metadata", LagReportController.ValidateSubmission(dto));
+    }
+
+    [Test]
+    public void Validate_MissingConnectionTopology_ReturnsError()
+    {
+        var dto = CreateValidDto();
+        dto.ConnectionTopology = null;
+        Assert.AreEqual("Missing connection_topology", LagReportController.ValidateSubmission(dto));
+    }
+
+    [Test]
+    public void Validate_TooManyLagEvents_ReturnsError()
+    {
+        var dto = CreateValidDto();
+        dto.Diagnostics.LagEvents = Enumerable.Range(0, 201)
+            .Select(i => new LagEventDto { Timestamp = DateTimeOffset.UtcNow, GameTimeOffsetMs = i * 1000 })
+            .ToList();
+        Assert.AreEqual("Too many lag_events", LagReportController.ValidateSubmission(dto));
+    }
+
+    [Test]
+    public void Validate_TooManyCategories_ReturnsError()
+    {
+        var dto = CreateValidDto();
+        dto.Categories = Enumerable.Range(0, 21).Select(_ => EIssueCategory.Other).ToList();
+        Assert.AreEqual("Too many categories", LagReportController.ValidateSubmission(dto));
+    }
+
+    [Test]
+    public void Validate_FreeTextTooLong_ReturnsError()
+    {
+        var dto = CreateValidDto();
+        dto.FreeText = new string('x', 5001);
+        Assert.AreEqual("free_text too long", LagReportController.ValidateSubmission(dto));
+    }
+
+    [Test]
+    public void Validate_TooManyHopsInTrace_ReturnsError()
+    {
+        var dto = CreateValidDto();
+        dto.Diagnostics.TargetMtr[0].Trace.Hops = Enumerable.Range(0, 65)
+            .Select(i => new HopDto { HopNumber = i, LossPercent = 0 })
+            .ToList();
+        Assert.AreEqual("Too many hops in trace", LagReportController.ValidateSubmission(dto));
+    }
+
+    [Test]
+    public void Validate_AnnotationTextTooLong_ReturnsError()
+    {
+        var dto = CreateValidDto();
+        dto.Annotations[0].Text = new string('x', 1001);
+        Assert.AreEqual("Annotation text too long", LagReportController.ValidateSubmission(dto));
+    }
+
+    [Test]
+    public void Validate_NullLists_DoesNotThrow()
+    {
+        var dto = CreateValidDto();
+        dto.Diagnostics.LagEvents = null;
+        dto.Diagnostics.TargetMtr = null;
+        dto.Diagnostics.AllServerBaselines = null;
+        dto.Diagnostics.ReverseMtr = null;
+        dto.Diagnostics.PingHistory = null;
+        dto.Diagnostics.ConnectionEvents = null;
+        dto.Annotations = null;
+        dto.Categories = null;
+        Assert.IsNull(LagReportController.ValidateSubmission(dto));
+    }
+
+    [Test]
+    public void Validate_ClientIpTooLong_ReturnsError()
+    {
+        var dto = CreateValidDto();
+        dto.ConnectionTopology.ClientIp = new string('x', 101);
+        Assert.AreEqual("client_ip too long", LagReportController.ValidateSubmission(dto));
+    }
+
+    // ── Mapping tests ─────────────────────────────────────────────────
+
+    [Test]
+    public void MapToPlayer_SetsBasicFields()
+    {
+        var dto = CreateValidDto();
+        var player = LagReportController.MapToPlayer(dto, "TestPlayer#1234");
+
+        Assert.AreEqual("TestPlayer#1234", player.BattleTag);
+        Assert.AreEqual("203.0.113.1", player.ClientIp);
+        Assert.AreEqual(EConnectionType.Direct, player.ConnectionType);
+        Assert.IsTrue(player.IsExplicit);
+        Assert.AreEqual("Lag spike at 5 min", player.FreeText);
+        Assert.AreEqual(1, player.IssueCategories.Count);
+        Assert.AreEqual(EIssueCategory.SpikeLag, player.IssueCategories[0]);
+    }
+
+    [Test]
+    public void MapToPlayer_ParsesProxyAddress_IpAndPort()
+    {
+        var dto = CreateValidDto();
+        dto.ConnectionTopology.ConnectionType = EConnectionType.Proxied;
+        dto.ConnectionTopology.ProxyName = "EU-Proxy-1";
+        dto.ConnectionTopology.ProxyAddress = "10.0.0.1:8080";
+
+        var player = LagReportController.MapToPlayer(dto, "P#1");
+
+        Assert.AreEqual("10.0.0.1", player.ProxyIp);
+        Assert.AreEqual(8080, player.ProxyPort);
+        Assert.AreEqual("EU-Proxy-1", player.ProxyName);
+    }
+
+    [Test]
+    public void MapToPlayer_ParsesProxyAddress_IpOnly()
+    {
+        var dto = CreateValidDto();
+        dto.ConnectionTopology.ProxyAddress = "10.0.0.1";
+
+        var player = LagReportController.MapToPlayer(dto, "P#1");
+
+        Assert.AreEqual("10.0.0.1", player.ProxyIp);
+        Assert.IsNull(player.ProxyPort);
+    }
+
+    [Test]
+    public void MapToPlayer_NullProxyAddress_SetsNulls()
+    {
+        var dto = CreateValidDto();
+        dto.ConnectionTopology.ProxyAddress = null;
+
+        var player = LagReportController.MapToPlayer(dto, "P#1");
+
+        Assert.IsNull(player.ProxyIp);
+        Assert.IsNull(player.ProxyPort);
+    }
+
+    [Test]
+    public void MapToPlayer_MergesAnnotationsIntoLagEvents()
+    {
+        var dto = CreateValidDto();
+        var player = LagReportController.MapToPlayer(dto, "P#1");
+
+        Assert.AreEqual(1, player.Diagnostics.LagEvents.Count);
+        Assert.AreEqual("Froze for 2 seconds", player.Diagnostics.LagEvents[0].Annotation);
+    }
+
+    [Test]
+    public void MapToPlayer_LagEventWithoutAnnotation_HasNullAnnotation()
+    {
+        var dto = CreateValidDto();
+        dto.Annotations = [];
+
+        var player = LagReportController.MapToPlayer(dto, "P#1");
+
+        Assert.IsNull(player.Diagnostics.LagEvents[0].Annotation);
+    }
+
+    [Test]
+    public void MapToPlayer_NullLists_ProducesEmptyLists()
+    {
+        var dto = CreateValidDto();
+        dto.Diagnostics.LagEvents = null;
+        dto.Diagnostics.TargetMtr = null;
+        dto.Diagnostics.AllServerBaselines = null;
+        dto.Diagnostics.ReverseMtr = null;
+        dto.Diagnostics.PingHistory = null;
+        dto.Diagnostics.ConnectionEvents = null;
+        dto.Annotations = null;
+        dto.Categories = null;
+
+        var player = LagReportController.MapToPlayer(dto, "P#1");
+
+        Assert.IsEmpty(player.Diagnostics.LagEvents);
+        Assert.IsEmpty(player.Diagnostics.TargetMtr);
+        Assert.IsEmpty(player.Diagnostics.AllServerBaselines);
+        Assert.IsEmpty(player.Diagnostics.ReverseMtr);
+        Assert.IsEmpty(player.Diagnostics.PingHistory);
+        Assert.IsEmpty(player.Diagnostics.ConnectionEvents);
+        Assert.IsEmpty(player.Annotations);
+        Assert.IsEmpty(player.IssueCategories);
+    }
+
+    [Test]
+    public void MapToPlayer_FiltersOutNullTraces()
+    {
+        var dto = CreateValidDto();
+        dto.Diagnostics.TargetMtr.Add(new TimedTraceDto { Timestamp = DateTimeOffset.UtcNow, Trace = null });
+        dto.Diagnostics.ReverseMtr =
+        [
+            new TimedTraceDto { Timestamp = DateTimeOffset.UtcNow, Trace = null },
+        ];
+        dto.Diagnostics.AllServerBaselines =
+        [
+            new ServerTraceDto { Timestamp = DateTimeOffset.UtcNow, ServerId = 1, ServerName = "X", Trace = null },
+        ];
+
+        var player = LagReportController.MapToPlayer(dto, "P#1");
+
+        // The valid trace from CreateValidDto survives, the null ones are filtered
+        Assert.AreEqual(1, player.Diagnostics.TargetMtr.Count);
+        Assert.IsEmpty(player.Diagnostics.ReverseMtr);
+        Assert.IsEmpty(player.Diagnostics.AllServerBaselines);
+    }
+
+    [Test]
+    public void MapToPlayer_MapsDiagnosticsCorrectly()
+    {
+        var dto = CreateValidDto();
+        var player = LagReportController.MapToPlayer(dto, "P#1");
+
+        Assert.AreEqual(1, player.Diagnostics.TargetMtr.Count);
+        Assert.AreEqual("185.60.112.157", player.Diagnostics.TargetMtr[0].Target);
+        Assert.AreEqual(1, player.Diagnostics.TargetMtr[0].Hops.Count);
+        Assert.AreEqual("192.168.1.1", player.Diagnostics.TargetMtr[0].Hops[0].Host);
+        Assert.AreEqual(1.2, player.Diagnostics.TargetMtr[0].Hops[0].AvgRttMs);
+
+        Assert.AreEqual(1, player.Diagnostics.PingHistory.Count);
+        Assert.AreEqual(25, player.Diagnostics.PingHistory[0].Avg);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -133,25 +133,31 @@ public class LagReportRepositoryTests : IntegrationTestBase
         await _repo.UpsertPlayerData(t1.FloGameId, CreatePlayer("Alice#1111"), t1);
         await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("Bob#2222"), t2);
 
+        // Exact match
         var (items, total) = await _repo.GetReports(new LagReportQueryRequest { BattleTag = "Alice#1111" });
         Assert.AreEqual(1, total);
         Assert.AreEqual(1, items.Count);
         Assert.AreEqual(2001, items[0].FloGameId);
+
+        // Partial match (case-insensitive)
+        var (items2, total2) = await _repo.GetReports(new LagReportQueryRequest { BattleTag = "alice" });
+        Assert.AreEqual(1, total2);
+        Assert.AreEqual(1, items2.Count);
     }
 
     [Test]
-    public async Task GetReports_FiltersByServerNodeId()
+    public async Task GetReports_FiltersByServerName()
     {
         var t1 = CreateTemplate(floGameId: 3001, gameId: 7001);
-        t1.ServerNodeId = 10;
+        t1.ServerNodeName = "EU West";
         var t2 = CreateTemplate(floGameId: 3002, gameId: 7002);
-        t2.ServerNodeId = 20;
+        t2.ServerNodeName = "US East";
         await _repo.UpsertPlayerData(t1.FloGameId, CreatePlayer("P1#1"), t1);
         await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("P2#2"), t2);
 
-        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { ServerNodeId = 10 });
+        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { ServerName = "EU" });
         Assert.AreEqual(1, items.Count);
-        Assert.AreEqual(10, items[0].ServerNodeId);
+        Assert.AreEqual("EU West", items[0].ServerNodeName);
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using W3ChampionsStatisticService.LagReports;
+
+namespace WC3ChampionsStatisticService.Tests.LagReports;
+
+[TestFixture]
+public class LagReportRepositoryTests : IntegrationTestBase
+{
+    private LagReportRepository _repo;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repo = new LagReportRepository(MongoClient);
+    }
+
+    private static LagReportPlayer CreatePlayer(string battleTag, bool isExplicit = false) => new()
+    {
+        BattleTag = battleTag,
+        ClientIp = "203.0.113.1",
+        ConnectionType = EConnectionType.Direct,
+        IsExplicit = isExplicit,
+        IssueCategories = isExplicit ? [EIssueCategory.SpikeLag] : [],
+        FreeText = isExplicit ? "Lag spike at 5 min" : "",
+        Diagnostics = new PlayerDiagnostics
+        {
+            LagEvents = [new LagEvent { Timestamp = DateTimeOffset.UtcNow, GameTimeOffsetMs = 300000 }],
+            PingHistory = [new PingSample { Timestamp = DateTimeOffset.UtcNow, Avg = 25, LossRate = 0 }],
+        },
+    };
+
+    private static LagReport CreateTemplate(int floGameId = 1001, int gameId = 5001) => new()
+    {
+        GameId = gameId,
+        FloGameId = floGameId,
+        GameName = "test-game",
+        MapPath = "(2)EchoIsles.w3x",
+        ServerNodeId = 1,
+        ServerNodeName = "EU West",
+    };
+
+    [Test]
+    public async Task UpsertPlayerData_CreatesNewReport()
+    {
+        var template = CreateTemplate();
+        var player = CreatePlayer("Player1#1234", isExplicit: true);
+
+        var reportId = await _repo.UpsertPlayerData(template.FloGameId, player, template);
+
+        Assert.IsNotNull(reportId);
+
+        var report = await _repo.GetById(reportId);
+        Assert.IsNotNull(report);
+        Assert.AreEqual(template.FloGameId, report.FloGameId);
+        Assert.AreEqual(template.GameId, report.GameId);
+        Assert.AreEqual(template.GameName, report.GameName);
+        Assert.AreEqual(1, report.Players.Count);
+        Assert.AreEqual("Player1#1234", report.Players[0].BattleTag);
+        Assert.IsTrue(report.HasExplicitReport);
+    }
+
+    [Test]
+    public async Task UpsertPlayerData_SecondPlayerMergesIntoSameDocument()
+    {
+        var template = CreateTemplate();
+        var player1 = CreatePlayer("Player1#1234");
+        var player2 = CreatePlayer("Player2#5678", isExplicit: true);
+
+        var id1 = await _repo.UpsertPlayerData(template.FloGameId, player1, template);
+        var id2 = await _repo.UpsertPlayerData(template.FloGameId, player2, template);
+
+        Assert.AreEqual(id1, id2);
+
+        var report = await _repo.GetById(id1);
+        Assert.AreEqual(2, report.Players.Count);
+        Assert.IsTrue(report.HasExplicitReport);
+    }
+
+    [Test]
+    public async Task UpsertPlayerData_AutoSubmitDoesNotSetExplicit()
+    {
+        var template = CreateTemplate();
+        var player = CreatePlayer("Player1#1234", isExplicit: false);
+
+        var reportId = await _repo.UpsertPlayerData(template.FloGameId, player, template);
+
+        var report = await _repo.GetById(reportId);
+        Assert.IsFalse(report.HasExplicitReport);
+    }
+
+    [Test]
+    public async Task GetByFloGameId_ReturnsCorrectReport()
+    {
+        var template = CreateTemplate(floGameId: 9999);
+        var player = CreatePlayer("Player1#1234");
+        await _repo.UpsertPlayerData(template.FloGameId, player, template);
+
+        var report = await _repo.GetByFloGameId(9999);
+        Assert.IsNotNull(report);
+        Assert.AreEqual(9999, report.FloGameId);
+
+        var missing = await _repo.GetByFloGameId(8888);
+        Assert.IsNull(missing);
+    }
+
+    [Test]
+    public async Task UpdateServerSidePing_StoresData()
+    {
+        var template = CreateTemplate();
+        var player = CreatePlayer("Player1#1234");
+        var reportId = await _repo.UpsertPlayerData(template.FloGameId, player, template);
+
+        var pingData = new List<ServerSidePingData>
+        {
+            new() { PlayerId = 1, PlayerName = "Player1#1234", Samples = [new ServerPingSample { Time = 60, Avg = 22 }] }
+        };
+        await _repo.UpdateServerSidePing(reportId, pingData);
+
+        var report = await _repo.GetById(reportId);
+        Assert.IsNotNull(report.ServerSidePing);
+        Assert.AreEqual(1, report.ServerSidePing.Count);
+        Assert.AreEqual(22, report.ServerSidePing[0].Samples[0].Avg);
+    }
+
+    [Test]
+    public async Task GetReports_FiltersByBattleTag()
+    {
+        var t1 = CreateTemplate(floGameId: 2001, gameId: 6001);
+        var t2 = CreateTemplate(floGameId: 2002, gameId: 6002);
+        await _repo.UpsertPlayerData(t1.FloGameId, CreatePlayer("Alice#1111"), t1);
+        await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("Bob#2222"), t2);
+
+        var (items, total) = await _repo.GetReports(new LagReportQueryRequest { BattleTag = "Alice#1111" });
+        Assert.AreEqual(1, total);
+        Assert.AreEqual(1, items.Count);
+        Assert.AreEqual(2001, items[0].FloGameId);
+    }
+
+    [Test]
+    public async Task GetReports_FiltersByServerNodeId()
+    {
+        var t1 = CreateTemplate(floGameId: 3001, gameId: 7001);
+        t1.ServerNodeId = 10;
+        var t2 = CreateTemplate(floGameId: 3002, gameId: 7002);
+        t2.ServerNodeId = 20;
+        await _repo.UpsertPlayerData(t1.FloGameId, CreatePlayer("P1#1"), t1);
+        await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("P2#2"), t2);
+
+        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { ServerNodeId = 10 });
+        Assert.AreEqual(1, items.Count);
+        Assert.AreEqual(10, items[0].ServerNodeId);
+    }
+
+    [Test]
+    public async Task GetReports_FiltersByExplicitOnly()
+    {
+        var t1 = CreateTemplate(floGameId: 4001, gameId: 8001);
+        var t2 = CreateTemplate(floGameId: 4002, gameId: 8002);
+        await _repo.UpsertPlayerData(t1.FloGameId, CreatePlayer("P1#1", isExplicit: true), t1);
+        await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("P2#2", isExplicit: false), t2);
+
+        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { ExplicitOnly = true });
+        Assert.AreEqual(1, items.Count);
+        Assert.IsTrue(items[0].HasExplicitReport);
+    }
+
+    [Test]
+    public async Task GetReports_FiltersByProxyName()
+    {
+        var t1 = CreateTemplate(floGameId: 5001, gameId: 9001);
+        var t2 = CreateTemplate(floGameId: 5002, gameId: 9002);
+        var proxied = CreatePlayer("P1#1");
+        proxied.ProxyName = "EU-Proxy-1";
+        proxied.ProxyIp = "10.0.0.1";
+        await _repo.UpsertPlayerData(t1.FloGameId, proxied, t1);
+        await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("P2#2"), t2);
+
+        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { ProxyName = "EU-Proxy-1" });
+        Assert.AreEqual(1, items.Count);
+    }
+
+    [Test]
+    public async Task GetReports_FiltersByProxyIp()
+    {
+        var t1 = CreateTemplate(floGameId: 5003, gameId: 9003);
+        var t2 = CreateTemplate(floGameId: 5004, gameId: 9004);
+        var proxied = CreatePlayer("P1#1");
+        proxied.ProxyIp = "10.0.0.99";
+        await _repo.UpsertPlayerData(t1.FloGameId, proxied, t1);
+        await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("P2#2"), t2);
+
+        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { ProxyIp = "10.0.0.99" });
+        Assert.AreEqual(1, items.Count);
+    }
+
+    [Test]
+    public async Task GetReports_FiltersByIssueCategory()
+    {
+        var t1 = CreateTemplate(floGameId: 6001, gameId: 10001);
+        var t2 = CreateTemplate(floGameId: 6002, gameId: 10002);
+        var player1 = CreatePlayer("P1#1");
+        player1.IssueCategories = [EIssueCategory.Reconnecting];
+        await _repo.UpsertPlayerData(t1.FloGameId, player1, t1);
+        await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("P2#2"), t2);
+
+        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { IssueCategory = "Reconnecting" });
+        Assert.AreEqual(1, items.Count);
+    }
+
+    [Test]
+    public async Task GetReports_Pagination()
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            var t = CreateTemplate(floGameId: 7000 + i, gameId: 11000 + i);
+            await _repo.UpsertPlayerData(t.FloGameId, CreatePlayer($"P{i}#1"), t);
+        }
+
+        var (page0, total) = await _repo.GetReports(new LagReportQueryRequest { Page = 0, PageSize = 2 });
+        Assert.AreEqual(5, total);
+        Assert.AreEqual(2, page0.Count);
+
+        var (page1, _) = await _repo.GetReports(new LagReportQueryRequest { Page = 1, PageSize = 2 });
+        Assert.AreEqual(2, page1.Count);
+
+        var (page2, _) = await _repo.GetReports(new LagReportQueryRequest { Page = 2, PageSize = 2 });
+        Assert.AreEqual(1, page2.Count);
+    }
+
+    [Test]
+    public async Task GetReports_SortsByCreatedAtDescending()
+    {
+        var t1 = CreateTemplate(floGameId: 8001, gameId: 12001);
+        var t2 = CreateTemplate(floGameId: 8002, gameId: 12002);
+        await _repo.UpsertPlayerData(t1.FloGameId, CreatePlayer("P1#1"), t1);
+        await Task.Delay(50); // ensure distinct CreatedAt
+        await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("P2#2"), t2);
+
+        var (items, _) = await _repo.GetReports(new LagReportQueryRequest());
+        Assert.IsTrue(items[0].CreatedAt >= items[1].CreatedAt);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the backend layer for the network diagnostics (`!lag`) feature — storage, aggregation, server-side ping enrichment, and admin query API.

- **MongoDB `LagReports` collection**: Game-level documents with atomic per-player upserts. One document per game containing all players' measurement data.
- **REST API endpoints**:
  - `POST /api/lag-reports` — Player submission (authenticated). Atomically upserts player data into game document. Fetches server-side ping if match ended.
  - `GET /api/admin/lag-reports` — Paginated admin list with filters (BattleTag, Game ID, server, proxy, date range, issue categories, explicit-only). Requires `EPermission.Proxies`.
  - `GET /api/admin/lag-reports/{id}` — Full report detail for admin dashboard.
- **`FloStatsService`**: Fetches server-side ping from flo-stats-service via WebSocket. Triggered on player submission (if match ended) or on `MatchFinishedEvent`/`MatchCanceledEvent`. Gracefully degrades if service unreachable.
- **Match event hooks**: Listens for `MatchFinishedEvent` and `MatchCanceledEvent` to fetch flo-stats data for existing reports.
- **Partial matching filters**: BattleTag, game name, server name, and proxy filters support partial/substring matching.
- **`GameCrashed`**: New connection event type and issue category.
- **Tests**: Controller tests (298 lines) and repository tests (251 lines).

## Cross-repo PRs

This is part of a multi-repo feature. Related PRs:
- **flo**: w3champions/flo#111 — Real-time measurement engine (foundation)
- **launcher-e**: w3champions/launcher-e#724 — Post-game UX and submission
- **website**: w3champions/website#1021 — Admin dashboard
- **docker-compose-files**: w3champions/docker-compose-files#118 — `FLO_STATS_WS_URL` env config (required for `FloStatsService`)

Deployment order: flo → **docker-compose-files + website-backend** → launcher-e → website

## Test plan

- [ ] Verify `POST /api/lag-reports` creates game-level document and upserts player data atomically
- [ ] Verify duplicate submissions for same player+game update rather than duplicate
- [ ] Verify server-side ping fetch from flo-stats on submission when match is ended
- [ ] Verify `MatchFinishedEvent` triggers flo-stats fetch for existing reports
- [ ] Verify admin list endpoint returns paginated results with all filter combinations
- [ ] Verify partial matching works for BattleTag, game name, server, proxy filters
- [ ] Verify admin detail endpoint returns full report with all measurement data
- [ ] Verify graceful degradation when flo-stats service is unreachable
- [ ] Run existing test suite: `LagReportControllerTests` and `LagReportRepositoryTests`