### PR TITLE
fix(rewards): Patreon data correctness — tier filter, SyncSingleUser, IsActivePatron

### DIFF
--- a/W3C.Domain/Rewards/Entities/EntitledTier.cs
+++ b/W3C.Domain/Rewards/Entities/EntitledTier.cs
@@ -1,0 +1,8 @@
+namespace W3C.Domain.Rewards.Entities;
+
+public class EntitledTier
+{
+    public string TierId { get; set; }
+    public long? AmountCents { get; set; }
+    public string Title { get; set; }
+}

--- a/W3C.Domain/Rewards/Entities/EntitledTier.cs
+++ b/W3C.Domain/Rewards/Entities/EntitledTier.cs
@@ -1,5 +1,17 @@
 namespace W3C.Domain.Rewards.Entities;
 
+/// <summary>
+/// Internal Patreon/KoFi tier representation. Carries TierId for routing,
+/// AmountCents for the tier-filter ranking, and Title for human-readable
+/// display.
+/// </summary>
+/// <remarks>
+/// Wire format: external API responses currently project to
+/// <c>entitledTierIds: List&lt;string&gt;</c> via <c>.Select(t => t.TierId)</c>
+/// at the controller boundary to preserve compatibility with admin
+/// frontend tooling. Do not serialize this type directly to public APIs
+/// without intentional coordination.
+/// </remarks>
 public class EntitledTier
 {
     public string TierId { get; set; }

--- a/W3C.Domain/Rewards/Entities/EntitledTier.cs
+++ b/W3C.Domain/Rewards/Entities/EntitledTier.cs
@@ -6,11 +6,12 @@ namespace W3C.Domain.Rewards.Entities;
 /// display.
 /// </summary>
 /// <remarks>
-/// Wire format: external API responses currently project to
-/// <c>entitledTierIds: List&lt;string&gt;</c> via <c>.Select(t => t.TierId)</c>
-/// at the controller boundary to preserve compatibility with admin
-/// frontend tooling. Do not serialize this type directly to public APIs
-/// without intentional coordination.
+/// Serialized directly on the wire by AdminRewardController.GetPatreonMemberDetails,
+/// PatreonWebhookController webhook ack, and RewardDriftDetectionController
+/// missing-members payloads as <c>entitledTiers: [{tierId, amountCents, title}]</c>
+/// (camelCase via System.Text.Json defaults). The admin frontend consumes all three
+/// fields to render readable titles plus a tooltip with the tier ID and amount.
+/// Preserve this shape when modifying the type.
 /// </remarks>
 public class EntitledTier
 {

--- a/W3C.Domain/Rewards/Events/RewardEvent.cs
+++ b/W3C.Domain/Rewards/Events/RewardEvent.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using W3C.Domain.Rewards.Entities;
 
 namespace W3C.Domain.Rewards.Events;
 
@@ -17,7 +18,7 @@ public class RewardEvent
     public Dictionary<string, object> Metadata { get; set; } = new();
 
     // All providers use this - single tier providers will have one item, multi-tier will have multiple
-    public List<string> EntitledTierIds { get; set; } = new();
+    public List<EntitledTier> EntitledTiers { get; set; } = new();
 
     /// <summary>
     /// Validates the reward event for required fields and business rules
@@ -36,16 +37,17 @@ public class RewardEvent
         if (string.IsNullOrEmpty(ProviderReference))
             throw new InvalidOperationException("ProviderReference cannot be null or empty");
 
-        if (EntitledTierIds == null)
-            throw new InvalidOperationException("EntitledTierIds cannot be null");
+        if (EntitledTiers == null)
+            throw new InvalidOperationException("EntitledTiers cannot be null");
 
         // Validate tier IDs are not empty strings
-        if (EntitledTierIds.Any(string.IsNullOrWhiteSpace))
-            throw new InvalidOperationException("EntitledTierIds cannot contain null or empty tier IDs");
+        if (EntitledTiers.Any(t => string.IsNullOrWhiteSpace(t?.TierId)))
+            throw new InvalidOperationException("EntitledTiers cannot contain null or empty tier IDs");
 
         // Validate no duplicate tier IDs
-        if (EntitledTierIds.Count != EntitledTierIds.Distinct().Count())
-            throw new InvalidOperationException("EntitledTierIds cannot contain duplicate tier IDs");
+        var tierIds = EntitledTiers.Select(t => t.TierId).ToList();
+        if (tierIds.Count != tierIds.Distinct().Count())
+            throw new InvalidOperationException("EntitledTiers cannot contain duplicate tier IDs");
 
         if (Timestamp == DateTime.MinValue || Timestamp == default)
             throw new InvalidOperationException("Timestamp must be set to a valid date");

--- a/W3ChampionsStatisticService/AssemblyInfo.cs
+++ b/W3ChampionsStatisticService/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("WC3ChampionsStatisticService.Tests")]

--- a/W3ChampionsStatisticService/AssemblyInfo.cs
+++ b/W3ChampionsStatisticService/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("WC3ChampionsStatisticService.Tests")]

--- a/W3ChampionsStatisticService/Rewards/Controllers/AdminRewardController.cs
+++ b/W3ChampionsStatisticService/Rewards/Controllers/AdminRewardController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using W3C.Domain.Rewards.Abstractions;
 using W3C.Domain.Common.Services;
+using W3C.Domain.Rewards.Entities;
 using W3C.Domain.Rewards.Repositories;
 using W3C.Domain.Rewards.ValueObjects;
 using W3ChampionsStatisticService.Rewards.DTOs;
@@ -277,7 +278,7 @@ public class AdminRewardController(
                 email = memberDetails.Email,
                 patronStatus = memberDetails.PatronStatus,
                 isActivePatron = memberDetails.IsActivePatron,
-                entitledTierIds = memberDetails.EntitledTiers?.Select(t => t.TierId).ToList() ?? new List<string>(),
+                entitledTiers = memberDetails.EntitledTiers ?? new List<EntitledTier>(),
                 lastChargeDate = memberDetails.LastChargeDate?.ToString("O"),
                 lastChargeStatus = memberDetails.LastChargeStatus,
                 pledgeRelationshipStart = memberDetails.PledgeRelationshipStart?.ToString("O"),

--- a/W3ChampionsStatisticService/Rewards/Controllers/AdminRewardController.cs
+++ b/W3ChampionsStatisticService/Rewards/Controllers/AdminRewardController.cs
@@ -277,7 +277,7 @@ public class AdminRewardController(
                 email = memberDetails.Email,
                 patronStatus = memberDetails.PatronStatus,
                 isActivePatron = memberDetails.IsActivePatron,
-                entitledTierIds = memberDetails.EntitledTierIds,
+                entitledTierIds = memberDetails.EntitledTiers?.Select(t => t.TierId).ToList() ?? new List<string>(),
                 lastChargeDate = memberDetails.LastChargeDate?.ToString("O"),
                 lastChargeStatus = memberDetails.LastChargeStatus,
                 pledgeRelationshipStart = memberDetails.PledgeRelationshipStart?.ToString("O"),

--- a/W3ChampionsStatisticService/Rewards/Controllers/PatreonWebhookController.cs
+++ b/W3ChampionsStatisticService/Rewards/Controllers/PatreonWebhookController.cs
@@ -67,7 +67,7 @@ public class PatreonWebhookController(
             var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(rewardEvent.UserId, rewardEvent.EventId, dryRun: false);
 
             _logger.LogInformation("Successfully processed Patreon webhook for user {UserId} with {TierCount} entitled tiers. Associations: {AssociationCount}, Rewards Added: {Added}, Rewards Revoked: {Revoked}",
-                rewardEvent.UserId, rewardEvent.EntitledTierIds.Count, associationResults.Count, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
+                rewardEvent.UserId, rewardEvent.EntitledTiers.Count, associationResults.Count, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
 
             return Ok(new
             {
@@ -75,7 +75,7 @@ public class PatreonWebhookController(
                 associationsProcessed = associationResults.Count,
                 rewardsAdded = reconciliationResult.RewardsAdded,
                 rewardsRevoked = reconciliationResult.RewardsRevoked,
-                entitledTiers = rewardEvent.EntitledTierIds
+                entitledTiers = rewardEvent.EntitledTiers.Select(t => t.TierId).ToList()
             });
         }
         catch (Exception ex)
@@ -109,10 +109,11 @@ public class PatreonWebhookController(
             }
 
             // Create new associations for entitled tiers (if any)
-            if (rewardEvent.EntitledTierIds?.Any() == true)
+            if (rewardEvent.EntitledTiers?.Any() == true)
             {
-                foreach (var tierId in rewardEvent.EntitledTierIds)
+                foreach (var tier in rewardEvent.EntitledTiers)
                 {
+                    var tierId = tier.TierId;
                     var association = await CreateAssociationForTier(rewardEvent, tierId);
                     if (association != null)
                     {

--- a/W3ChampionsStatisticService/Rewards/Controllers/PatreonWebhookController.cs
+++ b/W3ChampionsStatisticService/Rewards/Controllers/PatreonWebhookController.cs
@@ -11,6 +11,7 @@ using W3C.Domain.Rewards.Entities;
 using W3C.Domain.Rewards.Events;
 using W3C.Domain.Rewards.Repositories;
 using W3ChampionsStatisticService.Rewards.Providers.Patreon;
+using W3ChampionsStatisticService.Rewards.Services;
 
 namespace W3ChampionsStatisticService.Rewards.Controllers;
 
@@ -108,12 +109,13 @@ public class PatreonWebhookController(
                     association.Id, rewardEvent.UserId);
             }
 
-            // Create new associations for entitled tiers (if any)
+            // Create new associations for entitled tiers (if any), applying tier filter
             if (rewardEvent.EntitledTiers?.Any() == true)
             {
-                foreach (var tier in rewardEvent.EntitledTiers)
+                var productMappings = await _productMappingRepository.GetByProviderId(rewardEvent.ProviderId);
+                var filteredTierIds = PatreonTierFilter.Filter(rewardEvent.EntitledTiers, productMappings);
+                foreach (var tierId in filteredTierIds)
                 {
-                    var tierId = tier.TierId;
                     var association = await CreateAssociationForTier(rewardEvent, tierId);
                     if (association != null)
                     {

--- a/W3ChampionsStatisticService/Rewards/Controllers/PatreonWebhookController.cs
+++ b/W3ChampionsStatisticService/Rewards/Controllers/PatreonWebhookController.cs
@@ -76,7 +76,7 @@ public class PatreonWebhookController(
                 associationsProcessed = associationResults.Count,
                 rewardsAdded = reconciliationResult.RewardsAdded,
                 rewardsRevoked = reconciliationResult.RewardsRevoked,
-                entitledTiers = rewardEvent.EntitledTiers.Select(t => t.TierId).ToList()
+                entitledTiers = rewardEvent.EntitledTiers
             });
         }
         catch (Exception ex)

--- a/W3ChampionsStatisticService/Rewards/Providers/KoFi/KoFiProvider.cs
+++ b/W3ChampionsStatisticService/Rewards/Providers/KoFi/KoFiProvider.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using W3C.Domain.Rewards.Abstractions;
+using W3C.Domain.Rewards.Entities;
 using W3C.Domain.Rewards.Events;
 
 namespace W3ChampionsStatisticService.Rewards.Providers.KoFi;
@@ -89,7 +90,7 @@ public class KoFiProvider(ILogger<KoFiProvider> logger) : IRewardProvider
                     : null,
                 Currency = webhookData.Currency ?? "USD",
                 Timestamp = DateTime.UtcNow,
-                EntitledTierIds = new List<string> { tierId },
+                EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = tierId, AmountCents = null, Title = null } },
                 Metadata = new Dictionary<string, object>
                 {
                     ["message"] = webhookData.Message ?? "",

--- a/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonApiClient.cs
+++ b/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonApiClient.cs
@@ -238,10 +238,13 @@ public class PatreonApiClient
 
     internal bool IsMemberForCampaign(PatreonApiData memberData)
     {
-        if (memberData.Relationships?.ContainsKey("campaign") != true)
+        if (memberData?.Relationships == null) return false;
+        if (!memberData.Relationships.TryGetValue("campaign", out var campaignRel) || campaignRel?.Data == null)
+        {
+            Log.Warning("Patreon identity-endpoint member {MemberId} missing 'campaign' relationship; rejecting.", memberData.Id);
             return false;
-        var campaignRelation = memberData.Relationships["campaign"];
-        if (campaignRelation?.Data is JsonElement campaignData)
+        }
+        if (campaignRel.Data is JsonElement campaignData)
             return campaignData.TryGetProperty("id", out var idProp) && idProp.GetString() == _campaignId;
         return false;
     }
@@ -361,10 +364,10 @@ public class PatreonMember
     public List<EntitledTier> EntitledTiers { get; set; } = new();
 
     public bool IsActivePatron =>
-        PatronStatus == "active_patron" &&
-        (LastChargeStatus == "Paid"
-            || LastChargeStatus == "Pending"
-            || LastChargeStatus == "Free Trial");
+        string.Equals(PatronStatus, "active_patron", StringComparison.OrdinalIgnoreCase) &&
+        (string.Equals(LastChargeStatus, "Paid", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(LastChargeStatus, "Pending", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(LastChargeStatus, "Free Trial", StringComparison.OrdinalIgnoreCase));
 }
 
 public class PatreonApiResponse

--- a/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonApiClient.cs
+++ b/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonApiClient.cs
@@ -300,7 +300,9 @@ public class PatreonMember
 
     public bool IsActivePatron =>
         PatronStatus == "active_patron" &&
-        LastChargeStatus == "Paid";
+        (LastChargeStatus == "Paid"
+            || LastChargeStatus == "Pending"
+            || LastChargeStatus == "Free Trial");
 }
 
 public class PatreonApiResponse

--- a/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonApiClient.cs
+++ b/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonApiClient.cs
@@ -151,8 +151,10 @@ public class PatreonApiClient
             var userData = apiResponse.Data;
             var patreonUserId = userData.Id;
 
-            // Find membership data in included resources
-            var membershipData = apiResponse.Included?.FirstOrDefault(i => i.Type == "member");
+            // Find membership data in included resources (campaign-scoped to prevent cross-campaign identity-endpoint artifacts)
+            var membershipData = apiResponse.Included?
+                .FirstOrDefault(i => i.Type == "member"
+                    && IsMemberForCampaign(i));
             if (membershipData == null)
             {
                 Log.Information("User {PatreonUserId} has no active memberships", patreonUserId);
@@ -232,6 +234,16 @@ public class PatreonApiClient
         if (userRelation?.Data is JsonElement userData)
             return userData.TryGetProperty("id", out var idProp) ? idProp.GetString() : null;
         return null;
+    }
+
+    private bool IsMemberForCampaign(PatreonApiData memberData)
+    {
+        if (memberData.Relationships?.ContainsKey("campaign") != true)
+            return false;
+        var campaignRelation = memberData.Relationships["campaign"];
+        if (campaignRelation?.Data is JsonElement campaignData)
+            return campaignData.TryGetProperty("id", out var idProp) && idProp.GetString() == _campaignId;
+        return false;
     }
 
     private PatreonMember ParseMemberData(PatreonApiData memberData, List<PatreonApiData> included = null)

--- a/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonApiClient.cs
+++ b/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonApiClient.cs
@@ -184,6 +184,56 @@ public class PatreonApiClient
         }
     }
 
+    /// <summary>
+    /// Searches the campaign-members endpoint (using the campaign creator token) for the member
+    /// matching the given Patreon user ID. Paginates through all pages until a match is found.
+    /// Returns null if the user is not a member of this campaign.
+    /// </summary>
+    public virtual async Task<PatreonMember> GetCampaignMemberByPatreonUserId(string patreonUserId)
+    {
+        var url = $"{BaseUrl}/campaigns/{_campaignId}/members"
+            + "?include=currently_entitled_tiers,user"
+            + "&fields[member]=patron_status,last_charge_status,last_charge_date,currently_entitled_amount_cents,pledge_relationship_start"
+            + "&fields[tier]=title,amount_cents"
+            + "&fields[user]=full_name"
+            + "&page[count]=200";
+
+        while (!string.IsNullOrEmpty(url))
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
+
+            var response = await _httpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            var content = await response.Content.ReadAsStringAsync();
+            var apiResponse = JsonSerializer.Deserialize<PatreonApiResponse>(content, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            var match = apiResponse?.Data?.FirstOrDefault(d =>
+                d.Type == "member" && GetUserIdFromRelationships(d) == patreonUserId);
+
+            if (match != null)
+                return ParseMemberData(match, apiResponse.Included);
+
+            url = apiResponse?.Links?.Next;
+        }
+
+        return null;
+    }
+
+    private static string GetUserIdFromRelationships(PatreonApiData memberData)
+    {
+        if (memberData.Relationships?.ContainsKey("user") != true)
+            return null;
+        var userRelation = memberData.Relationships["user"];
+        if (userRelation?.Data is JsonElement userData)
+            return userData.TryGetProperty("id", out var idProp) ? idProp.GetString() : null;
+        return null;
+    }
+
     private PatreonMember ParseMemberData(PatreonApiData memberData, List<PatreonApiData> included = null)
     {
         try

--- a/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonApiClient.cs
+++ b/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonApiClient.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Serilog;
+using W3C.Domain.Rewards.Entities;
 
 namespace W3ChampionsStatisticService.Rewards.Providers.Patreon;
 
@@ -77,7 +78,7 @@ public class PatreonApiClient
                 {
                     foreach (var memberData in apiResponse.Data)
                     {
-                        var member = ParseMemberData(memberData);
+                        var member = ParseMemberData(memberData, apiResponse.Included);
                         if (member != null)
                         {
                             allMembers.Add(member);
@@ -161,17 +162,17 @@ public class PatreonApiClient
                     PatreonUserId = patreonUserId,
                     PatronStatus = "never_patron",
                     LastChargeStatus = null,
-                    EntitledTierIds = new List<string>()
+                    EntitledTiers = new List<EntitledTier>()
                 };
             }
 
             // Parse membership data into PatreonMember
-            var member = ParseMemberData(membershipData);
+            var member = ParseMemberData(membershipData, apiResponse.Included);
             if (member != null)
             {
                 member.PatreonUserId = patreonUserId;
                 Log.Information("Successfully fetched membership data for user {PatreonUserId}, Status: {Status}, Tiers: {Tiers}",
-                    patreonUserId, member.PatronStatus, string.Join(",", member.EntitledTierIds));
+                    patreonUserId, member.PatronStatus, string.Join(",", member.EntitledTiers.Select(t => t.TierId)));
             }
 
             return member;
@@ -183,7 +184,7 @@ public class PatreonApiClient
         }
     }
 
-    private PatreonMember ParseMemberData(PatreonApiData memberData)
+    private PatreonMember ParseMemberData(PatreonApiData memberData, List<PatreonApiData> included = null)
     {
         try
         {
@@ -192,7 +193,7 @@ public class PatreonApiClient
                 Id = memberData.Id,
                 PatronStatus = memberData.Attributes?.GetValueOrDefault("patron_status")?.ToString(),
                 LastChargeStatus = memberData.Attributes?.GetValueOrDefault("last_charge_status")?.ToString(),
-                EntitledTierIds = new List<string>()
+                EntitledTiers = new List<EntitledTier>()
             };
 
             // Extract email
@@ -232,7 +233,13 @@ public class PatreonApiClient
                 }
             }
 
-            // Get entitled tiers
+            // Build a lookup of included tier resources by ID
+            var includedTierLookup = included?
+                .Where(i => i.Type == "tier")
+                .ToDictionary(i => i.Id, i => i, StringComparer.Ordinal)
+                ?? new Dictionary<string, PatreonApiData>();
+
+            // Get entitled tiers with rich data from included resources
             if (memberData.Relationships?.ContainsKey("currently_entitled_tiers") == true)
             {
                 var tiersRelation = memberData.Relationships["currently_entitled_tiers"];
@@ -242,7 +249,29 @@ public class PatreonApiClient
                     {
                         if (tierElement.TryGetProperty("id", out var idProp))
                         {
-                            member.EntitledTierIds.Add(idProp.GetString());
+                            var tierId = idProp.GetString();
+                            includedTierLookup.TryGetValue(tierId, out var tierResource);
+
+                            long? amountCents = null;
+                            string title = null;
+
+                            if (tierResource?.Attributes != null)
+                            {
+                                if (tierResource.Attributes.TryGetValue("amount_cents", out var amountObj) && amountObj is JsonElement amountEl)
+                                {
+                                    if (amountEl.ValueKind == JsonValueKind.Number && amountEl.TryGetInt64(out var amount))
+                                        amountCents = amount;
+                                }
+                                if (tierResource.Attributes.TryGetValue("title", out var titleObj))
+                                    title = titleObj?.ToString();
+                            }
+
+                            member.EntitledTiers.Add(new EntitledTier
+                            {
+                                TierId = tierId,
+                                AmountCents = amountCents,
+                                Title = title
+                            });
                         }
                     }
                 }
@@ -267,7 +296,7 @@ public class PatreonMember
     public string LastChargeStatus { get; set; }
     public DateTime? LastChargeDate { get; set; }
     public DateTime? PledgeRelationshipStart { get; set; }
-    public List<string> EntitledTierIds { get; set; } = new();
+    public List<EntitledTier> EntitledTiers { get; set; } = new();
 
     public bool IsActivePatron =>
         PatronStatus == "active_patron" &&

--- a/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonApiClient.cs
+++ b/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonApiClient.cs
@@ -236,7 +236,7 @@ public class PatreonApiClient
         return null;
     }
 
-    private bool IsMemberForCampaign(PatreonApiData memberData)
+    internal bool IsMemberForCampaign(PatreonApiData memberData)
     {
         if (memberData.Relationships?.ContainsKey("campaign") != true)
             return false;
@@ -246,7 +246,7 @@ public class PatreonApiClient
         return false;
     }
 
-    private PatreonMember ParseMemberData(PatreonApiData memberData, List<PatreonApiData> included = null)
+    internal PatreonMember ParseMemberData(PatreonApiData memberData, List<PatreonApiData> included = null)
     {
         try
         {

--- a/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonProvider.cs
+++ b/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonProvider.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using W3C.Domain.Rewards.Abstractions;
+using W3C.Domain.Rewards.Entities;
 using W3C.Domain.Rewards.Events;
 using W3C.Domain.Rewards.Repositories;
 
@@ -68,7 +69,7 @@ public class PatreonProvider(ILogger<PatreonProvider> logger, IPatreonAccountLin
 
             var eventType = MapPatreonEventType(headers, webhookData.Data.Attributes.PatronStatus);
             var userId = await ResolveUserId(webhookData.Data.Id);
-            var tierIds = ExtractAllTierIdsFromRelationships(webhookData);
+            var entitledTiers = ExtractEntitledTiersFromRelationships(webhookData);
 
             if (string.IsNullOrEmpty(userId))
             {
@@ -86,11 +87,11 @@ public class PatreonProvider(ILogger<PatreonProvider> logger, IPatreonAccountLin
                 UserId = userId,
                 ProviderReference = webhookData.Data.Id,
                 Timestamp = DateTime.UtcNow,
-                EntitledTierIds = tierIds,
+                EntitledTiers = entitledTiers,
                 Metadata = new Dictionary<string, object>
                 {
                     ["patron_status"] = webhookData.Data.Attributes.PatronStatus ?? "unknown",
-                    ["total_entitled_tiers"] = tierIds.Count,
+                    ["total_entitled_tiers"] = entitledTiers.Count,
                     ["patreon_user_id"] = webhookData.Data.Id
                 }
             };
@@ -174,7 +175,7 @@ public class PatreonProvider(ILogger<PatreonProvider> logger, IPatreonAccountLin
         };
     }
 
-    private List<string> ExtractAllTierIdsFromRelationships(PatreonWebhookData webhookData)
+    private List<EntitledTier> ExtractEntitledTiersFromRelationships(PatreonWebhookData webhookData)
     {
         var tierIds = new List<string>();
 
@@ -189,6 +190,20 @@ public class PatreonProvider(ILogger<PatreonProvider> logger, IPatreonAccountLin
             );
         }
 
-        return tierIds;
+        var includedTiers = webhookData.Included?
+            .Where(i => i.Type == "tier")
+            .ToDictionary(i => i.Id, i => i, StringComparer.Ordinal)
+            ?? new Dictionary<string, PatreonIncludedResource>();
+
+        return tierIds.Select(id =>
+        {
+            includedTiers.TryGetValue(id, out var inc);
+            return new EntitledTier
+            {
+                TierId = id,
+                AmountCents = inc?.Attributes?.AmountCents,
+                Title = inc?.Attributes?.Title
+            };
+        }).ToList();
     }
 }

--- a/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonWebhookModels.cs
+++ b/W3ChampionsStatisticService/Rewards/Providers/Patreon/PatreonWebhookModels.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace W3ChampionsStatisticService.Rewards.Providers.Patreon;
@@ -6,6 +7,9 @@ public class PatreonWebhookData
 {
     [JsonPropertyName("data")]
     public PatreonData Data { get; set; }
+
+    [JsonPropertyName("included")]
+    public List<PatreonIncludedResource> Included { get; set; }
 }
 
 public class PatreonData
@@ -60,4 +64,25 @@ public class PatreonTiersRelationship
 {
     [JsonPropertyName("data")]
     public PatreonRelationshipData[] Data { get; set; }
+}
+
+public class PatreonIncludedResource
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+
+    [JsonPropertyName("attributes")]
+    public PatreonIncludedAttributes Attributes { get; set; }
+}
+
+public class PatreonIncludedAttributes
+{
+    [JsonPropertyName("amount_cents")]
+    public long? AmountCents { get; set; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; }
 }

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -124,8 +124,12 @@ public class PatreonDriftDetectionService(
                 var internalTierIds = ExtractTierIdsFromAssociations(associations);
 
                 // Apply the same TIERED filtering logic that would be applied during sync to BOTH sides
-                var filteredPatreonTiers = FilterTierIdsForProcessing(patreonMember.EntitledTiers.Select(t => t.TierId).ToList(), allProductMappings);
-                var filteredInternalTiers = FilterTierIdsForProcessing(internalTierIds, allProductMappings);
+                var filteredPatreonTiers = FilterTierIdsForProcessing(patreonMember.EntitledTiers, allProductMappings);
+                var filteredInternalTiers = FilterTierIdsForProcessing(
+                    associations.Where(a => a.IsActive() && a.ProviderId == "patreon")
+                        .Select(a => new EntitledTier { TierId = a.ProviderProductId, AmountCents = null })
+                        .ToList(),
+                    allProductMappings);
 
                 if (!AreTierSetsEqual(filteredPatreonTiers, filteredInternalTiers))
                 {
@@ -687,7 +691,7 @@ public class PatreonDriftDetectionService(
         if (!dryRun)
         {
             // Create associations for each entitled tier using batch-optimized method
-            await CreateAssociationsForTiers(battleTag, missingMember.EntitledTiers?.Select(t => t.TierId).ToList() ?? new List<string>(), "drift_sync_missing");
+            await CreateAssociationsForTiers(battleTag, missingMember.EntitledTiers ?? new List<EntitledTier>(), "drift_sync_missing");
 
             var eventIdPrefix = $"drift_sync_{DateTime.UtcNow:yyyyMMddHHmmss}_{battleTag}";
             var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(battleTag, eventIdPrefix, dryRun: false);
@@ -756,56 +760,10 @@ public class PatreonDriftDetectionService(
     }
 
     /// <summary>
-    /// Filters tier IDs based on ProductMappingType - for TIERED rewards, only process the first tier
+    /// Filters tier IDs based on ProductMappingType - for TIERED rewards, only process the highest-amount tier
     /// </summary>
-    private List<string> FilterTierIdsForProcessing(List<string> tierIds, List<ProductMapping> productMappings)
-    {
-        if (tierIds == null || !tierIds.Any())
-            return new List<string>();
-
-        // Group tiers by their mapping type
-        var tieredMappings = new List<string>();
-        var nonTieredMappings = new List<string>();
-
-        foreach (var tierId in tierIds)
-        {
-            var mapping = productMappings
-                .FirstOrDefault(pm => pm.ProductProviders
-                    .Any(pp => pp.ProviderId == ProviderId && pp.ProductId == tierId));
-
-            if (mapping != null && mapping.Type == ProductMappingType.Tiered)
-            {
-                tieredMappings.Add(tierId);
-            }
-            else
-            {
-                nonTieredMappings.Add(tierId);
-            }
-        }
-
-        // For TIERED mappings, only take the first one
-        var resultTiers = new List<string>();
-        if (tieredMappings.Any())
-        {
-            resultTiers.Add(tieredMappings.First());
-            if (tieredMappings.Count > 1)
-            {
-                Log.Debug("Filtering TIERED rewards: keeping only first tier {FirstTier} from {AllTiers}",
-                    tieredMappings.First(), string.Join(", ", tieredMappings));
-            }
-        }
-
-        // Add all non-tiered mappings
-        resultTiers.AddRange(nonTieredMappings);
-
-        if (tierIds.Count != resultTiers.Count)
-        {
-            Log.Information("Filtered tier IDs from [{OriginalTiers}] to [{FilteredTiers}]",
-                string.Join(", ", tierIds), string.Join(", ", resultTiers));
-        }
-
-        return resultTiers;
-    }
+    private List<string> FilterTierIdsForProcessing(List<EntitledTier> tiers, List<ProductMapping> productMappings)
+        => PatreonTierFilter.Filter(tiers, productMappings);
 
     /// <summary>
     /// Creates associations for new patrons
@@ -815,8 +773,8 @@ public class PatreonDriftDetectionService(
         // Get all product mappings once to avoid multiple DB calls
         var allProductMappings = await _productMappingRepository.GetByProviderId(ProviderId);
 
-        // Filter tier IDs - for TIERED rewards, only process the first one
-        var filteredTierIds = FilterTierIdsForProcessing(patreonData.EntitledTiers?.Select(t => t.TierId).ToList() ?? new List<string>(), allProductMappings);
+        // Filter tier IDs - for TIERED rewards, only process the highest-amount one
+        var filteredTierIds = FilterTierIdsForProcessing(patreonData.EntitledTiers ?? new List<EntitledTier>(), allProductMappings);
 
         foreach (var tierId in filteredTierIds)
         {
@@ -847,8 +805,8 @@ public class PatreonDriftDetectionService(
         // Get all product mappings once to avoid multiple DB calls
         var allProductMappings = await _productMappingRepository.GetByProviderId(ProviderId);
 
-        // Filter tier IDs - for TIERED rewards, only process the first one
-        var filteredTierIds = FilterTierIdsForProcessing(patreonData.EntitledTiers?.Select(t => t.TierId).ToList() ?? new List<string>(), allProductMappings);
+        // Filter tier IDs - for TIERED rewards, only process the highest-amount one
+        var filteredTierIds = FilterTierIdsForProcessing(patreonData.EntitledTiers ?? new List<EntitledTier>(), allProductMappings);
 
         // Create new associations
         foreach (var tierId in filteredTierIds)
@@ -884,15 +842,15 @@ public class PatreonDriftDetectionService(
     /// <summary>
     /// Creates associations for multiple tiers in batch to avoid repeated DB calls
     /// </summary>
-    private async Task CreateAssociationsForTiers(string battleTag, List<string> tierIds, string source)
+    private async Task CreateAssociationsForTiers(string battleTag, List<EntitledTier> tiers, string source)
     {
-        if (!tierIds.Any()) return;
+        if (!tiers.Any()) return;
 
         // Get all product mappings for these tiers in one call
         var allProductMappings = await _productMappingRepository.GetByProviderId(ProviderId);
 
-        // Filter tier IDs - for TIERED rewards, only process the first one
-        var filteredTierIds = FilterTierIdsForProcessing(tierIds, allProductMappings);
+        // Filter tier IDs - for TIERED rewards, only process the highest-amount one
+        var filteredTierIds = FilterTierIdsForProcessing(tiers, allProductMappings);
 
         // Filter for mappings that match the tier IDs for Patreon provider
         var tierMappings = allProductMappings

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -113,7 +113,7 @@ public class PatreonDriftDetectionService(
                     PatreonMemberId = patreonMember.Id,
                     PatreonUserId = patreonMember.PatreonUserId,
                     PatronStatus = patreonMember.PatronStatus,
-                    EntitledTierIds = patreonMember.EntitledTierIds,
+                    EntitledTiers = patreonMember.EntitledTiers,
                     Reason = "Active patron found in Patreon but no active rewards in our system"
                 });
             }
@@ -124,7 +124,7 @@ public class PatreonDriftDetectionService(
                 var internalTierIds = ExtractTierIdsFromAssociations(associations);
 
                 // Apply the same TIERED filtering logic that would be applied during sync to BOTH sides
-                var filteredPatreonTiers = FilterTierIdsForProcessing(patreonMember.EntitledTierIds, allProductMappings);
+                var filteredPatreonTiers = FilterTierIdsForProcessing(patreonMember.EntitledTiers.Select(t => t.TierId).ToList(), allProductMappings);
                 var filteredInternalTiers = FilterTierIdsForProcessing(internalTierIds, allProductMappings);
 
                 if (!AreTierSetsEqual(filteredPatreonTiers, filteredInternalTiers))
@@ -133,7 +133,7 @@ public class PatreonDriftDetectionService(
                     {
                         UserId = battleTag,
                         PatreonMemberId = patreonMember.Id,
-                        PatreonTiers = patreonMember.EntitledTierIds,  // Original unfiltered tiers
+                        PatreonTiers = patreonMember.EntitledTiers.Select(t => t.TierId).ToList(),  // Original unfiltered tiers
                         PatreonTiersFiltered = filteredPatreonTiers,   // What was actually compared
                         InternalTiers = internalTierIds,               // Original internal tiers
                         InternalTiersFiltered = filteredInternalTiers, // What was actually compared
@@ -233,7 +233,7 @@ public class PatreonDriftDetectionService(
             {
                 Log.Warning("Missing member: Email={Email}, PatreonId={Id}, Status={Status}, Tiers={Tiers}",
                     missing.PatreonUserId, missing.PatreonMemberId, missing.PatronStatus,
-                    string.Join(",", missing.EntitledTierIds ?? new List<string>()));
+                    string.Join(",", missing.EntitledTiers?.Select(t => t.TierId) ?? new List<string>()));
             }
 
             // Log details for extra assignments
@@ -504,7 +504,7 @@ public class PatreonDriftDetectionService(
                 Email = patreonMember.Email,
                 PatronStatus = patreonMember.PatronStatus,
                 IsActivePatron = patreonMember.IsActivePatron,
-                EntitledTierIds = patreonMember.EntitledTierIds ?? new List<string>(),
+                EntitledTiers = patreonMember.EntitledTiers ?? new List<EntitledTier>(),
                 LastChargeDate = patreonMember.LastChargeDate,
                 LastChargeStatus = patreonMember.LastChargeStatus,
                 PledgeRelationshipStart = patreonMember.PledgeRelationshipStart,
@@ -615,7 +615,7 @@ public class PatreonDriftDetectionService(
     private UserSyncAction DetermineRequiredSyncAction(PatreonMember patreonData, List<ProductMappingUserAssociation> currentAssociations)
     {
         var internalTierIds = ExtractTierIdsFromAssociations(currentAssociations);
-        var patreonTierIds = patreonData.EntitledTierIds ?? new List<string>();
+        var patreonTierIds = patreonData.EntitledTiers?.Select(t => t.TierId).ToList() ?? new List<string>();
 
         // If user is not an active patron, they should have no associations
         if (!patreonData.IsActivePatron)
@@ -687,7 +687,7 @@ public class PatreonDriftDetectionService(
         if (!dryRun)
         {
             // Create associations for each entitled tier using batch-optimized method
-            await CreateAssociationsForTiers(battleTag, missingMember.EntitledTierIds ?? new List<string>(), "drift_sync_missing");
+            await CreateAssociationsForTiers(battleTag, missingMember.EntitledTiers?.Select(t => t.TierId).ToList() ?? new List<string>(), "drift_sync_missing");
 
             var eventIdPrefix = $"drift_sync_{DateTime.UtcNow:yyyyMMddHHmmss}_{battleTag}";
             var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(battleTag, eventIdPrefix, dryRun: false);
@@ -816,7 +816,7 @@ public class PatreonDriftDetectionService(
         var allProductMappings = await _productMappingRepository.GetByProviderId(ProviderId);
 
         // Filter tier IDs - for TIERED rewards, only process the first one
-        var filteredTierIds = FilterTierIdsForProcessing(patreonData.EntitledTierIds ?? new List<string>(), allProductMappings);
+        var filteredTierIds = FilterTierIdsForProcessing(patreonData.EntitledTiers?.Select(t => t.TierId).ToList() ?? new List<string>(), allProductMappings);
 
         foreach (var tierId in filteredTierIds)
         {
@@ -848,7 +848,7 @@ public class PatreonDriftDetectionService(
         var allProductMappings = await _productMappingRepository.GetByProviderId(ProviderId);
 
         // Filter tier IDs - for TIERED rewards, only process the first one
-        var filteredTierIds = FilterTierIdsForProcessing(patreonData.EntitledTierIds ?? new List<string>(), allProductMappings);
+        var filteredTierIds = FilterTierIdsForProcessing(patreonData.EntitledTiers?.Select(t => t.TierId).ToList() ?? new List<string>(), allProductMappings);
 
         // Create new associations
         foreach (var tierId in filteredTierIds)
@@ -1021,7 +1021,7 @@ public class MissingMember
     public string PatreonMemberId { get; set; }
     public string PatreonUserId { get; set; }
     public string PatronStatus { get; set; }
-    public List<string> EntitledTierIds { get; set; }
+    public List<EntitledTier> EntitledTiers { get; set; }
     public string Reason { get; set; }
 }
 
@@ -1091,7 +1091,7 @@ public class PatreonMemberDetails
     public string Email { get; set; }
     public string PatronStatus { get; set; }
     public bool IsActivePatron { get; set; }
-    public List<string> EntitledTierIds { get; set; } = new();
+    public List<EntitledTier> EntitledTiers { get; set; } = new();
     public DateTime? LastChargeDate { get; set; }
     public string LastChargeStatus { get; set; }
     public DateTime? PledgeRelationshipStart { get; set; }

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -555,8 +555,8 @@ public class PatreonDriftDetectionService(
 
             Log.Information("[USER-SYNC] Starting single user sync for BattleTag {BattleTag}", battleTag);
 
-            // Fetch fresh Patreon data using access token
-            var patreonData = await _patreonApiClient.GetUserMemberships(accessToken);
+            // Fetch fresh Patreon data using campaign endpoint (authoritative for our campaign)
+            var patreonData = await _patreonApiClient.GetCampaignMemberByPatreonUserId(patreonUserId);
             if (patreonData == null)
             {
                 result.Success = false;

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonTierFilter.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonTierFilter.cs
@@ -28,7 +28,7 @@ internal static class PatreonTierFilter
         if (tieredCandidates.Any())
         {
             var winner = tieredCandidates
-                .OrderByDescending(c => c.AmountCents ?? long.MinValue)
+                .OrderByDescending(c => c.AmountCents.HasValue && c.AmountCents.Value >= 0 ? c.AmountCents.Value : long.MinValue)
                 .ThenBy(c => c.TierId, System.StringComparer.Ordinal)
                 .First();
             result.Add(winner.TierId);

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonTierFilter.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonTierFilter.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Linq;
+using Serilog;
+using W3C.Domain.Rewards.Entities;
+
+namespace W3ChampionsStatisticService.Rewards.Services;
+
+internal static class PatreonTierFilter
+{
+    private const string ProviderId = "patreon";
+
+    public static List<string> Filter(List<EntitledTier> tiers, List<ProductMapping> productMappings)
+    {
+        var tieredCandidates = new List<EntitledTier>();
+        var passthrough = new List<string>();
+
+        foreach (var t in tiers)
+        {
+            var mapping = productMappings.FirstOrDefault(pm =>
+                pm.ProductProviders.Any(pp => pp.ProviderId == ProviderId && pp.ProductId == t.TierId));
+            if (mapping?.Type == ProductMappingType.Tiered)
+                tieredCandidates.Add(t);
+            else
+                passthrough.Add(t.TierId);
+        }
+
+        var result = new List<string>(passthrough);
+        if (tieredCandidates.Any())
+        {
+            var winner = tieredCandidates
+                .OrderByDescending(c => c.AmountCents ?? long.MinValue)
+                .ThenBy(c => c.TierId, System.StringComparer.Ordinal)
+                .First();
+            result.Add(winner.TierId);
+            if (tieredCandidates.Count > 1)
+                Log.Information("Tier upgrade: keeping highest-priced {Winner} ({Cents}c) over {Others}",
+                    winner.TierId, winner.AmountCents,
+                    string.Join(",", tieredCandidates.Where(c => c.TierId != winner.TierId)
+                        .Select(c => $"{c.TierId}({c.AmountCents}c)")));
+        }
+        return result;
+    }
+}

--- a/W3ChampionsStatisticService/Rewards/Services/RewardService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/RewardService.cs
@@ -47,8 +47,8 @@ public class RewardService(
         if (string.IsNullOrEmpty(rewardEvent.ProviderReference))
             throw new RewardsValidationException("ProviderReference cannot be null or empty", nameof(rewardEvent.ProviderReference));
 
-        if (rewardEvent.EntitledTierIds == null)
-            throw new RewardsValidationException("EntitledTierIds cannot be null", nameof(rewardEvent.EntitledTierIds));
+        if (rewardEvent.EntitledTiers == null)
+            throw new RewardsValidationException("EntitledTiers cannot be null", nameof(rewardEvent.EntitledTiers));
 
         try
         {
@@ -69,7 +69,7 @@ public class RewardService(
 
             // Get previous entitled tiers from the database for diffing
             var previousTiers = await GetPreviousEntitledTiers(rewardEvent.UserId, rewardEvent.ProviderId);
-            var currentTiers = rewardEvent.EntitledTierIds ?? new List<string>();
+            var currentTiers = rewardEvent.EntitledTiers.Select(t => t.TierId).ToList();
 
             // Calculate tier changes
             var addedTiers = currentTiers.Except(previousTiers).ToList();

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/Builders/EntitledTierBuilder.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/Builders/EntitledTierBuilder.cs
@@ -1,0 +1,25 @@
+using W3C.Domain.Rewards.Entities;
+
+namespace WC3ChampionsStatisticService.UnitTests.Rewards.Builders;
+
+public class EntitledTierBuilder
+{
+    private string _tierId = "default-tier-id";
+    private long? _amountCents = 100;
+    private string _title = "Default Tier";
+
+    public EntitledTierBuilder WithTierId(string id) { _tierId = id; return this; }
+    public EntitledTierBuilder WithAmountCents(long? cents) { _amountCents = cents; return this; }
+    public EntitledTierBuilder WithTitle(string title) { _title = title; return this; }
+
+    public EntitledTier Build() => new EntitledTier
+    {
+        TierId = _tierId,
+        AmountCents = _amountCents,
+        Title = _title
+    };
+
+    public static EntitledTier Bronze() => new EntitledTierBuilder().WithTierId("6482051").WithAmountCents(100).WithTitle("Bronze Tier Supporter").Build();
+    public static EntitledTier Silver() => new EntitledTierBuilder().WithTierId("6482057").WithAmountCents(500).WithTitle("Silver Tier Supporter").Build();
+    public static EntitledTier Gold() => new EntitledTierBuilder().WithTierId("6482070").WithAmountCents(1000).WithTitle("Gold Tier Supporter").Build();
+}

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/Builders/PatreonMemberBuilder.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/Builders/PatreonMemberBuilder.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using W3C.Domain.Rewards.Entities;
+using W3ChampionsStatisticService.Rewards.Providers.Patreon;
+
+namespace WC3ChampionsStatisticService.UnitTests.Rewards.Builders;
+
+public class PatreonMemberBuilder
+{
+    private string _patreonUserId = "default-patreon-user-id";
+    private string _email = "test@example.com";
+    private string _patronStatus = "active_patron";
+    private string _lastChargeStatus = "Paid";
+    private List<EntitledTier> _entitledTiers = new();
+
+    public PatreonMemberBuilder WithPatreonUserId(string id) { _patreonUserId = id; return this; }
+    public PatreonMemberBuilder WithEmail(string e) { _email = e; return this; }
+    public PatreonMemberBuilder WithPatronStatus(string s) { _patronStatus = s; return this; }
+    public PatreonMemberBuilder WithLastChargeStatus(string s) { _lastChargeStatus = s; return this; }
+    public PatreonMemberBuilder WithTiers(params EntitledTier[] tiers) { _entitledTiers = new List<EntitledTier>(tiers); return this; }
+
+    public PatreonMember Build() => new PatreonMember
+    {
+        PatreonUserId = _patreonUserId,
+        Email = _email,
+        PatronStatus = _patronStatus,
+        LastChargeStatus = _lastChargeStatus,
+        EntitledTiers = _entitledTiers
+    };
+}

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/FilterTierIdsForProcessingTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/FilterTierIdsForProcessingTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using W3C.Domain.Rewards.Entities;
+using W3ChampionsStatisticService.Rewards.Services;
+using WC3ChampionsStatisticService.UnitTests.Rewards.Builders;
+
+namespace WC3ChampionsStatisticService.UnitTests.Rewards;
+
+[TestFixture]
+public class FilterTierIdsForProcessingTests
+{
+    private List<ProductMapping> _mappings;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mappings = new List<ProductMapping>
+        {
+            // Bronze, Silver, Gold all Tiered. Distinct tier IDs.
+            new ProductMapping { Type = ProductMappingType.Tiered, ProductProviders = new() { new ProductProviderPair { ProviderId = "patreon", ProductId = "6482051" } } },
+            new ProductMapping { Type = ProductMappingType.Tiered, ProductProviders = new() { new ProductProviderPair { ProviderId = "patreon", ProductId = "6482057" } } },
+            new ProductMapping { Type = ProductMappingType.Tiered, ProductProviders = new() { new ProductProviderPair { ProviderId = "patreon", ProductId = "6482070" } } },
+            // A non-Tiered mapping for additive tests
+            new ProductMapping { Type = ProductMappingType.OneTime, ProductProviders = new() { new ProductProviderPair { ProviderId = "patreon", ProductId = "onetime-1" } } }
+        };
+    }
+
+    [Test]
+    public void TwoTieredMappings_PicksHighestAmountCents()
+    {
+        var input = new List<EntitledTier> { EntitledTierBuilder.Bronze(), EntitledTierBuilder.Gold() };
+        var result = PatreonTierFilter.Filter(input, _mappings);
+        Assert.AreEqual(new[] { "6482070" }, result.ToArray());
+    }
+
+    [Test]
+    public void HighestAmountIsLastInList_PicksLast()
+    {
+        var input = new List<EntitledTier> { EntitledTierBuilder.Bronze(), EntitledTierBuilder.Silver(), EntitledTierBuilder.Gold() };
+        var result = PatreonTierFilter.Filter(input, _mappings);
+        Assert.AreEqual(new[] { "6482070" }, result.ToArray(), "Defeats .First() regression: must pick last (Gold) by amount, not first (Bronze) by position.");
+    }
+
+    [Test]
+    public void TiedAmountCents_TiebreakerByTierIdOrdinal()
+    {
+        var t1 = new EntitledTierBuilder().WithTierId("Z-tier").WithAmountCents(500).Build();
+        var t2 = new EntitledTierBuilder().WithTierId("A-tier").WithAmountCents(500).Build();
+        var mappings = new List<ProductMapping>
+        {
+            new ProductMapping { Type = ProductMappingType.Tiered, ProductProviders = new() { new ProductProviderPair { ProviderId = "patreon", ProductId = "Z-tier" } } },
+            new ProductMapping { Type = ProductMappingType.Tiered, ProductProviders = new() { new ProductProviderPair { ProviderId = "patreon", ProductId = "A-tier" } } },
+        };
+        var result = PatreonTierFilter.Filter(new List<EntitledTier> { t1, t2 }, mappings);
+        Assert.AreEqual(new[] { "A-tier" }, result.ToArray(), "Lexicographic tiebreaker: A-tier < Z-tier, A wins.");
+    }
+
+    [Test]
+    public void NullAmountCentsOnOneMapping_PrefersExplicitOverNull()
+    {
+        var bronze = EntitledTierBuilder.Bronze();
+        var nullTier = new EntitledTierBuilder().WithTierId("6482057").WithAmountCents(null).Build();
+        var result = PatreonTierFilter.Filter(new List<EntitledTier> { nullTier, bronze }, _mappings);
+        Assert.AreEqual(new[] { "6482051" }, result.ToArray(), "Null amounts treated as lowest priority; explicit Bronze wins.");
+    }
+
+    [Test]
+    public void AllTieredAmountCentsZero_PicksDeterministically()
+    {
+        var t1 = new EntitledTierBuilder().WithTierId("6482051").WithAmountCents(0).Build();
+        var t2 = new EntitledTierBuilder().WithTierId("6482057").WithAmountCents(0).Build();
+        var result = PatreonTierFilter.Filter(new List<EntitledTier> { t2, t1 }, _mappings);
+        Assert.AreEqual(new[] { "6482051" }, result.ToArray(), "Tiebreaker by tier ID applies even at 0 amount.");
+    }
+
+    [Test]
+    public void NegativeAmountCents_TreatedAsLowestPriority()
+    {
+        var negative = new EntitledTierBuilder().WithTierId("6482051").WithAmountCents(-100).Build();
+        var positive = new EntitledTierBuilder().WithTierId("6482070").WithAmountCents(100).Build();
+        var result = PatreonTierFilter.Filter(new List<EntitledTier> { negative, positive }, _mappings);
+        Assert.AreEqual(new[] { "6482070" }, result.ToArray());
+    }
+
+    [Test]
+    public void VeryLargeAmountCents_DoesNotOverflow()
+    {
+        var huge = new EntitledTierBuilder().WithTierId("6482051").WithAmountCents(long.MaxValue).Build();
+        var small = new EntitledTierBuilder().WithTierId("6482070").WithAmountCents(100).Build();
+        var result = PatreonTierFilter.Filter(new List<EntitledTier> { small, huge }, _mappings);
+        Assert.AreEqual(new[] { "6482051" }, result.ToArray());
+    }
+
+    [Test]
+    public void MixedTieredAndOneTime_HighestTieredWins_OneTimesPreserved()
+    {
+        var oneTime = new EntitledTierBuilder().WithTierId("onetime-1").WithAmountCents(50).Build();
+        var input = new List<EntitledTier> { EntitledTierBuilder.Bronze(), oneTime, EntitledTierBuilder.Gold() };
+        var result = PatreonTierFilter.Filter(input, _mappings);
+        CollectionAssert.AreEquivalent(new[] { "6482070", "onetime-1" }, result.ToArray(),
+            "Highest tiered (Gold) plus all non-tiered passthroughs.");
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/FilterTierIdsForProcessingTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/FilterTierIdsForProcessingTests.cs
@@ -83,6 +83,22 @@ public class FilterTierIdsForProcessingTests
     }
 
     [Test]
+    public void NegativeAmount_LosesToNullAmount_TiebreakerByTierIdOrdinal()
+    {
+        // Both negative and null are mapped to long.MinValue; lexicographic tiebreaker decides.
+        var negative = new EntitledTierBuilder().WithTierId("Z-tier").WithAmountCents(-100).Build();
+        var nullAmt = new EntitledTierBuilder().WithTierId("A-tier").WithAmountCents(null).Build();
+        var mappings = new List<ProductMapping>
+        {
+            new ProductMapping { Type = ProductMappingType.Tiered, ProductProviders = new() { new ProductProviderPair { ProviderId = "patreon", ProductId = "Z-tier" } } },
+            new ProductMapping { Type = ProductMappingType.Tiered, ProductProviders = new() { new ProductProviderPair { ProviderId = "patreon", ProductId = "A-tier" } } },
+        };
+        var result = PatreonTierFilter.Filter(new List<EntitledTier> { negative, nullAmt }, mappings);
+        Assert.AreEqual(new[] { "A-tier" }, result.ToArray(),
+            "Negative and null amounts both rank as long.MinValue; lexicographic tiebreaker → A-tier wins.");
+    }
+
+    [Test]
     public void VeryLargeAmountCents_DoesNotOverflow()
     {
         var huge = new EntitledTierBuilder().WithTierId("6482051").WithAmountCents(long.MaxValue).Build();

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/Fixtures/PatreonPayloadLoader.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/Fixtures/PatreonPayloadLoader.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace WC3ChampionsStatisticService.UnitTests.Rewards.Fixtures;
+
+public static class PatreonPayloadLoader
+{
+    private static readonly string PayloadsDir = ResolvePayloadsDir();
+
+    private static string ResolvePayloadsDir()
+    {
+        var assembly = typeof(PatreonPayloadLoader).GetTypeInfo().Assembly;
+        var assemblyDir = Path.GetDirectoryName(assembly.Location);
+        var payloadsPath = Path.Combine(assemblyDir, "Rewards", "Fixtures", "Payloads");
+
+        if (!Directory.Exists(payloadsPath))
+            throw new InvalidOperationException($"Could not locate payloads directory at {payloadsPath}");
+
+        return payloadsPath;
+    }
+
+    public static string LoadRaw(string name) => File.ReadAllText(Path.Combine(PayloadsDir, name));
+
+    public static string MembersCreateJson() => LoadRaw("members-create.json");
+    public static string MembersUpdateJson() => LoadRaw("members-update.json");
+    public static string MembersDeleteJson() => LoadRaw("members-delete.json");
+}

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/Fixtures/Payloads/members-create.json
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/Fixtures/Payloads/members-create.json
@@ -1,0 +1,147 @@
+{
+    "data": {
+        "attributes": {
+            "campaign_lifetime_support_cents": 0,
+            "currently_entitled_amount_cents": 1337,
+            "email": "jw@example.com",
+            "full_name": "Jules Winnfield",
+            "is_follower": false,
+            "is_free_trial": false,
+            "is_gifted": false,
+            "last_charge_date": null,
+            "last_charge_status": null,
+            "lifetime_support_cents": 0,
+            "next_charge_date": "2025-04-01T07:00:00.000+00:00",
+            "note": "",
+            "patron_status": "active_patron",
+            "pledge_cadence": 1,
+            "pledge_relationship_start": "2025-03-02T13:37:00.000+00:00",
+            "will_pay_amount_cents": 1337
+        },
+        "id": "d29e61b6-f73b-4662-955e-dade715cef83",
+        "relationships": {
+            "address": {
+                "data": null
+            },
+            "campaign": {
+                "data": {
+                    "id": "11410294",
+                    "type": "campaign"
+                },
+                "links": {
+                    "related": "https://www.patreon.com/api/oauth2/v2/campaigns/11410294"
+                }
+            },
+            "currently_entitled_tiers": {
+                "data": [
+                    {
+                        "id": "196241737",
+                        "type": "tier"
+                    }
+                ]
+            },
+            "user": {
+                "data": {
+                    "id": "108692085",
+                    "type": "user"
+                },
+                "links": {
+                    "related": "https://www.patreon.com/api/oauth2/v2/user/108692085"
+                }
+            }
+        },
+        "type": "member"
+    },
+    "included": [
+        {
+            "attributes": {
+                "created_at": "2025-03-02T13:37:00.000+00:00",
+                "creation_name": "",
+                "discord_server_id": null,
+                "google_analytics_id": null,
+                "has_rss": false,
+                "has_sent_rss_notify": false,
+                "image_small_url": "https://c10.patreonusercontent.com/4/patreon-media/p/campaign/69073700/0267c2da7994410084f34411b9ce619c/eyJ3IjoxOTIwLCJ3ZSI6MX0%3D/1?token-time=1743724800&token-hash=gaXo-j34utqldsEeggT1K66nQXiJvMgttWq1PfZt3kE%3D",
+                "image_url": "https://c10.patreonusercontent.com/4/patreon-media/p/campaign/69073700/0267c2da7994410084f34411b9ce619c/eyJ3IjoxOTIwLCJ3ZSI6MX0%3D/1?token-time=1743724800&token-hash=gaXo-j34utqldsEeggT1K66nQXiJvMgttWq1PfZt3kE%3D",
+                "is_charged_immediately": false,
+                "is_monthly": true,
+                "is_nsfw": false,
+                "main_video_embed": null,
+                "main_video_url": null,
+                "one_liner": "",
+                "patron_count": 0,
+                "pay_per_name": "month",
+                "pledge_url": "/checkout/thebriefcase",
+                "published_at": "2025-03-02T13:37:00.000+00:00",
+                "rss_artwork_url": null,
+                "rss_feed_title": null,
+                "summary": null,
+                "thanks_embed": "",
+                "thanks_msg": "",
+                "thanks_video_url": "",
+                "url": "https://www.patreon.com/thebriefcase",
+                "vanity": "thebriefcase"
+            },
+            "id": "11410294",
+            "type": "campaign"
+        },
+        {
+            "attributes": {
+                "about": "About!",
+                "created": "2025-03-02T13:37:00.000+00:00",
+                "first_name": "Jules",
+                "full_name": "Jules Winnfield",
+                "hide_pledges": false,
+                "image_url": "https://c8.patreon.com/3/200/108692085",
+                "is_creator": false,
+                "last_name": "Winnfield",
+                "like_count": 0,
+                "social_connections": {
+                    "discord": null,
+                    "facebook": null,
+                    "google": null,
+                    "instagram": null,
+                    "reddit": null,
+                    "spotify": null,
+                    "spotify_open_access": null,
+                    "tiktok": null,
+                    "twitch": null,
+                    "twitter": null,
+                    "twitter2": null,
+                    "vimeo": null,
+                    "youtube": null
+                },
+                "thumb_url": "https://c8.patreon.com/3/200/108692085",
+                "url": "https://www.patreon.com/saywhat",
+                "vanity": "saywhat"
+            },
+            "id": "108692085",
+            "type": "user"
+        },
+        {
+            "attributes": {
+                "amount_cents": 1337,
+                "created_at": "2025-03-02T13:37:00.000+00:00",
+                "description": "Tier for Top Patrons",
+                "discord_role_ids": null,
+                "edited_at": "2025-03-02T13:37:00.000+00:00",
+                "image_url": null,
+                "patron_count": 0,
+                "post_count": 0,
+                "published": true,
+                "published_at": "2025-03-02T13:37:00.000+00:00",
+                "remaining": null,
+                "requires_shipping": false,
+                "title": "Elite Tier",
+                "unpublished_at": null,
+                "url": "/checkout/thebriefcase?rid=196241737",
+                "user_limit": null
+            },
+            "id": "196241737",
+            "type": "tier"
+        }
+    ],
+    "links": {
+        "self": "https://www.patreon.com/api/oauth2/v2/members/d29e61b6-f73b-4662-955e-dade715cef83"
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/Fixtures/Payloads/members-delete.json
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/Fixtures/Payloads/members-delete.json
@@ -1,0 +1,147 @@
+{
+    "data": {
+        "attributes": {
+            "campaign_lifetime_support_cents": 1337,
+            "currently_entitled_amount_cents": 1337,
+            "email": "jw@example.com",
+            "full_name": "Jules Winnfield",
+            "is_follower": false,
+            "is_free_trial": false,
+            "is_gifted": false,
+            "last_charge_date": null,
+            "last_charge_status": null,
+            "lifetime_support_cents": 1337,
+            "next_charge_date": "2025-04-01T07:00:00.000+00:00",
+            "note": "",
+            "patron_status": "active_patron",
+            "pledge_cadence": 1,
+            "pledge_relationship_start": "2025-03-02T13:37:00.000+00:00",
+            "will_pay_amount_cents": 1337
+        },
+        "id": "d29e61b6-f73b-4662-955e-dade715cef83",
+        "relationships": {
+            "address": {
+                "data": null
+            },
+            "campaign": {
+                "data": {
+                    "id": "11410294",
+                    "type": "campaign"
+                },
+                "links": {
+                    "related": "https://www.patreon.com/api/oauth2/v2/campaigns/11410294"
+                }
+            },
+            "currently_entitled_tiers": {
+                "data": [
+                    {
+                        "id": "196241737",
+                        "type": "tier"
+                    }
+                ]
+            },
+            "user": {
+                "data": {
+                    "id": "108692085",
+                    "type": "user"
+                },
+                "links": {
+                    "related": "https://www.patreon.com/api/oauth2/v2/user/108692085"
+                }
+            }
+        },
+        "type": "member"
+    },
+    "included": [
+        {
+            "attributes": {
+                "created_at": "2025-03-02T13:37:00.000+00:00",
+                "creation_name": "",
+                "discord_server_id": null,
+                "google_analytics_id": null,
+                "has_rss": false,
+                "has_sent_rss_notify": false,
+                "image_small_url": "https://c10.patreonusercontent.com/4/patreon-media/p/campaign/69073700/0267c2da7994410084f34411b9ce619c/eyJ3IjoxOTIwLCJ3ZSI6MX0%3D/1?token-time=1743724800&token-hash=gaXo-j34utqldsEeggT1K66nQXiJvMgttWq1PfZt3kE%3D",
+                "image_url": "https://c10.patreonusercontent.com/4/patreon-media/p/campaign/69073700/0267c2da7994410084f34411b9ce619c/eyJ3IjoxOTIwLCJ3ZSI6MX0%3D/1?token-time=1743724800&token-hash=gaXo-j34utqldsEeggT1K66nQXiJvMgttWq1PfZt3kE%3D",
+                "is_charged_immediately": false,
+                "is_monthly": true,
+                "is_nsfw": false,
+                "main_video_embed": null,
+                "main_video_url": null,
+                "one_liner": "",
+                "patron_count": 0,
+                "pay_per_name": "month",
+                "pledge_url": "/checkout/thebriefcase",
+                "published_at": "2025-03-02T13:37:00.000+00:00",
+                "rss_artwork_url": null,
+                "rss_feed_title": null,
+                "summary": null,
+                "thanks_embed": "",
+                "thanks_msg": "",
+                "thanks_video_url": "",
+                "url": "https://www.patreon.com/thebriefcase",
+                "vanity": "thebriefcase"
+            },
+            "id": "11410294",
+            "type": "campaign"
+        },
+        {
+            "attributes": {
+                "about": "About!",
+                "created": "2025-03-02T13:37:00.000+00:00",
+                "first_name": "Jules",
+                "full_name": "Jules Winnfield",
+                "hide_pledges": false,
+                "image_url": "https://c8.patreon.com/3/200/108692085",
+                "is_creator": false,
+                "last_name": "Winnfield",
+                "like_count": 0,
+                "social_connections": {
+                    "discord": null,
+                    "facebook": null,
+                    "google": null,
+                    "instagram": null,
+                    "reddit": null,
+                    "spotify": null,
+                    "spotify_open_access": null,
+                    "tiktok": null,
+                    "twitch": null,
+                    "twitter": null,
+                    "twitter2": null,
+                    "vimeo": null,
+                    "youtube": null
+                },
+                "thumb_url": "https://c8.patreon.com/3/200/108692085",
+                "url": "https://www.patreon.com/saywhat",
+                "vanity": "saywhat"
+            },
+            "id": "108692085",
+            "type": "user"
+        },
+        {
+            "attributes": {
+                "amount_cents": 1337,
+                "created_at": "2025-03-02T13:37:00.000+00:00",
+                "description": "Tier for Top Patrons",
+                "discord_role_ids": null,
+                "edited_at": "2025-03-02T13:37:00.000+00:00",
+                "image_url": null,
+                "patron_count": 0,
+                "post_count": 0,
+                "published": true,
+                "published_at": "2025-03-02T13:37:00.000+00:00",
+                "remaining": null,
+                "requires_shipping": false,
+                "title": "Elite Tier",
+                "unpublished_at": null,
+                "url": "/checkout/thebriefcase?rid=196241737",
+                "user_limit": null
+            },
+            "id": "196241737",
+            "type": "tier"
+        }
+    ],
+    "links": {
+        "self": "https://www.patreon.com/api/oauth2/v2/members/d29e61b6-f73b-4662-955e-dade715cef83"
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/Fixtures/Payloads/members-update.json
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/Fixtures/Payloads/members-update.json
@@ -1,0 +1,147 @@
+{
+    "data": {
+        "attributes": {
+            "campaign_lifetime_support_cents": 1337,
+            "currently_entitled_amount_cents": 1337,
+            "email": "jw-new@example.com",
+            "full_name": "Jules Winnfield",
+            "is_follower": false,
+            "is_free_trial": false,
+            "is_gifted": false,
+            "last_charge_date": null,
+            "last_charge_status": null,
+            "lifetime_support_cents": 1337,
+            "next_charge_date": "2025-04-01T07:00:00.000+00:00",
+            "note": "",
+            "patron_status": "active_patron",
+            "pledge_cadence": 1,
+            "pledge_relationship_start": "2025-03-02T13:37:00.000+00:00",
+            "will_pay_amount_cents": 1337
+        },
+        "id": "d29e61b6-f73b-4662-955e-dade715cef83",
+        "relationships": {
+            "address": {
+                "data": null
+            },
+            "campaign": {
+                "data": {
+                    "id": "11410294",
+                    "type": "campaign"
+                },
+                "links": {
+                    "related": "https://www.patreon.com/api/oauth2/v2/campaigns/11410294"
+                }
+            },
+            "currently_entitled_tiers": {
+                "data": [
+                    {
+                        "id": "196241737",
+                        "type": "tier"
+                    }
+                ]
+            },
+            "user": {
+                "data": {
+                    "id": "108692085",
+                    "type": "user"
+                },
+                "links": {
+                    "related": "https://www.patreon.com/api/oauth2/v2/user/108692085"
+                }
+            }
+        },
+        "type": "member"
+    },
+    "included": [
+        {
+            "attributes": {
+                "created_at": "2025-03-02T13:37:00.000+00:00",
+                "creation_name": "",
+                "discord_server_id": null,
+                "google_analytics_id": null,
+                "has_rss": false,
+                "has_sent_rss_notify": false,
+                "image_small_url": "https://c10.patreonusercontent.com/4/patreon-media/p/campaign/69073700/0267c2da7994410084f34411b9ce619c/eyJ3IjoxOTIwLCJ3ZSI6MX0%3D/1?token-time=1743724800&token-hash=gaXo-j34utqldsEeggT1K66nQXiJvMgttWq1PfZt3kE%3D",
+                "image_url": "https://c10.patreonusercontent.com/4/patreon-media/p/campaign/69073700/0267c2da7994410084f34411b9ce619c/eyJ3IjoxOTIwLCJ3ZSI6MX0%3D/1?token-time=1743724800&token-hash=gaXo-j34utqldsEeggT1K66nQXiJvMgttWq1PfZt3kE%3D",
+                "is_charged_immediately": false,
+                "is_monthly": true,
+                "is_nsfw": false,
+                "main_video_embed": null,
+                "main_video_url": null,
+                "one_liner": "",
+                "patron_count": 0,
+                "pay_per_name": "month",
+                "pledge_url": "/checkout/thebriefcase",
+                "published_at": "2025-03-02T13:37:00.000+00:00",
+                "rss_artwork_url": null,
+                "rss_feed_title": null,
+                "summary": null,
+                "thanks_embed": "",
+                "thanks_msg": "",
+                "thanks_video_url": "",
+                "url": "https://www.patreon.com/thebriefcase",
+                "vanity": "thebriefcase"
+            },
+            "id": "11410294",
+            "type": "campaign"
+        },
+        {
+            "attributes": {
+                "about": "About!",
+                "created": "2025-03-02T13:37:00.000+00:00",
+                "first_name": "Jules",
+                "full_name": "Jules Winnfield",
+                "hide_pledges": false,
+                "image_url": "https://c8.patreon.com/3/200/108692085",
+                "is_creator": false,
+                "last_name": "Winnfield",
+                "like_count": 0,
+                "social_connections": {
+                    "discord": null,
+                    "facebook": null,
+                    "google": null,
+                    "instagram": null,
+                    "reddit": null,
+                    "spotify": null,
+                    "spotify_open_access": null,
+                    "tiktok": null,
+                    "twitch": null,
+                    "twitter": null,
+                    "twitter2": null,
+                    "vimeo": null,
+                    "youtube": null
+                },
+                "thumb_url": "https://c8.patreon.com/3/200/108692085",
+                "url": "https://www.patreon.com/saywhat",
+                "vanity": "saywhat"
+            },
+            "id": "108692085",
+            "type": "user"
+        },
+        {
+            "attributes": {
+                "amount_cents": 1337,
+                "created_at": "2025-03-02T13:37:00.000+00:00",
+                "description": "Tier for Top Patrons",
+                "discord_role_ids": null,
+                "edited_at": "2025-03-02T13:37:00.000+00:00",
+                "image_url": null,
+                "patron_count": 0,
+                "post_count": 0,
+                "published": true,
+                "published_at": "2025-03-02T13:37:00.000+00:00",
+                "remaining": null,
+                "requires_shipping": false,
+                "title": "Elite Tier",
+                "unpublished_at": null,
+                "url": "/checkout/thebriefcase?rid=196241737",
+                "user_limit": null
+            },
+            "id": "196241737",
+            "type": "tier"
+        }
+    ],
+    "links": {
+        "self": "https://www.patreon.com/api/oauth2/v2/members/d29e61b6-f73b-4662-955e-dade715cef83"
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonApiClientTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonApiClientTests.cs
@@ -1,3 +1,12 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
 using NUnit.Framework;
 using W3ChampionsStatisticService.Rewards.Providers.Patreon;
 
@@ -26,5 +35,226 @@ public class PatreonApiClientTests
             LastChargeStatus = lastChargeStatus
         };
         Assert.AreEqual(expected, member.IsActivePatron);
+    }
+}
+
+[TestFixture]
+public class PatreonApiClientCampaignMemberTests
+{
+    private Mock<HttpMessageHandler> _handlerMock;
+    private HttpClient _httpClient;
+    private PatreonApiClient _client;
+
+    [SetUp]
+    public void SetUp()
+    {
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_CAMPAIGN_ID", "4973374");
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_ACCESS_TOKEN", "test-token");
+        _handlerMock = new Mock<HttpMessageHandler>();
+        _httpClient = new HttpClient(_handlerMock.Object);
+        _client = new PatreonApiClient(_httpClient);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_CAMPAIGN_ID", null);
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_ACCESS_TOKEN", null);
+        _httpClient?.Dispose();
+    }
+
+    private void SetupResponseSequence(params string[] jsonBodies)
+    {
+        var sequence = _handlerMock.Protected().SetupSequence<Task<HttpResponseMessage>>(
+            "SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        foreach (var body in jsonBodies)
+            sequence = sequence.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            { Content = new StringContent(body) });
+    }
+
+    [Test]
+    public async Task GetCampaignMemberByPatreonUserId_UserExistsInFirstPage_ReturnsMember()
+    {
+        var page1 = JsonSerializer.Serialize(new
+        {
+            data = new[]
+            {
+                new {
+                    type = "member",
+                    id = "member-1",
+                    attributes = new { patron_status = "active_patron", last_charge_status = "Paid" },
+                    relationships = new {
+                        user = new { data = new { id = "152572628" } },
+                        currently_entitled_tiers = new { data = new[] { new { id = "6482070", type = "tier" } } }
+                    }
+                }
+            },
+            included = new[]
+            {
+                new { type = "tier", id = "6482070", attributes = new { title = "Gold", amount_cents = 1000 } }
+            },
+            links = new { next = (string)null }
+        });
+        SetupResponseSequence(page1);
+
+        var member = await _client.GetCampaignMemberByPatreonUserId("152572628");
+
+        Assert.IsNotNull(member);
+        Assert.AreEqual("152572628", member.PatreonUserId);
+        Assert.AreEqual(1, member.EntitledTiers.Count);
+        Assert.AreEqual("6482070", member.EntitledTiers[0].TierId);
+        Assert.AreEqual(1000, member.EntitledTiers[0].AmountCents);
+    }
+
+    [Test]
+    public async Task GetCampaignMemberByPatreonUserId_UserExistsOnPageThree_TraversesPagination()
+    {
+        var page1 = MakePage(new[] { ("user-a", "tier-a") }, nextLink: "https://www.patreon.com/api/oauth2/v2/campaigns/4973374/members?page[cursor]=page2");
+        var page2 = MakePage(new[] { ("user-b", "tier-b") }, nextLink: "https://www.patreon.com/api/oauth2/v2/campaigns/4973374/members?page[cursor]=page3");
+        var page3 = MakePage(new[] { ("152572628", "6482070") }, nextLink: null);
+        SetupResponseSequence(page1, page2, page3);
+
+        var member = await _client.GetCampaignMemberByPatreonUserId("152572628");
+
+        Assert.IsNotNull(member);
+        Assert.AreEqual("152572628", member.PatreonUserId);
+    }
+
+    [Test]
+    public async Task GetCampaignMemberByPatreonUserId_UserNotInCampaign_ReturnsNull()
+    {
+        var page1 = MakePage(new[] { ("user-a", "tier-a"), ("user-b", "tier-b") }, nextLink: null);
+        SetupResponseSequence(page1);
+
+        var member = await _client.GetCampaignMemberByPatreonUserId("152572628");
+
+        Assert.IsNull(member);
+    }
+
+    [Test]
+    public async Task GetCampaignMemberByPatreonUserId_EmptyCampaign_ReturnsNull()
+    {
+        var emptyPage = JsonSerializer.Serialize(new { data = new object[0], included = new object[0], links = new { next = (string)null } });
+        SetupResponseSequence(emptyPage);
+
+        var member = await _client.GetCampaignMemberByPatreonUserId("152572628");
+
+        Assert.IsNull(member);
+    }
+
+    [Test]
+    public async Task GetCampaignMemberByPatreonUserId_PaginationTerminatesOnNullNextLink()
+    {
+        var page1 = MakePage(new[] { ("user-a", "tier-a") }, nextLink: null);
+        SetupResponseSequence(page1);
+
+        var member = await _client.GetCampaignMemberByPatreonUserId("152572628");
+
+        Assert.IsNull(member);
+        // Verify only one HTTP call made
+        _handlerMock.Protected().Verify("SendAsync", Times.Once(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Test]
+    public void GetCampaignMemberByPatreonUserId_HttpError_Throws()
+    {
+        _handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        Assert.ThrowsAsync<HttpRequestException>(async () =>
+            await _client.GetCampaignMemberByPatreonUserId("152572628"));
+    }
+
+    [Test]
+    public void GetCampaignMemberByPatreonUserId_MalformedJson_Throws()
+    {
+        SetupResponseSequence("{ this is not valid json");
+        Assert.ThrowsAsync<JsonException>(async () =>
+            await _client.GetCampaignMemberByPatreonUserId("152572628"));
+    }
+
+    [Test]
+    public async Task GetCampaignMemberByPatreonUserId_PopulatesEntitledTiersWithAmountCents()
+    {
+        var page1 = JsonSerializer.Serialize(new
+        {
+            data = new[]
+            {
+                new {
+                    type = "member", id = "member-1",
+                    attributes = new { patron_status = "active_patron", last_charge_status = "Paid" },
+                    relationships = new {
+                        user = new { data = new { id = "152572628" } },
+                        currently_entitled_tiers = new { data = new[] {
+                            new { id = "6482051", type = "tier" },
+                            new { id = "6482070", type = "tier" }
+                        } }
+                    }
+                }
+            },
+            included = new[]
+            {
+                new { type = "tier", id = "6482051", attributes = new { title = "Bronze", amount_cents = 100 } },
+                new { type = "tier", id = "6482070", attributes = new { title = "Gold", amount_cents = 1000 } }
+            },
+            links = new { next = (string)null }
+        });
+        SetupResponseSequence(page1);
+
+        var member = await _client.GetCampaignMemberByPatreonUserId("152572628");
+
+        Assert.AreEqual(2, member.EntitledTiers.Count);
+        var gold = member.EntitledTiers.Single(t => t.TierId == "6482070");
+        Assert.AreEqual(1000, gold.AmountCents);
+        Assert.AreEqual("Gold", gold.Title);
+    }
+
+    [Test]
+    public async Task GetCampaignMemberByPatreonUserId_FreeMembershipPatronStatusNull_ReturnsMember()
+    {
+        var page1 = JsonSerializer.Serialize(new
+        {
+            data = new[]
+            {
+                new {
+                    type = "member", id = "member-1",
+                    attributes = new { patron_status = (string)null, last_charge_status = (string)null },
+                    relationships = new {
+                        user = new { data = new { id = "152572628" } },
+                        currently_entitled_tiers = new { data = new[] { new { id = "free-tier", type = "tier" } } }
+                    }
+                }
+            },
+            included = new[] { new { type = "tier", id = "free-tier", attributes = new { title = "Free", amount_cents = 0 } } },
+            links = new { next = (string)null }
+        });
+        SetupResponseSequence(page1);
+
+        var member = await _client.GetCampaignMemberByPatreonUserId("152572628");
+
+        Assert.IsNotNull(member);
+        Assert.IsNull(member.PatronStatus);
+        Assert.IsFalse(member.IsActivePatron, "Free members are not active patrons.");
+    }
+
+    private string MakePage((string userId, string tierId)[] members, string nextLink)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            data = members.Select((m, i) => new
+            {
+                type = "member",
+                id = $"member-{i}",
+                attributes = new { patron_status = "active_patron", last_charge_status = "Paid" },
+                relationships = new
+                {
+                    user = new { data = new { id = m.userId } },
+                    currently_entitled_tiers = new { data = new[] { new { id = m.tierId, type = "tier" } } }
+                }
+            }).ToArray(),
+            included = members.Select(m => new { type = "tier", id = m.tierId, attributes = new { title = "X", amount_cents = 100 } }).ToArray(),
+            links = new { next = nextLink }
+        });
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonApiClientTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonApiClientTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -9,6 +10,7 @@ using Moq;
 using Moq.Protected;
 using NUnit.Framework;
 using W3ChampionsStatisticService.Rewards.Providers.Patreon;
+using WC3ChampionsStatisticService.UnitTests.Rewards.Fixtures;
 
 namespace WC3ChampionsStatisticService.UnitTests.Rewards;
 
@@ -256,5 +258,365 @@ public class PatreonApiClientCampaignMemberTests
             included = members.Select(m => new { type = "tier", id = m.tierId, attributes = new { title = "X", amount_cents = 100 } }).ToArray(),
             links = new { next = nextLink }
         });
+    }
+}
+
+/// <summary>
+/// Tests for PatreonApiClient.ParseMemberData (made internal for testability).
+/// Tests build PatreonApiData objects programmatically using JsonSerializer to produce
+/// the JsonElement values that ParseMemberData reads via dictionary deserialization.
+/// </summary>
+[TestFixture]
+public class ParseMemberDataTests
+{
+    private HttpClient _httpClient;
+    private PatreonApiClient _client;
+
+    [SetUp]
+    public void SetUp()
+    {
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_CAMPAIGN_ID", "4973374");
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_ACCESS_TOKEN", "test-token");
+        _httpClient = new HttpClient(new Mock<HttpMessageHandler>().Object);
+        _client = new PatreonApiClient(_httpClient);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_CAMPAIGN_ID", null);
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_ACCESS_TOKEN", null);
+        _httpClient?.Dispose();
+    }
+
+    // Deserializes a JSON string to PatreonApiData using the same options as production code.
+    private static PatreonApiData DeserializeMemberData(string json)
+    {
+        return JsonSerializer.Deserialize<PatreonApiData>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+    }
+
+    private static List<PatreonApiData> DeserializeIncluded(string json)
+    {
+        return JsonSerializer.Deserialize<List<PatreonApiData>>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 1: Real members-create payload — extract all key fields
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public void ParseMemberData_RealMembersCreatePayload_ExtractsAllFields()
+    {
+        // The real members-create.json is a webhook envelope: the member is in data{}
+        // and tier details are in included[]. We parse data{} as the member element.
+        var rawJson = PatreonPayloadLoader.MembersCreateJson();
+        var root = JsonSerializer.Deserialize<JsonElement>(rawJson);
+
+        var memberJson = root.GetProperty("data").GetRawText();
+        var includedJson = root.GetProperty("included").GetRawText();
+
+        var memberData = DeserializeMemberData(memberJson);
+        var included = DeserializeIncluded(includedJson);
+
+        var member = _client.ParseMemberData(memberData, included);
+
+        Assert.IsNotNull(member);
+        Assert.AreEqual("d29e61b6-f73b-4662-955e-dade715cef83", member.Id);
+        Assert.AreEqual("active_patron", member.PatronStatus);
+        Assert.IsNull(member.LastChargeStatus, "Fresh signup has null last_charge_status");
+        Assert.AreEqual("108692085", member.PatreonUserId);
+        Assert.IsNotNull(member.EntitledTiers);
+        Assert.AreEqual(1, member.EntitledTiers.Count);
+        Assert.AreEqual("196241737", member.EntitledTiers[0].TierId);
+        Assert.AreEqual(1337, member.EntitledTiers[0].AmountCents);
+        Assert.AreEqual("Elite Tier", member.EntitledTiers[0].Title);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 2: amount_cents populated from matching included tier resource
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public void ParseMemberData_AmountCentsPopulatedFromIncludedTier_AssociatedWithTierId()
+    {
+        var memberJson = JsonSerializer.Serialize(new
+        {
+            id = "member-1",
+            type = "member",
+            attributes = new { patron_status = "active_patron", last_charge_status = "Paid" },
+            relationships = new
+            {
+                user = new { data = new { id = "user-99", type = "user" } },
+                currently_entitled_tiers = new { data = new[] { new { id = "tier-42", type = "tier" } } }
+            }
+        });
+
+        var includedJson = JsonSerializer.Serialize(new[]
+        {
+            new { id = "tier-42", type = "tier", attributes = new { title = "Silver", amount_cents = 500 } }
+        });
+
+        var member = _client.ParseMemberData(DeserializeMemberData(memberJson), DeserializeIncluded(includedJson));
+
+        Assert.IsNotNull(member);
+        Assert.AreEqual(1, member.EntitledTiers.Count);
+        Assert.AreEqual("tier-42", member.EntitledTiers[0].TierId);
+        Assert.AreEqual(500, member.EntitledTiers[0].AmountCents);
+        Assert.AreEqual("Silver", member.EntitledTiers[0].Title);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 3: Tier ID in currently_entitled_tiers but not in included[] → null amount/title
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public void ParseMemberData_TierResourceMissingFromIncluded_ProducesEntitledTierWithNullAmount()
+    {
+        var memberJson = JsonSerializer.Serialize(new
+        {
+            id = "member-1",
+            type = "member",
+            attributes = new { patron_status = "active_patron", last_charge_status = "Paid" },
+            relationships = new
+            {
+                user = new { data = new { id = "user-1", type = "user" } },
+                currently_entitled_tiers = new { data = new[] { new { id = "tier-missing", type = "tier" } } }
+            }
+        });
+
+        // included[] has a different tier, not the one referenced above
+        var includedJson = JsonSerializer.Serialize(new[]
+        {
+            new { id = "tier-other", type = "tier", attributes = new { title = "Other", amount_cents = 200 } }
+        });
+
+        var member = _client.ParseMemberData(DeserializeMemberData(memberJson), DeserializeIncluded(includedJson));
+
+        Assert.IsNotNull(member);
+        Assert.AreEqual(1, member.EntitledTiers.Count);
+        Assert.AreEqual("tier-missing", member.EntitledTiers[0].TierId);
+        Assert.IsNull(member.EntitledTiers[0].AmountCents, "No matching included[] resource → AmountCents must be null");
+        Assert.IsNull(member.EntitledTiers[0].Title, "No matching included[] resource → Title must be null");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 4: null patron_status preserved (free-tier member)
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public void ParseMemberData_NullPatronStatus_PreservedAsNull()
+    {
+        var memberJson = JsonSerializer.Serialize(new
+        {
+            id = "member-free",
+            type = "member",
+            attributes = new { patron_status = (string)null, last_charge_status = (string)null },
+            relationships = new
+            {
+                user = new { data = new { id = "user-free", type = "user" } },
+                currently_entitled_tiers = new { data = Array.Empty<object>() }
+            }
+        });
+
+        var member = _client.ParseMemberData(DeserializeMemberData(memberJson), new List<PatreonApiData>());
+
+        Assert.IsNotNull(member);
+        Assert.IsNull(member.PatronStatus, "Free-tier member patron_status must be null");
+        Assert.IsFalse(member.IsActivePatron, "Free-tier member is not an active patron");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 5: null last_charge_status preserved (fresh signup)
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public void ParseMemberData_NullLastChargeStatus_PreservedAsNull()
+    {
+        var rawJson = PatreonPayloadLoader.MembersCreateJson();
+        var root = JsonSerializer.Deserialize<JsonElement>(rawJson);
+
+        var memberData = DeserializeMemberData(root.GetProperty("data").GetRawText());
+        var included = DeserializeIncluded(root.GetProperty("included").GetRawText());
+
+        var member = _client.ParseMemberData(memberData, included);
+
+        Assert.IsNotNull(member);
+        Assert.AreEqual("active_patron", member.PatronStatus);
+        Assert.IsNull(member.LastChargeStatus, "Fresh signup: last_charge_status is null before first charge");
+        Assert.IsFalse(member.IsActivePatron, "active_patron + null last_charge_status → not IsActivePatron");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 6: Multiple tiers all populated with correct amounts from included[]
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public void ParseMemberData_MultipleTiers_AllPopulatedWithCorrectAmounts()
+    {
+        var memberJson = JsonSerializer.Serialize(new
+        {
+            id = "member-multi",
+            type = "member",
+            attributes = new { patron_status = "active_patron", last_charge_status = "Paid" },
+            relationships = new
+            {
+                user = new { data = new { id = "user-1", type = "user" } },
+                currently_entitled_tiers = new
+                {
+                    data = new[]
+                    {
+                        new { id = "tier-bronze", type = "tier" },
+                        new { id = "tier-silver", type = "tier" },
+                        new { id = "tier-gold",   type = "tier" }
+                    }
+                }
+            }
+        });
+
+        var includedJson = JsonSerializer.Serialize(new[]
+        {
+            new { id = "tier-bronze", type = "tier", attributes = new { title = "Bronze", amount_cents = 100 } },
+            new { id = "tier-silver", type = "tier", attributes = new { title = "Silver", amount_cents = 500 } },
+            new { id = "tier-gold",   type = "tier", attributes = new { title = "Gold",   amount_cents = 1000 } }
+        });
+
+        var member = _client.ParseMemberData(DeserializeMemberData(memberJson), DeserializeIncluded(includedJson));
+
+        Assert.IsNotNull(member);
+        Assert.AreEqual(3, member.EntitledTiers.Count);
+
+        var bronze = member.EntitledTiers.Single(t => t.TierId == "tier-bronze");
+        var silver = member.EntitledTiers.Single(t => t.TierId == "tier-silver");
+        var gold = member.EntitledTiers.Single(t => t.TierId == "tier-gold");
+
+        Assert.AreEqual(100, bronze.AmountCents);
+        Assert.AreEqual("Bronze", bronze.Title);
+        Assert.AreEqual(500, silver.AmountCents);
+        Assert.AreEqual("Silver", silver.Title);
+        Assert.AreEqual(1000, gold.AmountCents);
+        Assert.AreEqual("Gold", gold.Title);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 7: Empty currently_entitled_tiers.data → empty EntitledTiers list
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public void ParseMemberData_EmptyEntitledTiers_ResultsInEmptyList()
+    {
+        var memberJson = JsonSerializer.Serialize(new
+        {
+            id = "member-empty",
+            type = "member",
+            attributes = new { patron_status = "former_patron", last_charge_status = "Declined" },
+            relationships = new
+            {
+                user = new { data = new { id = "user-1", type = "user" } },
+                currently_entitled_tiers = new { data = Array.Empty<object>() }
+            }
+        });
+
+        var member = _client.ParseMemberData(DeserializeMemberData(memberJson), new List<PatreonApiData>());
+
+        Assert.IsNotNull(member);
+        Assert.IsNotNull(member.EntitledTiers);
+        Assert.AreEqual(0, member.EntitledTiers.Count, "Empty currently_entitled_tiers.data → zero entitled tiers");
+    }
+}
+
+/// <summary>
+/// Cross-campaign defense tests for IsMemberForCampaign (made internal for testability).
+/// These verify that identity-endpoint payloads with multiple campaign memberships are
+/// filtered correctly so only the W3Champions campaign member is selected.
+/// </summary>
+[TestFixture]
+public class CrossCampaignDefenseTests
+{
+    private const string OurCampaignId = "4973374";
+
+    private HttpClient _httpClient;
+    private PatreonApiClient _client;
+
+    [SetUp]
+    public void SetUp()
+    {
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_CAMPAIGN_ID", OurCampaignId);
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_ACCESS_TOKEN", "test-token");
+        _httpClient = new HttpClient(new Mock<HttpMessageHandler>().Object);
+        _client = new PatreonApiClient(_httpClient);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_CAMPAIGN_ID", null);
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_ACCESS_TOKEN", null);
+        _httpClient?.Dispose();
+    }
+
+    private static PatreonApiData MakeMemberResource(string memberId, string campaignId)
+    {
+        var json = JsonSerializer.Serialize(new
+        {
+            id = memberId,
+            type = "member",
+            attributes = new { patron_status = "active_patron", last_charge_status = "Paid" },
+            relationships = new
+            {
+                campaign = new { data = new { id = campaignId, type = "campaign" } },
+                user = new { data = new { id = "user-1", type = "user" } },
+                currently_entitled_tiers = new { data = Array.Empty<object>() }
+            }
+        });
+        return JsonSerializer.Deserialize<PatreonApiData>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+    }
+
+    private static PatreonApiData MakeMemberResourceNoCampaign(string memberId)
+    {
+        var json = JsonSerializer.Serialize(new
+        {
+            id = memberId,
+            type = "member",
+            attributes = new { patron_status = "active_patron", last_charge_status = "Paid" },
+            relationships = new
+            {
+                user = new { data = new { id = "user-1", type = "user" } },
+                currently_entitled_tiers = new { data = Array.Empty<object>() }
+                // no "campaign" key
+            }
+        });
+        return JsonSerializer.Deserialize<PatreonApiData>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 8: identity endpoint with two member resources → pick our campaign's member
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public void IsMemberForCampaign_MultipleMembers_ReturnsTrueOnlyForOurCampaign()
+    {
+        var ourMember = MakeMemberResource("member-ours", OurCampaignId);
+        var foreignMember = MakeMemberResource("member-foreign", "99999999");
+
+        Assert.IsTrue(_client.IsMemberForCampaign(ourMember),
+            "Should match the member whose campaign.data.id == our campaign");
+        Assert.IsFalse(_client.IsMemberForCampaign(foreignMember),
+            "Should not match a member from a different campaign");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 9: identity endpoint where the only member is from a foreign campaign → no match
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public void IsMemberForCampaign_ForeignCampaignMemberOnly_ReturnsFalse()
+    {
+        var foreignMember = MakeMemberResource("member-foreign", "99999999");
+
+        Assert.IsFalse(_client.IsMemberForCampaign(foreignMember),
+            "A member for a foreign campaign must not match our campaign filter");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 10: member resource has no relationships.campaign key → no match
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public void IsMemberForCampaign_MissingCampaignRelationship_ReturnsFalse()
+    {
+        var memberWithNoCampaign = MakeMemberResourceNoCampaign("member-no-campaign");
+
+        Assert.IsFalse(_client.IsMemberForCampaign(memberWithNoCampaign),
+            "Member with no campaign relationship must not match our campaign filter");
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonApiClientTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonApiClientTests.cs
@@ -20,6 +20,9 @@ public class PatreonApiClientTests
     [TestCase("active_patron", "Paid", true)]
     [TestCase("active_patron", "Pending", true)] // NEW
     [TestCase("active_patron", "Free Trial", true)] // NEW
+    [TestCase("ACTIVE_PATRON", "PAID", true)] // casing-drift guard
+    [TestCase("active_patron", "paid", true)] // casing-drift guard
+    [TestCase("active_patron", "free trial", true)] // casing-drift guard
     [TestCase("active_patron", null, false)] // free-tier members have null status
     [TestCase("active_patron", "Declined", false)]
     [TestCase("active_patron", "Refunded", false)]

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonApiClientTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonApiClientTests.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using W3ChampionsStatisticService.Rewards.Providers.Patreon;
+
+namespace WC3ChampionsStatisticService.UnitTests.Rewards;
+
+[TestFixture]
+public class PatreonApiClientTests
+{
+    [TestCase("active_patron", "Paid", true)]
+    [TestCase("active_patron", "Pending", true)] // NEW
+    [TestCase("active_patron", "Free Trial", true)] // NEW
+    [TestCase("active_patron", null, false)] // free-tier members have null status
+    [TestCase("active_patron", "Declined", false)]
+    [TestCase("active_patron", "Refunded", false)]
+    [TestCase("active_patron", "Fraud", false)]
+    [TestCase("active_patron", "Other", false)]
+    [TestCase("active_patron", "Deleted", false)]
+    [TestCase("former_patron", "Paid", false)]
+    [TestCase("declined_patron", "Declined", false)]
+    [TestCase(null, null, false)]
+    public void IsActivePatron_TruthTable(string patronStatus, string lastChargeStatus, bool expected)
+    {
+        var member = new PatreonMember
+        {
+            PatronStatus = patronStatus,
+            LastChargeStatus = lastChargeStatus
+        };
+        Assert.AreEqual(expected, member.IsActivePatron);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -12,6 +12,7 @@ using W3C.Domain.Rewards.Repositories;
 using W3C.Domain.Rewards.ValueObjects;
 using W3ChampionsStatisticService.Rewards.Providers.Patreon;
 using W3ChampionsStatisticService.Rewards.Services;
+using WC3ChampionsStatisticService.UnitTests.Rewards.Builders;
 
 namespace WC3ChampionsStatisticService.Tests.Rewards;
 
@@ -428,12 +429,18 @@ public class PatreonDriftSyncTests
 
     public static IEnumerable<TestCaseData> DualTierTestCases()
     {
-        // Scenario 1: Dual tier addition - Fresh patron gains both bronze and silver tiers simultaneously
+        // Scenario 1: Dual tier addition - Fresh patron gains both bronze and silver tiers simultaneously.
+        // bronze-tier (100¢) and silver-tier (500¢) are both OneTime/Recurring (not Tiered),
+        // so the TIERED filter passes all through — both associations are created.
         yield return new TestCaseData(
             "DualTierAddition",
             "DualTierUser#1234",
             new List<string>(), // Current internal tiers (none)
-            new List<string> { "bronze-tier", "silver-tier" }, // New Patreon tiers (both at once)
+            new List<EntitledTier>
+            {
+                new EntitledTier { TierId = "bronze-tier", AmountCents = 100 },
+                new EntitledTier { TierId = "silver-tier", AmountCents = 500 }
+            }, // New Patreon tiers with explicit amount_cents
             new List<ProductMappingUserAssociation>(), // No existing associations
             0, // Expected TiersUpdated count (missing member scenario uses MembersAdded instead)
             Times.Exactly(2), // Expected Create calls (bronze + silver created fresh)
@@ -445,7 +452,10 @@ public class PatreonDriftSyncTests
             "TierDowngrade",
             "DowngradeUser#1234",
             new List<string> { "bronze-tier", "silver-tier" }, // Current internal tiers
-            new List<string> { "bronze-tier" }, // New Patreon tiers
+            new List<EntitledTier>
+            {
+                new EntitledTier { TierId = "bronze-tier", AmountCents = 100 }
+            }, // New Patreon tiers with explicit amount_cents
             new List<ProductMappingUserAssociation>
             {
                 new ProductMappingUserAssociation
@@ -477,7 +487,11 @@ public class PatreonDriftSyncTests
             "TierUpgrade",
             "UpgradeUser#1234",
             new List<string> { "bronze-tier" }, // Current internal tiers
-            new List<string> { "bronze-tier", "silver-tier" }, // New Patreon tiers
+            new List<EntitledTier>
+            {
+                new EntitledTier { TierId = "bronze-tier", AmountCents = 100 },
+                new EntitledTier { TierId = "silver-tier", AmountCents = 500 }
+            }, // New Patreon tiers with explicit amount_cents
             new List<ProductMappingUserAssociation>
             {
                 new ProductMappingUserAssociation
@@ -501,7 +515,7 @@ public class PatreonDriftSyncTests
         string scenarioName,
         string battleTag,
         List<string> currentInternalTiers,
-        List<string> newPatreonTiers,
+        List<EntitledTier> newPatreonTiers,
         List<ProductMappingUserAssociation> existingAssociations,
         int expectedTiersUpdated,
         Times expectedCreateCalls,
@@ -579,6 +593,8 @@ public class PatreonDriftSyncTests
             ProviderId = "patreon"
         };
 
+        var newPatreonTierIds = newPatreonTiers.Select(t => t.TierId).ToList();
+
         if (!currentInternalTiers.Any() && newPatreonTiers.Any())
         {
             // Missing member scenario - user has Patreon entitlements but no internal associations
@@ -589,7 +605,7 @@ public class PatreonDriftSyncTests
                     PatreonMemberId = patreonMemberId,
                     PatreonUserId = patreonUserId,
                     PatronStatus = "active_patron",
-                    EntitledTiers = newPatreonTiers.Select(id => new EntitledTier { TierId = id }).ToList(),
+                    EntitledTiers = newPatreonTiers.ToList(), // preserve AmountCents for filter logic
                     Reason = $"{scenarioName}: Active patron found in Patreon but no active rewards in our system"
                 }
             };
@@ -603,8 +619,8 @@ public class PatreonDriftSyncTests
                 {
                     UserId = battleTag,
                     PatreonMemberId = patreonMemberId,
-                    PatreonTiers = newPatreonTiers,
-                    PatreonTiersFiltered = newPatreonTiers, // For test, assume no filtering needed
+                    PatreonTiers = newPatreonTierIds,
+                    PatreonTiersFiltered = newPatreonTierIds, // For test, assume no filtering needed
                     InternalTiers = currentInternalTiers,
                     InternalTiersFiltered = currentInternalTiers, // For test, assume no filtering needed
                     Reason = $"{scenarioName}: Tier entitlements don't match between Patreon and internal state"
@@ -721,9 +737,10 @@ public class PatreonDriftSyncTests
     }
 
     [Test]
-    public async Task SyncDrift_MultipleTieredRewards_ProcessesOnlyFirstTier()
+    public async Task SyncDrift_MultipleTieredRewards_ProcessesHighestAmountTier()
     {
-        // Arrange
+        // Arrange: Silver (6482057, 500¢) and Gold (6482070, 1000¢) both TIERED.
+        // The filter must pick Gold regardless of input order.
         var battleTag = "TieredUser#1234";
         var patreonUserId = "tiered-user-id";
         var patreonMemberId = "tiered-member-id";
@@ -735,54 +752,50 @@ public class PatreonDriftSyncTests
         _mockPatreonLinkRepository.Setup(x => x.GetByPatreonUserId(patreonUserId))
             .ReturnsAsync(accountLink);
 
-        // Setup product mappings - both are TIERED type
-        var tier1Mapping = new ProductMapping
+        // Silver tier (500¢) — TIERED
+        var silverMapping = new ProductMapping
         {
-            Id = "tier1-mapping-id",
-            ProductName = "Tier 1",
-            Type = ProductMappingType.Tiered,  // TIERED type
-            RewardIds = new List<string> { "reward-tier1" },
+            Id = "silver-mapping-id",
+            ProductName = "Silver Tier",
+            Type = ProductMappingType.Tiered,
+            RewardIds = new List<string> { "reward-silver" },
             ProductProviders = new List<ProductProviderPair>
             {
                 new ProductProviderPair { ProviderId = "patreon", ProductId = "6482057" }
             }
         };
 
-        var tier2Mapping = new ProductMapping
+        // Gold tier (1000¢) — TIERED, highest amount_cents
+        var goldMapping = new ProductMapping
         {
-            Id = "tier2-mapping-id",
-            ProductName = "Tier 2",
-            Type = ProductMappingType.Tiered,  // TIERED type
-            RewardIds = new List<string> { "reward-tier2" },
+            Id = "gold-mapping-id",
+            ProductName = "Gold Tier",
+            Type = ProductMappingType.Tiered,
+            RewardIds = new List<string> { "reward-gold" },
             ProductProviders = new List<ProductProviderPair>
             {
-                new ProductProviderPair { ProviderId = "patreon", ProductId = "6482051" }
+                new ProductProviderPair { ProviderId = "patreon", ProductId = "6482070" }
             }
         };
 
-        // Setup GetByProviderId to return both mappings
         _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
-            .ReturnsAsync(new List<ProductMapping> { tier1Mapping, tier2Mapping });
-
-        // Setup GetByProviderAndProductId for individual lookups
+            .ReturnsAsync(new List<ProductMapping> { silverMapping, goldMapping });
         _mockProductMappingRepository.Setup(x => x.GetByProviderAndProductId("patreon", "6482057"))
-            .ReturnsAsync(new List<ProductMapping> { tier1Mapping });
-        _mockProductMappingRepository.Setup(x => x.GetByProviderAndProductId("patreon", "6482051"))
-            .ReturnsAsync(new List<ProductMapping> { tier2Mapping });
+            .ReturnsAsync(new List<ProductMapping> { silverMapping });
+        _mockProductMappingRepository.Setup(x => x.GetByProviderAndProductId("patreon", "6482070"))
+            .ReturnsAsync(new List<ProductMapping> { goldMapping });
 
-        // Setup no existing associations
         _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(battleTag))
             .ReturnsAsync(new List<ProductMappingUserAssociation>());
         _mockAssociationRepository.Setup(x => x.GetByUserAndProductMapping(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(new List<ProductMappingUserAssociation>());
 
-        // Track created associations
         var createdAssociations = new List<ProductMappingUserAssociation>();
         _mockAssociationRepository.Setup(x => x.Create(It.IsAny<ProductMappingUserAssociation>()))
             .Callback<ProductMappingUserAssociation>(a => createdAssociations.Add(a))
             .ReturnsAsync((ProductMappingUserAssociation a) => a);
 
-        // Create drift result with multiple entitled tier IDs
+        // Entitled tiers: Silver listed first, Gold listed second — Gold must win
         var driftResult = new DriftDetectionResult
         {
             Timestamp = DateTime.UtcNow,
@@ -794,8 +807,12 @@ public class PatreonDriftSyncTests
                     PatreonMemberId = patreonMemberId,
                     PatreonUserId = patreonUserId,
                     PatronStatus = "active_patron",
-                    EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = "6482057" }, new EntitledTier { TierId = "6482051" } }, // Multiple TIERED rewards
-                    Reason = "Active patron with multiple tiers"
+                    EntitledTiers = new List<EntitledTier>
+                    {
+                        new EntitledTier { TierId = "6482057", AmountCents = 500 }, // Silver first in list
+                        new EntitledTier { TierId = "6482070", AmountCents = 1000 } // Gold second — highest amount
+                    },
+                    Reason = "Active patron with Silver and Gold tiers"
                 }
             }
         };
@@ -807,25 +824,27 @@ public class PatreonDriftSyncTests
         Assert.IsTrue(syncResult.Success, "Sync should succeed");
         Assert.AreEqual(1, syncResult.MembersAdded, "Should add 1 member");
 
-        // Verify only ONE association was created (for the first tier)
+        // Filter picks the single highest-amount TIERED tier
         Assert.AreEqual(1, createdAssociations.Count,
-            "Should create only 1 association for TIERED rewards even with multiple entitled tiers");
+            "Should create only 1 association for TIERED rewards");
 
-        // Verify it's for the first tier
-        Assert.AreEqual("6482057", createdAssociations[0].ProviderProductId,
-            "Should process only the first tier ID for TIERED rewards");
-        Assert.AreEqual("tier1-mapping-id", createdAssociations[0].ProductMappingId,
-            "Should use the first tier's mapping");
+        // Gold (6482070) wins — it has the highest amount_cents
+        Assert.AreEqual("6482070", createdAssociations[0].ProviderProductId,
+            "Should process the highest-amount tier (Gold), not the first in the list (Silver)");
+        Assert.AreEqual("gold-mapping-id", createdAssociations[0].ProductMappingId,
+            "Should use the Gold tier mapping");
 
-        // Verify the second tier was NOT processed
-        Assert.IsFalse(createdAssociations.Any(a => a.ProviderProductId == "6482051"),
-            "Should NOT process the second tier for TIERED rewards");
+        // Silver must NOT be created
+        Assert.IsFalse(createdAssociations.Any(a => a.ProviderProductId == "6482057"),
+            "Should NOT process the lower-amount Silver tier");
     }
 
     [Test]
     public async Task SyncDrift_MixedTieredAndNonTiered_ProcessesCorrectly()
     {
-        // Arrange
+        // Arrange: tiered-1 (200¢) and tiered-2 (800¢) — tiered-2 is the highest-amount TIERED tier.
+        // The filter must pick tiered-2 even though tiered-1 appears first in the input list.
+        // Non-TIERED types (OneTime, Recurring) are all passed through unchanged.
         var battleTag = "MixedUser#1234";
         var patreonUserId = "mixed-user-id";
         var patreonMemberId = "mixed-member-id";
@@ -838,10 +857,11 @@ public class PatreonDriftSyncTests
             .ReturnsAsync(accountLink);
 
         // Setup product mappings - mix of TIERED and non-TIERED
+        // tiered-1: 200¢ — lower amount, listed first in entitled tiers
         var tiered1Mapping = new ProductMapping
         {
             Id = "tiered1-mapping-id",
-            ProductName = "Tiered 1",
+            ProductName = "Tiered 1 (cheaper)",
             Type = ProductMappingType.Tiered,  // TIERED
             RewardIds = new List<string> { "reward-tiered1" },
             ProductProviders = new List<ProductProviderPair>
@@ -850,10 +870,11 @@ public class PatreonDriftSyncTests
             }
         };
 
+        // tiered-2: 800¢ — higher amount, must be selected regardless of list position
         var tiered2Mapping = new ProductMapping
         {
             Id = "tiered2-mapping-id",
-            ProductName = "Tiered 2",
+            ProductName = "Tiered 2 (more expensive)",
             Type = ProductMappingType.Tiered,  // TIERED
             RewardIds = new List<string> { "reward-tiered2" },
             ProductProviders = new List<ProductProviderPair>
@@ -912,7 +933,8 @@ public class PatreonDriftSyncTests
             .Callback<ProductMappingUserAssociation>(a => createdAssociations.Add(a))
             .ReturnsAsync((ProductMappingUserAssociation a) => a);
 
-        // Create drift result with mix of tier types
+        // Create drift result with mix of tier types.
+        // tiered-1 (200¢) is listed first but tiered-2 (800¢) must win for TIERED selection.
         var driftResult = new DriftDetectionResult
         {
             Timestamp = DateTime.UtcNow,
@@ -924,8 +946,13 @@ public class PatreonDriftSyncTests
                     PatreonMemberId = patreonMemberId,
                     PatreonUserId = patreonUserId,
                     PatronStatus = "active_patron",
-                    // Mix of TIERED and non-TIERED tiers
-                    EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = "tiered-1" }, new EntitledTier { TierId = "tiered-2" }, new EntitledTier { TierId = "onetime-bonus" }, new EntitledTier { TierId = "recurring-perk" } },
+                    EntitledTiers = new List<EntitledTier>
+                    {
+                        new EntitledTier { TierId = "tiered-1", AmountCents = 200 }, // lower amount, first in list
+                        new EntitledTier { TierId = "tiered-2", AmountCents = 800 }, // higher amount, must win
+                        new EntitledTier { TierId = "onetime-bonus" },
+                        new EntitledTier { TierId = "recurring-perk" }
+                    },
                     Reason = "Active patron with mixed tier types"
                 }
             }
@@ -939,19 +966,19 @@ public class PatreonDriftSyncTests
         Assert.AreEqual(1, syncResult.MembersAdded, "Should add 1 member");
 
         // Should create 3 associations total:
-        // - 1 for the first TIERED (tiered-1)
+        // - 1 for the highest-amount TIERED (tiered-2, 800¢)
         // - 1 for OneTime (onetime-bonus)
         // - 1 for Recurring (recurring-perk)
         Assert.AreEqual(3, createdAssociations.Count,
-            "Should create 3 associations: 1 TIERED + 2 non-TIERED");
+            "Should create 3 associations: 1 highest-amount TIERED + 2 non-TIERED");
 
-        // Verify first TIERED tier was processed
-        Assert.IsTrue(createdAssociations.Any(a => a.ProviderProductId == "tiered-1"),
-            "Should process the first TIERED tier");
+        // Verify the highest-amount TIERED tier (tiered-2) was processed
+        Assert.IsTrue(createdAssociations.Any(a => a.ProviderProductId == "tiered-2"),
+            "Should process the highest-amount TIERED tier (tiered-2, 800¢)");
 
-        // Verify second TIERED tier was NOT processed
-        Assert.IsFalse(createdAssociations.Any(a => a.ProviderProductId == "tiered-2"),
-            "Should NOT process the second TIERED tier");
+        // Verify the lower-amount TIERED tier (tiered-1) was NOT processed
+        Assert.IsFalse(createdAssociations.Any(a => a.ProviderProductId == "tiered-1"),
+            "Should NOT process the lower-amount TIERED tier (tiered-1, 200¢)");
 
         // Verify all non-TIERED were processed
         Assert.IsTrue(createdAssociations.Any(a => a.ProviderProductId == "onetime-bonus"),
@@ -962,32 +989,46 @@ public class PatreonDriftSyncTests
 
     private static IEnumerable<TestCaseData> DriftDetectionTieredTestCases()
     {
-        // Case 1: No drift - User has multiple TIERED tiers from Patreon, internal has first tier only
+        // Case 1 (rewritten): Internal has the lower-amount tier (Bronze 6482051, 100¢).
+        // Patreon has [Bronze, Gold] — filter picks Gold (1000¢, highest amount_cents).
+        // Internal filter picks Bronze (only tier present). Gold ≠ Bronze → drift IS detected.
         yield return new TestCaseData(
             "eliphanti#2142",
-            new List<string> { "6482057", "6482051" },  // Patreon entitled tiers
-            new List<string> { "6482057" },              // Internal stored tiers (first only)
+            new List<EntitledTier>
+            {
+                new EntitledTier { TierId = "6482051", AmountCents = 100 },  // Bronze
+                new EntitledTier { TierId = "6482070", AmountCents = 1000 } // Gold — highest, must win
+            },
+            new List<string> { "6482051" },              // Internal has Bronze only (lower tier)
+            ProductMappingType.Tiered,                   // All tiers are TIERED type
+            true,                                         // SHOULD detect drift (internal has lower tier)
+            1,                                            // Expected mismatch count
+            "Multiple TIERED rewards - internal has lower tier (Bronze) but Patreon filters to Gold"
+        ).SetName("DetectDrift_MultipleTiered_InternalHasLowerTier_HasDrift");
+
+        // Case 2 (reframed by amount): Internal has the highest-amount tier (Gold 6482070, 1000¢).
+        // Patreon has [Silver, Gold] — filter picks Gold (1000¢). Both sides → Gold. No drift.
+        yield return new TestCaseData(
+            "correcttier#1234",
+            new List<EntitledTier>
+            {
+                new EntitledTier { TierId = "6482057", AmountCents = 500 },  // Silver
+                new EntitledTier { TierId = "6482070", AmountCents = 1000 }  // Gold — highest, must win
+            },
+            new List<string> { "6482070" },              // Internal correctly has Gold (highest-amount tier)
             ProductMappingType.Tiered,                   // All tiers are TIERED type
             false,                                        // Should NOT detect drift
             0,                                            // Expected mismatch count
-            "Multiple TIERED rewards - internal correctly has only first tier"
-        ).SetName("DetectDrift_MultipleTiered_InternalHasFirst_NoDrift");
-
-        // Case 2: Has drift - User has multiple TIERED tiers, internal has wrong tier (second instead of first)
-        yield return new TestCaseData(
-            "wrongtier#1234",
-            new List<string> { "6482057", "6482051" },  // Patreon entitled tiers
-            new List<string> { "6482051" },              // Internal has second tier (wrong!)
-            ProductMappingType.Tiered,                   // All tiers are TIERED type
-            true,                                         // SHOULD detect drift
-            1,                                            // Expected mismatch count
-            "Multiple TIERED rewards - internal has wrong tier (second instead of first)"
-        ).SetName("DetectDrift_MultipleTiered_InternalHasSecond_HasDrift");
+            "Multiple TIERED rewards - internal correctly has highest-amount tier (Gold)"
+        ).SetName("DetectDrift_MultipleTiered_InternalHasHighestAmountTier_NoDrift");
 
         // Case 3: No drift - Single TIERED tier matches
         yield return new TestCaseData(
             "singletier#1234",
-            new List<string> { "6482057" },              // Patreon entitled tiers
+            new List<EntitledTier>
+            {
+                new EntitledTier { TierId = "6482057", AmountCents = 500 }   // Silver only
+            },
             new List<string> { "6482057" },              // Internal stored tiers
             ProductMappingType.Tiered,                   // TIERED type
             false,                                        // Should NOT detect drift
@@ -998,7 +1039,7 @@ public class PatreonDriftSyncTests
         // Case 4: Has drift - User lost a tier
         yield return new TestCaseData(
             "losttier#1234",
-            new List<string> { },                        // Patreon entitled tiers (none)
+            new List<EntitledTier>(),                    // Patreon entitled tiers (none)
             new List<string> { "6482057" },              // Internal still has tier
             ProductMappingType.Tiered,                   // TIERED type
             true,                                         // SHOULD detect drift
@@ -1009,7 +1050,11 @@ public class PatreonDriftSyncTests
         // Case 5: No drift - Multiple non-TIERED rewards all match
         yield return new TestCaseData(
             "notiered#1234",
-            new List<string> { "onetime-1", "onetime-2" }, // Patreon entitled tiers
+            new List<EntitledTier>
+            {
+                new EntitledTier { TierId = "onetime-1" },
+                new EntitledTier { TierId = "onetime-2" }
+            },
             new List<string> { "onetime-1", "onetime-2" }, // Internal has both
             ProductMappingType.OneTime,                     // NOT TIERED
             false,                                           // Should NOT detect drift
@@ -1021,7 +1066,7 @@ public class PatreonDriftSyncTests
     [TestCaseSource(nameof(DriftDetectionTieredTestCases))]
     public async Task DetectDrift_TieredRewardScenarios(
         string battleTag,
-        List<string> patreonEntitledTiers,
+        List<EntitledTier> patreonEntitledTiers,
         List<string> internalStoredTiers,
         ProductMappingType mappingType,
         bool shouldDetectDrift,
@@ -1037,7 +1082,7 @@ public class PatreonDriftSyncTests
             .ReturnsAsync(new List<PatreonAccountLink> { accountLink });
 
         // Setup product mappings based on all unique tier IDs
-        var allTierIds = patreonEntitledTiers.Union(internalStoredTiers).Distinct().ToList();
+        var allTierIds = patreonEntitledTiers.Select(t => t.TierId).Union(internalStoredTiers).Distinct().ToList();
         var productMappings = new List<ProductMapping>();
 
         foreach (var tierId in allTierIds)
@@ -1058,7 +1103,7 @@ public class PatreonDriftSyncTests
         _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
             .ReturnsAsync(productMappings);
 
-        // Create Patreon members list
+        // Create Patreon members list (with full EntitledTier including AmountCents)
         var patreonMembers = new List<PatreonMember>();
         if (patreonEntitledTiers.Any())
         {
@@ -1068,7 +1113,7 @@ public class PatreonDriftSyncTests
                 PatreonUserId = patreonUserId,
                 PatronStatus = "active_patron",
                 LastChargeStatus = "Paid",  // This makes IsActivePatron = true
-                EntitledTiers = patreonEntitledTiers.Select(id => new EntitledTier { TierId = id }).ToList()
+                EntitledTiers = patreonEntitledTiers.ToList()
             });
         }
 
@@ -1119,7 +1164,7 @@ public class PatreonDriftSyncTests
         {
             var mismatch = driftResult.MismatchedTiers[0];
             Assert.AreEqual(battleTag, mismatch.UserId, "Mismatched user ID incorrect");
-            Assert.That(mismatch.PatreonTiers, Is.EquivalentTo(patreonEntitledTiers),
+            Assert.That(mismatch.PatreonTiers, Is.EquivalentTo(patreonEntitledTiers.Select(t => t.TierId).ToList()),
                 "Patreon tiers in mismatch record incorrect");
             Assert.That(mismatch.InternalTiers, Is.EquivalentTo(internalStoredTiers),
                 "Internal tiers in mismatch record incorrect");
@@ -1131,5 +1176,748 @@ public class PatreonDriftSyncTests
             Assert.IsTrue(driftResult.ExtraAssignments.Count > 0,
                 "Should have extra assignments when user lost all tiers");
         }
+    }
+
+    // ─── Step 2: SyncSingleUser end-to-end tests ────────────────────────────
+
+    /// <summary>
+    /// Sets up product mappings for standard Bronze (6482051) and Gold (6482070) TIERED tiers
+    /// so SyncSingleUser can resolve tiers via GetByProviderId and GetByProviderAndProductId.
+    /// </summary>
+    private void SetupStandardTierMappings()
+    {
+        var bronzeMapping = new ProductMapping
+        {
+            Id = "bronze-mapping-id",
+            ProductName = "Bronze Tier",
+            Type = ProductMappingType.Tiered,
+            RewardIds = new List<string> { "reward-bronze" },
+            ProductProviders = new List<ProductProviderPair>
+            {
+                new ProductProviderPair { ProviderId = "patreon", ProductId = "6482051" }
+            }
+        };
+        var goldMapping = new ProductMapping
+        {
+            Id = "gold-mapping-id",
+            ProductName = "Gold Tier",
+            Type = ProductMappingType.Tiered,
+            RewardIds = new List<string> { "reward-gold" },
+            ProductProviders = new List<ProductProviderPair>
+            {
+                new ProductProviderPair { ProviderId = "patreon", ProductId = "6482070" }
+            }
+        };
+
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping> { bronzeMapping, goldMapping });
+        _mockProductMappingRepository.Setup(x => x.GetByProviderAndProductId("patreon", "6482051"))
+            .ReturnsAsync(new List<ProductMapping> { bronzeMapping });
+        _mockProductMappingRepository.Setup(x => x.GetByProviderAndProductId("patreon", "6482070"))
+            .ReturnsAsync(new List<ProductMapping> { goldMapping });
+    }
+
+    [Test]
+    public async Task SyncSingleUser_UserBelongsToOtherCreatorsCampaign_DoesNotGrantOurRewards()
+    {
+        // TORREN-style regression: campaign endpoint returns null (user not in our campaign).
+        // The service returns early without touching associations.
+        const string battleTag = "TORREN#11438";
+        const string patreonUserId = "152572628";
+
+        _mockPatreonApiClient.Setup(x => x.GetCampaignMemberByPatreonUserId(patreonUserId))
+            .ReturnsAsync((PatreonMember)null);
+
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(battleTag))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+
+        var result = await _service.SyncSingleUser(battleTag, patreonUserId, "user-token");
+
+        // null from campaign API → SyncSingleUser returns early; SyncAction stays at default None
+        Assert.AreEqual(UserSyncAction.None, result.SyncAction,
+            "SyncAction must be None when the user is not a member of our campaign");
+        _mockAssociationRepository.Verify(r => r.Create(It.IsAny<ProductMappingUserAssociation>()), Times.Never,
+            "Should not create any associations for a non-member");
+    }
+
+    [Test]
+    public async Task SyncSingleUser_UserActiveInOurCampaign_GrantsCorrectTier()
+    {
+        // Active patron with a single Gold tier → CreateNew action, association created.
+        const string battleTag = "TORREN#11438";
+        const string patreonUserId = "152572628";
+
+        var member = new PatreonMemberBuilder()
+            .WithPatreonUserId(patreonUserId)
+            .WithPatronStatus("active_patron")
+            .WithLastChargeStatus("Paid")
+            .WithTiers(EntitledTierBuilder.Gold())
+            .Build();
+
+        _mockPatreonApiClient.Setup(x => x.GetCampaignMemberByPatreonUserId(patreonUserId))
+            .ReturnsAsync(member);
+
+        // No existing associations
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(battleTag))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockAssociationRepository.Setup(x => x.GetByUserAndProductMapping(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockAssociationRepository.Setup(x => x.Create(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+
+        SetupStandardTierMappings();
+
+        var result = await _service.SyncSingleUser(battleTag, patreonUserId, "user-token");
+
+        Assert.IsTrue(result.Success, "Sync should succeed for active patron");
+        Assert.AreEqual(UserSyncAction.CreateNew, result.SyncAction,
+            "Should create new associations for an active patron with no existing associations");
+    }
+
+    [Test]
+    public async Task SyncSingleUser_UserActiveInOurCampaign_MultipleTiers_GrantsHighestAmountOnly()
+    {
+        // Patron has Bronze (100¢) + Gold (1000¢) — filter must select Gold only.
+        const string battleTag = "TORREN#11438";
+        const string patreonUserId = "152572628";
+
+        var member = new PatreonMemberBuilder()
+            .WithPatreonUserId(patreonUserId)
+            .WithPatronStatus("active_patron")
+            .WithLastChargeStatus("Paid")
+            .WithTiers(EntitledTierBuilder.Bronze(), EntitledTierBuilder.Gold())
+            .Build();
+
+        _mockPatreonApiClient.Setup(x => x.GetCampaignMemberByPatreonUserId(patreonUserId))
+            .ReturnsAsync(member);
+
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(battleTag))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockAssociationRepository.Setup(x => x.GetByUserAndProductMapping(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+
+        var createdAssociations = new List<ProductMappingUserAssociation>();
+        _mockAssociationRepository.Setup(x => x.Create(It.IsAny<ProductMappingUserAssociation>()))
+            .Callback<ProductMappingUserAssociation>(a => createdAssociations.Add(a))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+
+        SetupStandardTierMappings();
+
+        var result = await _service.SyncSingleUser(battleTag, patreonUserId, "user-token");
+
+        Assert.AreEqual(UserSyncAction.CreateNew, result.SyncAction,
+            "Should create new associations");
+
+        // Only Gold association created — Bronze must be filtered out
+        Assert.AreEqual(1, createdAssociations.Count,
+            "Should create exactly 1 association (Gold only)");
+        _mockAssociationRepository.Verify(r => r.Create(
+            It.Is<ProductMappingUserAssociation>(a => a.ProviderProductId == "6482070")), Times.Once,
+            "Gold tier (6482070) must be created");
+        _mockAssociationRepository.Verify(r => r.Create(
+            It.Is<ProductMappingUserAssociation>(a => a.ProviderProductId == "6482051")), Times.Never,
+            "Bronze tier (6482051) must NOT be created — Gold wins by amount_cents");
+    }
+
+    [Test]
+    public async Task SyncSingleUser_UserNotInAnyCampaign_GrantsNoRewardsAndReturnsNoneAction()
+    {
+        // No campaign membership found → no reward changes, action is None.
+        const string battleTag = "TORREN#11438";
+        const string patreonUserId = "152572628";
+
+        _mockPatreonApiClient.Setup(x => x.GetCampaignMemberByPatreonUserId(patreonUserId))
+            .ReturnsAsync((PatreonMember)null);
+
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(battleTag))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+
+        var result = await _service.SyncSingleUser(battleTag, patreonUserId, "user-token");
+
+        Assert.AreEqual(UserSyncAction.None, result.SyncAction,
+            "Action must be None when user is not in any campaign");
+        _mockAssociationRepository.Verify(r => r.Create(It.IsAny<ProductMappingUserAssociation>()), Times.Never,
+            "No associations should be created");
+        _mockReconciliationService.Verify(r => r.ReconcileUserAssociations(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never,
+            "No reconciliation should be triggered");
+    }
+
+    [Test]
+    public async Task SyncSingleUser_UserDowngradedFromGoldToBronze_RevokesGoldGrantsBronze()
+    {
+        // Existing internal: Gold. Patreon now shows Bronze only.
+        // Expected: UpdateTiers action, Gold revoked, Bronze created.
+        const string battleTag = "TORREN#11438";
+        const string patreonUserId = "152572628";
+
+        var goldAssociation = new ProductMappingUserAssociation
+        {
+            Id = "gold-assoc-id",
+            UserId = battleTag,
+            ProductMappingId = "gold-mapping-id",
+            ProviderId = "patreon",
+            ProviderProductId = "6482070",
+            Status = AssociationStatus.Active,
+            AssignedAt = DateTime.UtcNow.AddDays(-30)
+        };
+
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(battleTag))
+            .ReturnsAsync(new List<ProductMappingUserAssociation> { goldAssociation });
+        _mockAssociationRepository.Setup(x => x.Update(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+        _mockAssociationRepository.Setup(x => x.GetByUserAndProductMapping(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockAssociationRepository.Setup(x => x.Create(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+
+        // Patreon now only has Bronze (downgraded)
+        var member = new PatreonMemberBuilder()
+            .WithPatreonUserId(patreonUserId)
+            .WithPatronStatus("active_patron")
+            .WithLastChargeStatus("Paid")
+            .WithTiers(EntitledTierBuilder.Bronze())
+            .Build();
+
+        _mockPatreonApiClient.Setup(x => x.GetCampaignMemberByPatreonUserId(patreonUserId))
+            .ReturnsAsync(member);
+
+        SetupStandardTierMappings();
+
+        var result = await _service.SyncSingleUser(battleTag, patreonUserId, "user-token");
+
+        Assert.IsTrue(result.Success, "Sync should succeed");
+        Assert.AreEqual(UserSyncAction.UpdateTiers, result.SyncAction,
+            "Should be UpdateTiers when patron downgrades from Gold to Bronze");
+
+        // Gold should be revoked
+        _mockAssociationRepository.Verify(r => r.Update(It.Is<ProductMappingUserAssociation>(
+            a => a.ProviderProductId == "6482070" && a.Status == AssociationStatus.Revoked)),
+            Times.Once, "Gold association must be revoked");
+
+        // Bronze should be created
+        _mockAssociationRepository.Verify(r => r.Create(It.Is<ProductMappingUserAssociation>(
+            a => a.ProviderProductId == "6482051")),
+            Times.Once, "Bronze association must be created after downgrade");
+    }
+
+    [Test]
+    public async Task SyncSingleUser_UserUpgradedFromBronzeToGold_TransitionsToGoldOnly()
+    {
+        // Existing internal: Bronze. Patreon now shows Bronze + Gold (upgrade window).
+        // Filter picks Gold (highest amount_cents) → UpdateTiers, Bronze revoked, Gold created.
+        const string battleTag = "TORREN#11438";
+        const string patreonUserId = "152572628";
+
+        var bronzeAssociation = new ProductMappingUserAssociation
+        {
+            Id = "bronze-assoc-id",
+            UserId = battleTag,
+            ProductMappingId = "bronze-mapping-id",
+            ProviderId = "patreon",
+            ProviderProductId = "6482051",
+            Status = AssociationStatus.Active,
+            AssignedAt = DateTime.UtcNow.AddDays(-60)
+        };
+
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(battleTag))
+            .ReturnsAsync(new List<ProductMappingUserAssociation> { bronzeAssociation });
+        _mockAssociationRepository.Setup(x => x.Update(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+        _mockAssociationRepository.Setup(x => x.GetByUserAndProductMapping(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockAssociationRepository.Setup(x => x.Create(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+
+        // Patreon: Bronze + Gold during the upgrade window — filter picks Gold
+        var member = new PatreonMemberBuilder()
+            .WithPatreonUserId(patreonUserId)
+            .WithPatronStatus("active_patron")
+            .WithLastChargeStatus("Paid")
+            .WithTiers(EntitledTierBuilder.Bronze(), EntitledTierBuilder.Gold())
+            .Build();
+
+        _mockPatreonApiClient.Setup(x => x.GetCampaignMemberByPatreonUserId(patreonUserId))
+            .ReturnsAsync(member);
+
+        SetupStandardTierMappings();
+
+        var result = await _service.SyncSingleUser(battleTag, patreonUserId, "user-token");
+
+        Assert.IsTrue(result.Success, "Sync should succeed");
+        Assert.AreEqual(UserSyncAction.UpdateTiers, result.SyncAction,
+            "Should be UpdateTiers — Patreon filtered side is Gold, internal is Bronze");
+
+        // Bronze revoked, Gold created
+        _mockAssociationRepository.Verify(r => r.Update(It.Is<ProductMappingUserAssociation>(
+            a => a.ProviderProductId == "6482051" && a.Status == AssociationStatus.Revoked)),
+            Times.Once, "Bronze association must be revoked on upgrade");
+        _mockAssociationRepository.Verify(r => r.Create(It.Is<ProductMappingUserAssociation>(
+            a => a.ProviderProductId == "6482070")),
+            Times.Once, "Gold association must be created on upgrade");
+    }
+
+    [Test]
+    public async Task SyncSingleUser_NewPatronWithPendingChargeStatus_TreatedAsActive()
+    {
+        // Pending charge is treated as active (Task 3 fix): patron should get rewards.
+        const string battleTag = "TORREN#11438";
+        const string patreonUserId = "152572628";
+
+        var member = new PatreonMemberBuilder()
+            .WithPatreonUserId(patreonUserId)
+            .WithPatronStatus("active_patron")
+            .WithLastChargeStatus("Pending") // Pending → IsActivePatron = true after Task 3
+            .WithTiers(EntitledTierBuilder.Gold())
+            .Build();
+
+        _mockPatreonApiClient.Setup(x => x.GetCampaignMemberByPatreonUserId(patreonUserId))
+            .ReturnsAsync(member);
+
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(battleTag))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockAssociationRepository.Setup(x => x.GetByUserAndProductMapping(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockAssociationRepository.Setup(x => x.Create(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+
+        SetupStandardTierMappings();
+
+        var result = await _service.SyncSingleUser(battleTag, patreonUserId, "user-token");
+
+        Assert.IsTrue(result.Success, "Pending charge patron should be treated as active");
+        Assert.AreEqual(UserSyncAction.CreateNew, result.SyncAction,
+            "Should create new associations for a Pending-charge patron (treated as active)");
+    }
+
+    [Test]
+    public async Task SyncSingleUser_NewPatronWithFreeTrialStatus_TreatedAsActive()
+    {
+        // Free Trial charge status is treated as active (Task 3 fix).
+        const string battleTag = "TORREN#11438";
+        const string patreonUserId = "152572628";
+
+        var member = new PatreonMemberBuilder()
+            .WithPatreonUserId(patreonUserId)
+            .WithPatronStatus("active_patron")
+            .WithLastChargeStatus("Free Trial") // Free Trial → IsActivePatron = true after Task 3
+            .WithTiers(EntitledTierBuilder.Gold())
+            .Build();
+
+        _mockPatreonApiClient.Setup(x => x.GetCampaignMemberByPatreonUserId(patreonUserId))
+            .ReturnsAsync(member);
+
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(battleTag))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockAssociationRepository.Setup(x => x.GetByUserAndProductMapping(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockAssociationRepository.Setup(x => x.Create(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+
+        SetupStandardTierMappings();
+
+        var result = await _service.SyncSingleUser(battleTag, patreonUserId, "user-token");
+
+        Assert.IsTrue(result.Success, "Free Trial patron should be treated as active");
+        Assert.AreEqual(UserSyncAction.CreateNew, result.SyncAction,
+            "Should create new associations for a Free-Trial patron (treated as active)");
+    }
+
+    // ─── Step 3: Drift integration scenario tests ───────────────────────────
+
+    [Test]
+    public async Task DetectDrift_TorrenScenario_GoldEntitledButNoInternalRewards_ReportsMissing()
+    {
+        // TORREN scenario: patron is active with Gold tier in Patreon but has zero
+        // internal associations. DetectDrift must place them in MissingMembers.
+        const string battleTag = "TORREN#11438";
+        const string patreonUserId = "torren-patreon-id";
+
+        var accountLink = new PatreonAccountLink(battleTag, patreonUserId);
+        _mockPatreonLinkRepository.Setup(x => x.GetAll())
+            .ReturnsAsync(new List<PatreonAccountLink> { accountLink });
+
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping>
+            {
+                new ProductMapping
+                {
+                    Id = "gold-mapping-id",
+                    ProductName = "Gold Tier",
+                    Type = ProductMappingType.Tiered,
+                    RewardIds = new List<string> { "reward-gold" },
+                    ProductProviders = new List<ProductProviderPair>
+                    {
+                        new ProductProviderPair { ProviderId = "patreon", ProductId = "6482070" }
+                    }
+                }
+            });
+
+        // Patreon has active Gold patron with full amount_cents
+        _mockPatreonApiClient.Setup(x => x.GetAllCampaignMembers())
+            .ReturnsAsync(new List<PatreonMember>
+            {
+                new PatreonMember
+                {
+                    Id = "torren-member-id",
+                    PatreonUserId = patreonUserId,
+                    PatronStatus = "active_patron",
+                    LastChargeStatus = "Paid",
+                    EntitledTiers = new List<EntitledTier> { EntitledTierBuilder.Gold() }
+                }
+            });
+
+        // No internal associations at all
+        _mockAssociationRepository.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+
+        var driftResult = await _service.DetectDrift();
+
+        Assert.IsTrue(driftResult.HasDrift, "Should detect drift when active patron has no internal rewards");
+        Assert.AreEqual(1, driftResult.MissingMembers.Count,
+            "Should report exactly one missing member (TORREN)");
+        Assert.AreEqual(patreonUserId, driftResult.MissingMembers[0].PatreonUserId,
+            "Missing member should be TORREN's Patreon user ID");
+        Assert.IsTrue(driftResult.MissingMembers[0].EntitledTiers.Any(t => t.TierId == "6482070"),
+            "Missing member's entitled tiers should include Gold (6482070)");
+    }
+
+    [Test]
+    public async Task DetectDrift_UserHasFreeTrialStatus_TreatedAsActive_NoDrift()
+    {
+        // Free Trial patron who already has the correct internal Gold association → no drift.
+        // Verifies Free Trial users are not incorrectly excluded as inactive.
+        const string battleTag = "freetrial#1234";
+        const string patreonUserId = "freetrial-patreon-id";
+
+        var accountLink = new PatreonAccountLink(battleTag, patreonUserId);
+        _mockPatreonLinkRepository.Setup(x => x.GetAll())
+            .ReturnsAsync(new List<PatreonAccountLink> { accountLink });
+
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping>
+            {
+                new ProductMapping
+                {
+                    Id = "gold-mapping-id",
+                    ProductName = "Gold Tier",
+                    Type = ProductMappingType.Tiered,
+                    RewardIds = new List<string> { "reward-gold" },
+                    ProductProviders = new List<ProductProviderPair>
+                    {
+                        new ProductProviderPair { ProviderId = "patreon", ProductId = "6482070" }
+                    }
+                }
+            });
+
+        // Patreon: Free Trial charge status — IsActivePatron = true after Task 3
+        _mockPatreonApiClient.Setup(x => x.GetAllCampaignMembers())
+            .ReturnsAsync(new List<PatreonMember>
+            {
+                new PatreonMember
+                {
+                    Id = "freetrial-member-id",
+                    PatreonUserId = patreonUserId,
+                    PatronStatus = "active_patron",
+                    LastChargeStatus = "Free Trial",
+                    EntitledTiers = new List<EntitledTier> { EntitledTierBuilder.Gold() }
+                }
+            });
+
+        // Internal has the correct Gold association
+        _mockAssociationRepository.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>
+            {
+                new ProductMappingUserAssociation
+                {
+                    Id = "gold-assoc-id",
+                    UserId = battleTag,
+                    ProductMappingId = "gold-mapping-id",
+                    ProviderId = "patreon",
+                    ProviderProductId = "6482070",
+                    Status = AssociationStatus.Active,
+                    AssignedAt = DateTime.UtcNow.AddDays(-5)
+                }
+            });
+
+        var driftResult = await _service.DetectDrift();
+
+        Assert.IsFalse(driftResult.HasDrift,
+            "Should NOT detect drift when Free Trial patron has the correct internal Gold association");
+        Assert.AreEqual(0, driftResult.MissingMembers.Count, "No missing members expected");
+        Assert.AreEqual(0, driftResult.MismatchedTiers.Count, "No tier mismatches expected");
+    }
+
+    [Test]
+    public async Task DetectDrift_UserCancelsMidCycle_PatronStatusFormer_StillHasInternalRewards_ReportsExtra()
+    {
+        // A patron cancelled — PatronStatus is "former_patron".
+        // They still have an active internal association that should be reported as extra.
+        const string battleTag = "cancelled#5678";
+        const string patreonUserId = "cancelled-patreon-id";
+
+        var accountLink = new PatreonAccountLink(battleTag, patreonUserId);
+        _mockPatreonLinkRepository.Setup(x => x.GetAll())
+            .ReturnsAsync(new List<PatreonAccountLink> { accountLink });
+
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping>
+            {
+                new ProductMapping
+                {
+                    Id = "gold-mapping-id",
+                    ProductName = "Gold Tier",
+                    Type = ProductMappingType.Tiered,
+                    RewardIds = new List<string> { "reward-gold" },
+                    ProductProviders = new List<ProductProviderPair>
+                    {
+                        new ProductProviderPair { ProviderId = "patreon", ProductId = "6482070" }
+                    }
+                }
+            });
+
+        // Patreon: former_patron (cancelled)
+        _mockPatreonApiClient.Setup(x => x.GetAllCampaignMembers())
+            .ReturnsAsync(new List<PatreonMember>
+            {
+                new PatreonMember
+                {
+                    Id = "cancelled-member-id",
+                    PatreonUserId = patreonUserId,
+                    PatronStatus = "former_patron", // Not active
+                    LastChargeStatus = "Paid",
+                    EntitledTiers = new List<EntitledTier>()
+                }
+            });
+
+        // Internal: still has Gold association (stale)
+        _mockAssociationRepository.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>
+            {
+                new ProductMappingUserAssociation
+                {
+                    Id = "stale-gold-assoc",
+                    UserId = battleTag,
+                    ProductMappingId = "gold-mapping-id",
+                    ProviderId = "patreon",
+                    ProviderProductId = "6482070",
+                    Status = AssociationStatus.Active,
+                    AssignedAt = DateTime.UtcNow.AddDays(-45)
+                }
+            });
+
+        var driftResult = await _service.DetectDrift();
+
+        Assert.IsTrue(driftResult.HasDrift,
+            "Should detect drift for cancelled patron with stale associations");
+        Assert.IsTrue(driftResult.ExtraAssignments.Count > 0,
+            "Should report stale associations as extra assignments");
+        Assert.AreEqual(battleTag.ToLowerInvariant(),
+            driftResult.ExtraAssignments[0].UserId.ToLowerInvariant(),
+            "Extra assignment should reference the cancelled patron");
+    }
+
+    [Test]
+    public async Task SyncDrift_DryRun_DoesNotMutateAssociationStatusOrCallReconciliation()
+    {
+        // A dry run with a missing member must increment MembersAdded but must never
+        // call Create / Update on the association repository or trigger reconciliation.
+        // patreonUserId is linked to "TestBattleTag#1234" in the Setup() account link
+        const string patreonUserId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+        var driftResult = new DriftDetectionResult
+        {
+            Timestamp = DateTime.UtcNow,
+            ProviderId = "patreon",
+            MissingMembers = new List<MissingMember>
+            {
+                new MissingMember
+                {
+                    PatreonMemberId = "member-dry-run",
+                    PatreonUserId = patreonUserId,
+                    PatronStatus = "active_patron",
+                    EntitledTiers = new List<EntitledTier> { EntitledTierBuilder.Gold() },
+                    Reason = "Dry-run missing member"
+                }
+            }
+        };
+
+        var syncResult = await _service.SyncDrift(driftResult, dryRun: true);
+
+        Assert.IsTrue(syncResult.Success, "Dry-run sync should succeed");
+        Assert.IsTrue(syncResult.WasDryRun, "WasDryRun must be true");
+        Assert.AreEqual(1, syncResult.MembersAdded,
+            "MembersAdded counter should be incremented even in dry-run");
+
+        // Critical: no repository mutations or reconciliation in dry run
+        _mockAssociationRepository.Verify(r => r.Create(It.IsAny<ProductMappingUserAssociation>()), Times.Never,
+            "Dry-run must not call Create on the repository");
+        _mockAssociationRepository.Verify(r => r.Update(It.IsAny<ProductMappingUserAssociation>()), Times.Never,
+            "Dry-run must not call Update on the repository");
+        _mockReconciliationService.Verify(r => r.ReconcileUserAssociations(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never,
+            "Dry-run must not trigger reconciliation");
+    }
+
+    [Test]
+    public async Task SyncDrift_Idempotency_RunningTwiceProducesNoSecondPassChanges()
+    {
+        // After a first successful sync (creates the association), a second pass with the
+        // same drift result should find the association already exists and create nothing more.
+        const string battleTag = "IdempotencyUser#9999";
+        const string patreonUserId = "idempotency-user-id";
+
+        var accountLink = new PatreonAccountLink(battleTag, patreonUserId);
+        _mockPatreonLinkRepository.Setup(x => x.GetAll())
+            .ReturnsAsync(new List<PatreonAccountLink> { accountLink });
+
+        var goldMapping = new ProductMapping
+        {
+            Id = "gold-mapping-id",
+            ProductName = "Gold Tier",
+            Type = ProductMappingType.Tiered,
+            RewardIds = new List<string> { "reward-gold" },
+            ProductProviders = new List<ProductProviderPair>
+            {
+                new ProductProviderPair { ProviderId = "patreon", ProductId = "6482070" }
+            }
+        };
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping> { goldMapping });
+        _mockProductMappingRepository.Setup(x => x.GetByProviderAndProductId("patreon", "6482070"))
+            .ReturnsAsync(new List<ProductMapping> { goldMapping });
+
+        var existingGoldAssociation = new ProductMappingUserAssociation
+        {
+            Id = "gold-assoc-id",
+            UserId = battleTag,
+            ProductMappingId = "gold-mapping-id",
+            ProviderId = "patreon",
+            ProviderProductId = "6482070",
+            Status = AssociationStatus.Active,
+            AssignedAt = DateTime.UtcNow
+        };
+
+        // First call: empty (no associations yet). Second call: association already created.
+        _mockAssociationRepository.SetupSequence(x => x.GetProductMappingsByUserId(battleTag))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>())
+            .ReturnsAsync(new List<ProductMappingUserAssociation> { existingGoldAssociation });
+
+        // For the individual-lookup path, always return empty (triggers the Create path first time)
+        _mockAssociationRepository.Setup(x => x.GetByUserAndProductMapping(It.IsAny<string>(), "gold-mapping-id"))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+
+        _mockAssociationRepository.Setup(x => x.Create(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+
+        var buildDrift = () => new DriftDetectionResult
+        {
+            Timestamp = DateTime.UtcNow,
+            ProviderId = "patreon",
+            MissingMembers = new List<MissingMember>
+            {
+                new MissingMember
+                {
+                    PatreonMemberId = "idempotency-member-id",
+                    PatreonUserId = patreonUserId,
+                    PatronStatus = "active_patron",
+                    EntitledTiers = new List<EntitledTier> { EntitledTierBuilder.Gold() },
+                    Reason = "Missing member"
+                }
+            }
+        };
+
+        var firstResult = await _service.SyncDrift(buildDrift(), dryRun: false);
+        Assert.IsTrue(firstResult.Success, "First pass should succeed");
+        Assert.AreEqual(1, firstResult.MembersAdded, "First pass should add 1 member");
+
+        var secondResult = await _service.SyncDrift(buildDrift(), dryRun: false);
+        Assert.IsTrue(secondResult.Success, "Second pass should also succeed");
+
+        // The association is skipped on the second call because GetProductMappingsByUserId
+        // returns the already-created association, so the batch method skips it.
+        _mockAssociationRepository.Verify(r => r.Create(It.IsAny<ProductMappingUserAssociation>()),
+            Times.AtMostOnce,
+            "Association should be created at most once across two passes (idempotency)");
+    }
+
+    [Test]
+    public async Task SyncDrift_PartialFailure_ProcessesRemainingUsersAndReportsErrors()
+    {
+        // When one member has no linked BattleTag (silently skipped), the remaining member
+        // should still be processed successfully and the overall sync should succeed.
+        const string goodPatreonUserId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"; // linked in Setup()
+        const string badPatreonUserId = "no-link-for-this-user"; // no account link
+
+        _mockPatreonLinkRepository.Setup(x => x.GetAll())
+            .ReturnsAsync(new List<PatreonAccountLink>
+            {
+                // Only one of the two users has a linked account
+                new PatreonAccountLink("TestBattleTag#1234", goodPatreonUserId)
+            });
+
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping>
+            {
+                new ProductMapping
+                {
+                    Id = "gold-mapping-id",
+                    ProductName = "Gold Tier",
+                    Type = ProductMappingType.Tiered,
+                    RewardIds = new List<string> { "reward-gold" },
+                    ProductProviders = new List<ProductProviderPair>
+                    {
+                        new ProductProviderPair { ProviderId = "patreon", ProductId = "6482070" }
+                    }
+                }
+            });
+
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId("TestBattleTag#1234"))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockAssociationRepository.Setup(x => x.GetByUserAndProductMapping(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockAssociationRepository.Setup(x => x.Create(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+
+        var driftResult = new DriftDetectionResult
+        {
+            Timestamp = DateTime.UtcNow,
+            ProviderId = "patreon",
+            MissingMembers = new List<MissingMember>
+            {
+                new MissingMember
+                {
+                    // User with no linked BattleTag — silently skipped (no error)
+                    PatreonMemberId = "bad-member-id",
+                    PatreonUserId = badPatreonUserId,
+                    PatronStatus = "active_patron",
+                    EntitledTiers = new List<EntitledTier> { EntitledTierBuilder.Gold() },
+                    Reason = "No linked BattleTag"
+                },
+                new MissingMember
+                {
+                    // User with linked BattleTag — processed successfully
+                    PatreonMemberId = "good-member-id",
+                    PatreonUserId = goodPatreonUserId,
+                    PatronStatus = "active_patron",
+                    EntitledTiers = new List<EntitledTier> { EntitledTierBuilder.Gold() },
+                    Reason = "Has linked BattleTag"
+                }
+            }
+        };
+
+        var syncResult = await _service.SyncDrift(driftResult, dryRun: false);
+
+        Assert.IsTrue(syncResult.Success,
+            "Overall sync should succeed even with one unlinked member (silent skip)");
+        Assert.AreEqual(2, syncResult.MembersAdded,
+            "Both entries increment MembersAdded; the unlinked one is silently skipped before creating associations");
+        Assert.AreEqual(0, syncResult.Errors.Count,
+            "Missing BattleTag link is a silent skip, not an error");
+
+        // Only the linked account should have an association created
+        _mockAssociationRepository.Verify(r => r.Create(It.Is<ProductMappingUserAssociation>(
+            a => a.UserId == "TestBattleTag#1234")), Times.Once,
+            "Should create association only for the user with a linked account");
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -113,7 +113,7 @@ public class PatreonDriftSyncTests
                     PatreonMemberId = "member123",
                     PatreonUserId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
                     PatronStatus = "active_patron",
-                    EntitledTierIds = new List<string> { "tier1" },
+                    EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = "tier1" } },
                     Reason = "Test missing member"
                 }
             },
@@ -202,7 +202,7 @@ public class PatreonDriftSyncTests
                     PatreonMemberId = "member123",
                     PatreonUserId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
                     PatronStatus = "active_patron",
-                    EntitledTierIds = new List<string> { "tier1" },
+                    EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = "tier1" } },
                     Reason = "Test missing member"
                 }
             }
@@ -589,7 +589,7 @@ public class PatreonDriftSyncTests
                     PatreonMemberId = patreonMemberId,
                     PatreonUserId = patreonUserId,
                     PatronStatus = "active_patron",
-                    EntitledTierIds = newPatreonTiers,
+                    EntitledTiers = newPatreonTiers.Select(id => new EntitledTier { TierId = id }).ToList(),
                     Reason = $"{scenarioName}: Active patron found in Patreon but no active rewards in our system"
                 }
             };
@@ -794,7 +794,7 @@ public class PatreonDriftSyncTests
                     PatreonMemberId = patreonMemberId,
                     PatreonUserId = patreonUserId,
                     PatronStatus = "active_patron",
-                    EntitledTierIds = new List<string> { "6482057", "6482051" }, // Multiple TIERED rewards
+                    EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = "6482057" }, new EntitledTier { TierId = "6482051" } }, // Multiple TIERED rewards
                     Reason = "Active patron with multiple tiers"
                 }
             }
@@ -925,7 +925,7 @@ public class PatreonDriftSyncTests
                     PatreonUserId = patreonUserId,
                     PatronStatus = "active_patron",
                     // Mix of TIERED and non-TIERED tiers
-                    EntitledTierIds = new List<string> { "tiered-1", "tiered-2", "onetime-bonus", "recurring-perk" },
+                    EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = "tiered-1" }, new EntitledTier { TierId = "tiered-2" }, new EntitledTier { TierId = "onetime-bonus" }, new EntitledTier { TierId = "recurring-perk" } },
                     Reason = "Active patron with mixed tier types"
                 }
             }
@@ -1068,7 +1068,7 @@ public class PatreonDriftSyncTests
                 PatreonUserId = patreonUserId,
                 PatronStatus = "active_patron",
                 LastChargeStatus = "Paid",  // This makes IsActivePatron = true
-                EntitledTierIds = patreonEntitledTiers
+                EntitledTiers = patreonEntitledTiers.Select(id => new EntitledTier { TierId = id }).ToList()
             });
         }
 

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonProviderTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonProviderTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using W3C.Domain.Rewards.Events;
+using W3C.Domain.Rewards.Repositories;
+using W3ChampionsStatisticService.Rewards.Providers.Patreon;
+using WC3ChampionsStatisticService.UnitTests.Rewards.Fixtures;
+
+namespace WC3ChampionsStatisticService.UnitTests.Rewards;
+
+/// <summary>
+/// Tests for PatreonProvider webhook parsing and HMAC signature validation.
+/// Uses real webhook payloads loaded from PatreonPayloadLoader.
+///
+/// Note on ResolveUserId:
+/// ParseWebhookEvent calls ResolveUserId (via IPatreonAccountLinkRepository) to map
+/// the Patreon user ID to a BattleTag.  When the repository returns null (no linked
+/// account) ParseWebhookEvent returns null as well — this is intentional production
+/// behaviour.  Tests that need a non-null RewardEvent stub the repository to return
+/// a known BattleTag.
+/// </summary>
+[TestFixture]
+public class PatreonProviderTests
+{
+    private const string TestWebhookSecret = "super-secret-hmac-key";
+    // In real webhook payloads data.id is the MEMBER resource ID, not the Patreon user ID.
+    // PatreonProvider.ParseWebhookEvent passes data.id directly to ResolveUserId.
+    private const string MemberResourceId = "d29e61b6-f73b-4662-955e-dade715cef83";
+    private const string ExpectedTierId = "196241737"; // Elite Tier, 1337 cents
+
+    private Mock<ILogger<PatreonProvider>> _loggerMock;
+    private Mock<IPatreonAccountLinkRepository> _repoMock;
+    private PatreonProvider _provider;
+
+    [SetUp]
+    public void SetUp()
+    {
+        Environment.SetEnvironmentVariable("PATREON_WEBHOOK_SECRET", TestWebhookSecret);
+        _loggerMock = new Mock<ILogger<PatreonProvider>>();
+        _repoMock = new Mock<IPatreonAccountLinkRepository>();
+        _provider = new PatreonProvider(_loggerMock.Object, _repoMock.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable("PATREON_WEBHOOK_SECRET", null);
+    }
+
+    // Helper: compute the expected HMAC-SHA256 hex signature for a payload.
+    private static string ComputeHmac(string payload, string secret)
+    {
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(payload));
+        return Convert.ToHexString(hash).ToLower();
+    }
+
+    /// <summary>
+    /// Stub the repository so the member-resource ID from the real payloads resolves to a BattleTag.
+    /// PatreonProvider calls ResolveUserId(webhookData.Data.Id) where Data.Id is the member-resource ID
+    /// (a UUID like d29e61b6-...) which is then passed directly to GetByPatreonUserId.
+    /// </summary>
+    private void StubBattleTagResolution(string battleTag = "TestUser#1234")
+    {
+        var link = new W3C.Domain.Rewards.Entities.PatreonAccountLink
+        {
+            PatreonUserId = MemberResourceId,
+            BattleTag = battleTag
+        };
+        _repoMock
+            .Setup(r => r.GetByPatreonUserId(MemberResourceId))
+            .ReturnsAsync(link);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 1: members:create real payload → extracts tier ID and Patreon user ID
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public async Task ParseWebhookEvent_MembersCreateRealPayload_ExtractsTierIdAndUserId()
+    {
+        StubBattleTagResolution();
+        var payload = PatreonPayloadLoader.MembersCreateJson();
+        var headers = new Dictionary<string, string> { ["X-Patreon-Event"] = "members:create" };
+
+        var evt = await _provider.ParseWebhookEvent(payload, headers);
+
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(RewardEventType.SubscriptionCreated, evt.EventType);
+        Assert.AreEqual("TestUser#1234", evt.UserId);
+        Assert.IsNotNull(evt.Metadata);
+        // patreon_user_id in metadata holds webhookData.Data.Id (the member resource ID),
+        // since PatreonProvider stores that value directly before identity resolution.
+        Assert.AreEqual(MemberResourceId, evt.Metadata["patreon_user_id"]?.ToString());
+        Assert.AreEqual(1, evt.EntitledTiers.Count);
+        Assert.AreEqual(ExpectedTierId, evt.EntitledTiers[0].TierId);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 2: members:update real payload → event type is SubscriptionRenewed
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public async Task ParseWebhookEvent_MembersUpdateRealPayload_DetectsTierChange()
+    {
+        StubBattleTagResolution();
+        var payload = PatreonPayloadLoader.MembersUpdateJson();
+        var headers = new Dictionary<string, string> { ["X-Patreon-Event"] = "members:update" };
+
+        var evt = await _provider.ParseWebhookEvent(payload, headers);
+
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(RewardEventType.SubscriptionRenewed, evt.EventType);
+        Assert.AreEqual("TestUser#1234", evt.UserId);
+        Assert.AreEqual(1, evt.EntitledTiers.Count);
+        Assert.AreEqual(ExpectedTierId, evt.EntitledTiers[0].TierId);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 3: members:delete real payload → event type is SubscriptionCancelled
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public async Task ParseWebhookEvent_MembersDeleteRealPayload_MapsToRevoke()
+    {
+        StubBattleTagResolution();
+        var payload = PatreonPayloadLoader.MembersDeleteJson();
+        var headers = new Dictionary<string, string> { ["X-Patreon-Event"] = "members:delete" };
+
+        var evt = await _provider.ParseWebhookEvent(payload, headers);
+
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(RewardEventType.SubscriptionCancelled, evt.EventType);
+        Assert.AreEqual("TestUser#1234", evt.UserId);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 4: correct HMAC signature on a real payload → validation passes
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public async Task ValidateWebhookSignature_RealPayloadAndSecret_PassesHmac()
+    {
+        var payload = PatreonPayloadLoader.MembersCreateJson();
+        var signature = ComputeHmac(payload, TestWebhookSecret);
+        var headers = new Dictionary<string, string>();
+
+        var isValid = await _provider.ValidateWebhookSignature(payload, signature, headers);
+
+        Assert.IsTrue(isValid, "A correctly-signed payload must pass HMAC validation");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 5: same signature, tampered body → validation fails
+    // ──────────────────────────────────────────────────────────────────────────
+    [Test]
+    public async Task ValidateWebhookSignature_TamperedPayload_FailsValidation()
+    {
+        var originalPayload = PatreonPayloadLoader.MembersCreateJson();
+        var signature = ComputeHmac(originalPayload, TestWebhookSecret);
+
+        // Tamper by appending a single character — signature must not match
+        var tamperedPayload = originalPayload + " ";
+        var headers = new Dictionary<string, string>();
+
+        var isValid = await _provider.ValidateWebhookSignature(tamperedPayload, signature, headers);
+
+        Assert.IsFalse(isValid, "A tampered payload must fail HMAC validation");
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/RewardServiceTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/RewardServiceTests.cs
@@ -157,7 +157,7 @@ public class RewardServiceTests
             ProviderId = providerId,
             UserId = userId,
             ProviderReference = providerReference,
-            EntitledTierIds = new List<string> { tierId },
+            EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = tierId } },
             Timestamp = DateTime.UtcNow,
             Metadata = new Dictionary<string, object>
             {
@@ -230,7 +230,7 @@ public class RewardServiceTests
             ProviderId = providerId,
             UserId = userId,
             ProviderReference = "member_123",
-            EntitledTierIds = new List<string> { tierId },
+            EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = tierId } },
             Timestamp = DateTime.UtcNow
         };
 
@@ -282,7 +282,7 @@ public class RewardServiceTests
             ProviderId = providerId,
             UserId = userId,
             ProviderReference = "member_123",
-            EntitledTierIds = new List<string> { tierId },
+            EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = tierId } },
             Timestamp = DateTime.UtcNow
         };
 
@@ -375,7 +375,7 @@ public class RewardServiceTests
             ProviderId = providerId,
             UserId = userId,
             ProviderReference = "member_123",
-            EntitledTierIds = new List<string> { tier1Id, tier2Id },
+            EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = tier1Id }, new EntitledTier { TierId = tier2Id } },
             Timestamp = DateTime.UtcNow
         };
 

--- a/WC3ChampionsStatisticService.UnitTests/WC3ChampionsStatisticService.Tests.csproj
+++ b/WC3ChampionsStatisticService.UnitTests/WC3ChampionsStatisticService.Tests.csproj
@@ -19,4 +19,10 @@
     <ProjectReference Include="..\W3ChampionsStatisticService\W3ChampionsStatisticService.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Rewards\Fixtures\Payloads\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Fixes 3 Patreon data-correctness bugs uncovered while investigating the TORREN#11438 Bronze→Gold incident:

- **Bug 2 (tier filter):** `FilterTierIdsForProcessing` picked `.First()` of multiple Tiered mappings; non-deterministic Patreon API order meant Bronze could win over Gold during an upgrade. Now picks highest `amount_cents`, deterministic tiebreaker by lexicographic `TierId`. Extracted to `PatreonTierFilter`. Applied symmetrically in `PatreonWebhookController` so drift-sync and webhook paths agree.
- **Bug 3 (cross-campaign sync):** `SyncSingleUser` used the identity endpoint with `identity.memberships` scope, returning members from foreign campaigns; the `FirstOrDefault` parser had no campaign filter. Switched to a new `GetCampaignMemberByPatreonUserId` (paginated campaign-members endpoint with the campaign creator token). Defense-in-depth: identity-endpoint parsing now also filters by campaign id (`IsMemberForCampaign`), with a `Log.Warning` if Patreon ever drops the campaign relationship.
- **`IsActivePatron` tightening:** previously only accepted `LastChargeStatus == "Paid"`. Now accepts `Paid | Pending | Free Trial` per Patreon API empirical audit (`Pending` is a normal mid-charge state for a brand-new active patron — TORREN's relink case; `Free Trial` is documented for pre-paid trial periods). Comparison is `OrdinalIgnoreCase` to defend against Patreon API casing drift.

### Internal refactor: `EntitledTierIds` → `EntitledTiers`

The filter rewrite needs `amount_cents` per tier, so `List<string> EntitledTierIds` became `List<EntitledTier> EntitledTiers` (carrying `TierId`, `AmountCents`, `Title`) on `PatreonMember`, `RewardEvent`, internal helpers `MissingMember` and `PatreonMemberDetails`. `ParseMemberData` joins `included[]` tier resources to populate the rich shape. KoFi events use `AmountCents = null` (no tier-amount metadata).

### Wire-shape change for the admin frontend (lockstep deploy)

`AdminRewardController.GetPatreonMemberDetails`, `PatreonWebhookController` ack response, and `RewardDriftDetectionController.DetectPatreonDrift.missingMembers` now serialize `entitledTiers: [{ tierId, amountCents, title }]` (camelCase via System.Text.Json) instead of `entitledTierIds: List<string>`. The companion frontend PR (`feat/rewards-rich-tier-display`) renders titles + tier-id/amount in tooltips. Brief deploy-window misalignment is acceptable — only known consumers are the two admin Vue components (no launcher / matchmaking-service consumption).

### Bug fix: drift table chip column

`AdminDriftDetection.vue` was silently broken pre-PR (bound to non-existent `entitledTierIds`); the rich emit + frontend update fix it.

## Test plan

- [x] `dotnet build` clean.
- [x] `dotnet format --verify-no-changes` clean.
- [x] `dotnet test` 488 passed / 9 skipped (pre-existing) / 0 failed.
- [x] **Test infrastructure:** new `EntitledTierBuilder`, `PatreonMemberBuilder`, `PatreonPayloadLoader` (loads real Patreon webhook samples committed under `WC3ChampionsStatisticService.UnitTests/Rewards/Fixtures/Payloads/`).
- [x] **`PatreonTierFilter`:** 9 unit tests (highest-amount-wins, ordinal tiebreaker, null-amount lowest, negative ranks with null, `long.MaxValue` no-overflow, mixed Tiered + non-Tiered passthrough preserved).
- [x] **`IsActivePatron` truth-table:** 12 cases including 3 new `Pending`/`Free Trial`/casing-drift variants.
- [x] **`GetCampaignMemberByPatreonUserId`:** 9 HTTP-mocked tests (first-page hit, page-3 traversal, not-in-campaign, empty campaign, pagination terminates on null next-link, HTTP error throws, malformed JSON throws, multi-tier amount-cents association, free-membership null-status preserved).
- [x] **`PatreonDriftSyncTests` rewrite:** 5 first-wins-enshrining tests rewritten to assert highest-amount-wins; 8 new `SyncSingleUser` end-to-end tests covering TORREN's regression, upgrade/downgrade, Pending/Free-Trial, cross-campaign no-grant; 6 drift integration scenarios (TORREN scenario, free-trial active, cancellation mid-cycle, dry-run, idempotency, partial-failure).
- [x] **`ParseMemberData` parsing tests:** 7 (real members-create payload, included-tier amount association, missing tier resource, null patron-status, null charge-status, multi-tier, empty-entitled-tiers).
- [x] **Cross-campaign defense:** 3 (picks our-campaign member when multiple campaigns present, returns null when no our-campaign member, missing campaign relationship → reject + log warn).
- [x] **PatreonProvider webhook parsing + HMAC:** 5 (members:create/update/delete with real payloads, HMAC validate, tampered payload rejected).
- [ ] Post-deploy: drift detection cycle runs without errors; logs show \`Tier upgrade: keeping highest-priced ...\` on next run for any multi-tier user.
- [ ] Post-deploy: `curl /api/rewards/admin/patreon/members/<some-multi-tier-user>` returns rich `entitledTiers` with `tierId/amountCents/title`.

## Coordinated rollout

Lockstep deploy with `website` PR `feat/rewards-rich-tier-display` (renders the rich shape with debug-id tooltip). Brief misalignment is acceptable per agreed rollout plan. The follow-up Spec 2 PR (`battletag-casing-canonicalization`) stacks on this branch.

Independent of the Spec 1 deploy (this PR doesn't call `/api/users/exists`).