### PR TITLE
Fix map filter for finished matches

### DIFF
--- a/W3ChampionsStatisticService/Matches/MatchRepository.cs
+++ b/W3ChampionsStatisticService/Matches/MatchRepository.cs
@@ -233,14 +233,29 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
             playerBlizzard.teamIndex);
     }
 
-    public async Task<List<Matchup>> Load(int season, GameMode gameMode, int offset = 0, int pageSize = 100, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null, int? minDuration = null, int? maxDuration = null)
+    public async Task<List<Matchup>> Load(int season, GameMode gameMode, int offset = 0, int pageSize = 100, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null, int? minDuration = null, int? maxDuration = null, string mapName = "Overall")
     {
         if (maxMmr == null) maxMmr = MmrConstants.MaxMmrPerGameMode[gameMode];
         var mongoCollection = CreateCollection<Matchup>();
-        var filter = GetLoadFilter(season, gameMode, hero, minMmr, maxMmr, minDuration, maxDuration);
+        var filter = GetLoadFilter(season, gameMode, hero, minMmr, maxMmr, minDuration, maxDuration, mapName);
         var results = await mongoCollection.Find(filter).SortByDescending(s => s.EndTime).Skip(offset).Limit(pageSize).ToListAsync();
         PlayersObfuscator.ObfuscateMmr(results);
         return results;
+    }
+
+    public async Task<List<string>> LoadMapNames(int season, GameMode gameMode)
+    {
+        var builder = Builders<Matchup>.Filter;
+        var filter = builder.Eq(m => m.Season, season)
+            & builder.Eq(m => m.GameMode, gameMode)
+            & builder.Ne(m => m.MapName, null)
+            & builder.Ne(m => m.MapName, string.Empty);
+
+        var mapNames = await CreateCollection<Matchup>()
+            .Distinct(m => m.MapName, filter)
+            .ToListAsync();
+
+        return mapNames.OrderBy(mapName => mapName).ToList();
     }
 
     public async Task<int> GetFloIdFromId(string gameId)
@@ -250,18 +265,23 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
         return (match == null || match.FloMatchId == null) ? 0 : match.FloMatchId.Value;
     }
 
-    public Task<long> Count(int season, GameMode gameMode, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null, int? minDuration = null, int? maxDuration = null)
+    public Task<long> Count(int season, GameMode gameMode, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null, int? minDuration = null, int? maxDuration = null, string mapName = "Overall")
     {
         if (maxMmr == null) maxMmr = MmrConstants.MaxMmrPerGameMode[gameMode];
-        var filter = GetLoadFilter(season, gameMode, hero, minMmr, maxMmr, minDuration, maxDuration);
+        var filter = GetLoadFilter(season, gameMode, hero, minMmr, maxMmr, minDuration, maxDuration, mapName);
         return CreateCollection<Matchup>().CountDocumentsAsync(filter);
     }
 
-    private FilterDefinition<Matchup> GetLoadFilter(int season, GameMode gameMode, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null, int? minDuration = null, int? maxDuration = null)
+    private FilterDefinition<Matchup> GetLoadFilter(int season, GameMode gameMode, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null, int? minDuration = null, int? maxDuration = null, string mapName = "Overall")
     {
         if (maxMmr == null) maxMmr = MmrConstants.MaxMmrPerGameMode[gameMode];
         var builder = Builders<Matchup>.Filter;
         var filter = builder.Eq(m => m.GameMode, gameMode) & builder.Eq(m => m.Season, season);
+
+        if (!string.IsNullOrWhiteSpace(mapName) && mapName != "Overall")
+        {
+            filter &= builder.Eq(m => m.MapName, mapName);
+        }
 
         if (hero != HeroType.AllFilter && hero != HeroType.Unknown)
         {

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using MongoDB.Bson;
 using W3C.Contracts.Matchmaking;
@@ -31,6 +32,24 @@ public class MatchesController(
     private readonly MatchService _matchService = matchService;
     private readonly MmrDistributionHandler _mmrDistributionHandler = mmrDistributionHandler;
 
+    /// <summary>
+    /// Gets the distinct map names for a season and game mode.
+    /// </summary>
+    /// <param name="season">The season filter.</param>
+    /// <param name="gameMode">The game mode filter.</param>
+    /// <returns>
+    /// 200 OK: The array of distinct map names from the season
+    /// </returns>
+    [ProducesResponseType(typeof(List<string>), 200)]
+    [HttpGet("map-names")]
+    public async Task<IActionResult> GetMapNames(
+        GameMode gameMode,
+        int season
+    )
+    {
+        var mapNames = await _matchRepository.LoadMapNames(season, gameMode);
+        return Ok(mapNames);
+    }
 
     /// <summary>
     /// Gets a paginated list of matches with optional filters.
@@ -68,7 +87,8 @@ public class MatchesController(
         int? minPercentile = null,
         int? maxPercentile = null,
         int? minDuration = null,
-        int? maxDuration = null
+        int? maxDuration = null,
+        string mapName = "Overall"
     )
     {
         if (maxMmr == null) maxMmr = MmrConstants.MaxMmrPerGameMode[gameMode];
@@ -88,9 +108,9 @@ public class MatchesController(
             season = lastSeason.Id;
         }
         if (pageSize > 100) pageSize = 100;
-        var matches = await _matchRepository.Load(season, gameMode, offset, pageSize, hero, minMmr, maxMmr, minDuration, maxDuration);
+        var matches = await _matchRepository.Load(season, gameMode, offset, pageSize, hero, minMmr, maxMmr, minDuration, maxDuration, mapName);
         PlayersObfuscator.ObfuscateMmr(matches);
-        var count = await _matchRepository.Count(season, gameMode, hero, minMmr, maxMmr, minDuration, maxDuration);
+        var count = await _matchRepository.Count(season, gameMode, hero, minMmr, maxMmr, minDuration, maxDuration, mapName);
         return Ok(new { matches, count });
     }
 

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -47,7 +47,7 @@ public class MatchesController(
         int season
     )
     {
-        var mapNames = await _matchRepository.LoadMapNames(season, gameMode);
+        var mapNames = await _matchService.GetMapNames(season, gameMode);
         return Ok(mapNames);
     }
 

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -13,7 +13,9 @@ namespace W3ChampionsStatisticService.Ports;
 
 public interface IMatchRepository
 {
-    Task<List<Matchup>> Load(int season, GameMode gameMode, int offset = 0, int pageSize = 100, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null, int? minDuration = null, int? maxDuration = null);
+    Task<List<Matchup>> Load(int season, GameMode gameMode, int offset = 0, int pageSize = 100, HeroType hero = HeroType.AllFilter, int minMmr = 0, int? maxMmr = null, int? minDuration = null, int? maxDuration = null, string mapName = "Overall");
+
+    Task<List<string>> LoadMapNames(int season, GameMode gameMode);
 
     Task<long> Count(
         int season,
@@ -22,7 +24,8 @@ public interface IMatchRepository
         int minMmr = 0,
         int? maxMmr = null,
         int? minDuration = null,
-        int? maxDuration = null);
+        int? maxDuration = null,
+        string mapName = "Overall");
 
     Task Insert(Matchup matchup);
 

--- a/W3ChampionsStatisticService/Services/MatchService.cs
+++ b/W3ChampionsStatisticService/Services/MatchService.cs
@@ -24,11 +24,13 @@ public class MatchService(
     IMatchRepository matchRepository,
     ICachedDataProvider<List<Matchup>> cachedMatchesProvider,
     ICachedDataProvider<CachedLong> cachedMatchCountProvider,
+    ICachedDataProvider<List<string>> cachedMapNamesProvider,
     IPersonalSettingsRepository personalSettingsRepository)
 {
     private readonly IMatchRepository _matchRepository = matchRepository;
     private readonly ICachedDataProvider<List<Matchup>> _cachedMatchesProvider = cachedMatchesProvider;
     private readonly ICachedDataProvider<CachedLong> _cachedMatchCountProvider = cachedMatchCountProvider;
+    private readonly ICachedDataProvider<List<string>> _cachedMapNamesProvider = cachedMapNamesProvider;
     private readonly IPersonalSettingsRepository _personalSettingsRepository = personalSettingsRepository;
 
     public async Task<List<Matchup>> GetMatchesPerPlayer(
@@ -83,6 +85,16 @@ public class MatchService(
                     opponentRace, season, hero)
             }, cacheKeyCount, TimeSpan.FromSeconds(5));
         return count.Value;
+    }
+
+    public async Task<List<string>> GetMapNames(int season, GameMode gameMode)
+    {
+        string cacheKey = $"map_names_{season}_{gameMode}";
+
+        return await _cachedMapNamesProvider.GetCachedOrRequestAsync(
+            async () => await _matchRepository.LoadMapNames(season, gameMode),
+            cacheKey,
+            TimeSpan.FromMinutes(10));
     }
 
     public async Task SetPlayersCountryCode(Matchup matchup)

--- a/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
@@ -391,6 +391,7 @@ public static class TestDtoHelper
         return new Mock<MatchService>(new Mock<IMatchRepository>().Object,
             new Mock<ICachedDataProvider<List<Matchup>>>().Object,
             new Mock<ICachedDataProvider<CachedLong>>().Object,
+            new Mock<ICachedDataProvider<List<string>>>().Object,
             new PersonalSettingsRepository(mongoClient));
     }
 

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -132,6 +132,57 @@ public class MatchupRepoTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task LoadMapNames_ReturnsDistinctMapNamesForSeason()
+    {
+        var amazonia = TestDtoHelper.CreateFakeEvent();
+        amazonia.match.mapName = "Amazonia";
+        amazonia.match.season = 1;
+
+        var duplicateAmazonia = TestDtoHelper.CreateFakeEvent();
+        duplicateAmazonia.match.mapName = "Amazonia";
+        duplicateAmazonia.match.season = 1;
+
+        var concealedHill = TestDtoHelper.CreateFakeEvent();
+        concealedHill.match.mapName = "Concealed Hill";
+        concealedHill.match.season = 1;
+
+        var otherSeason = TestDtoHelper.CreateFakeEvent();
+        otherSeason.match.mapName = "Autumn Leaves";
+        otherSeason.match.season = 2;
+
+        await matchRepository.Insert(Matchup.Create(amazonia));
+        await matchRepository.Insert(Matchup.Create(duplicateAmazonia));
+        await matchRepository.Insert(Matchup.Create(concealedHill));
+        await matchRepository.Insert(Matchup.Create(otherSeason));
+
+        var mapNames = await matchRepository.LoadMapNames(1, amazonia.match.gameMode);
+
+        Assert.AreEqual(new[] { "Amazonia", "Concealed Hill" }, mapNames);
+    }
+
+    [Test]
+    public async Task LoadAndCount_WithMapFilter_ReturnsOnlySelectedMap()
+    {
+        var amazonia = TestDtoHelper.CreateFakeEvent();
+        amazonia.match.mapName = "Amazonia";
+        amazonia.match.season = 1;
+
+        var concealedHill = TestDtoHelper.CreateFakeEvent();
+        concealedHill.match.mapName = "Concealed Hill";
+        concealedHill.match.season = 1;
+
+        await matchRepository.Insert(Matchup.Create(amazonia));
+        await matchRepository.Insert(Matchup.Create(concealedHill));
+
+        var matches = await matchRepository.Load(1, amazonia.match.gameMode, mapName: "Amazonia");
+        var count = await matchRepository.Count(1, amazonia.match.gameMode, mapName: "Amazonia");
+
+        Assert.AreEqual(1, matches.Count);
+        Assert.AreEqual(1, count);
+        Assert.AreEqual("Amazonia", matches.Single().MapName);
+    }
+
+    [Test]
     public async Task LoadWithHeroFilter()
     {
         var matchFinishedEvent = TestDtoHelper.CreateFakeEvent();


### PR DESCRIPTION
This fixes the map filter being broken for finished matches.

For seasons 10+, we have the MapName in the MatchUp collection.

In this PR we get the distinct MapNames for the season, offer them as dropdown options, and filter by them.

For seasons 1-10, we will stop offering the Map filter for now. Steps could be taken to make those work too, in a future PR.

This would benefit from an index on MatchUp.MapName.

<img width="1303" height="861" alt="image" src="https://github.com/user-attachments/assets/3dcd91bc-e4c9-456e-bc8d-3135590f8699" />

[website pr](https://github.com/w3champions/website/pull/1040)