### PR TITLE
fix: BattleTag casing canonicalization across entry points + SignalR Hub security

### DIFF
--- a/W3ChampionsStatisticService/Admin/AdminController.cs
+++ b/W3ChampionsStatisticService/Admin/AdminController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using MongoDB.Bson;
 using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.Services;
 using W3ChampionsStatisticService.WebApi.ActionFilters;
 using W3C.Domain.Repositories;
 using W3C.Domain.CommonValueObjects;
@@ -23,7 +24,8 @@ public class AdminController(
     INewsRepository newsRepository,
     IInformationMessagesRepository informationMessagesRepository,
     IAdminRepository adminRepository,
-    IRankRepository rankRepository) : ControllerBase
+    IRankRepository rankRepository,
+    IBattleTagResolver battleTagResolver) : ControllerBase
 {
     private readonly IMatchRepository _matchRepository = matchRepository;
     private readonly MatchmakingServiceClient _matchmakingServiceRepository = matchmakingServiceRepository;
@@ -31,6 +33,7 @@ public class AdminController(
     private readonly IInformationMessagesRepository _informationMessagesRepository = informationMessagesRepository;
     private readonly IAdminRepository _adminRepository = adminRepository;
     private readonly IRankRepository _rankRepository = rankRepository;
+    private readonly IBattleTagResolver _battleTagResolver = battleTagResolver;
 
     [HttpGet("health-check")]
     [NoTrace]
@@ -278,7 +281,11 @@ public class AdminController(
     [BearerHasPermissionFilter(Permission = EPermission.Proxies)]
     public async Task<IActionResult> UpdateProxies([FromBody] ProxyUpdate proxyUpdateData, [FromRoute] string tag)
     {
-        await _adminRepository.UpdateProxies(proxyUpdateData, tag);
+        var canonical = await _battleTagResolver.ResolveCanonical(tag);
+        if (canonical == null)
+            return BadRequest(new { error = "user_not_found", input = tag });
+
+        await _adminRepository.UpdateProxies(proxyUpdateData, canonical);
         return Ok();
     }
 
@@ -302,6 +309,11 @@ public class AdminController(
     [BearerHasPermissionFilter(Permission = EPermission.Moderation)]
     public async Task<IActionResult> PutChatBan([FromBody] ChatBanPutDto chatBan)
     {
+        var canonical = await _battleTagResolver.ResolveCanonical(chatBan.battleTag);
+        if (canonical == null)
+            return BadRequest(new { error = "user_not_found", input = chatBan.battleTag });
+
+        chatBan.battleTag = canonical;
         await _adminRepository.PutChatBan(chatBan);
         return Ok();
     }

--- a/W3ChampionsStatisticService/Admin/AdminController.cs
+++ b/W3ChampionsStatisticService/Admin/AdminController.cs
@@ -64,6 +64,11 @@ public class AdminController(
     [BearerHasPermissionFilter(Permission = EPermission.Moderation)]
     public async Task<IActionResult> PostBannedPlayer([FromBody] BannedPlayerReadmodel bannedPlayerReadmodel)
     {
+        var canonical = await _battleTagResolver.ResolveCanonical(bannedPlayerReadmodel.battleTag);
+        if (canonical == null)
+            return BadRequest(new { error = "user_not_found", input = bannedPlayerReadmodel.battleTag });
+
+        bannedPlayerReadmodel.battleTag = canonical;
         await _matchmakingServiceRepository.PostBannedPlayer(bannedPlayerReadmodel);
         return Ok();
     }

--- a/W3ChampionsStatisticService/Clans/ClanController.cs
+++ b/W3ChampionsStatisticService/Clans/ClanController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using W3ChampionsStatisticService.Clans.Commands;
+using W3ChampionsStatisticService.Services;
 using W3ChampionsStatisticService.WebApi.ActionFilters;
 using W3C.Domain.Tracing;
 
@@ -10,9 +11,11 @@ namespace W3ChampionsStatisticService.Clans;
 [Route("api/clans")]
 [Trace]
 public class ClanController(
-    ClanCommandHandler clanCommandHandler) : ControllerBase
+    ClanCommandHandler clanCommandHandler,
+    IBattleTagResolver battleTagResolver) : ControllerBase
 {
     private readonly ClanCommandHandler _clanCommandHandler = clanCommandHandler;
+    private readonly IBattleTagResolver _battleTagResolver = battleTagResolver;
 
     [HttpPost]
     [InjectActingPlayerAuthCode]
@@ -60,7 +63,9 @@ public class ClanController(
         string actingPlayer,
         [FromBody] PlayerDto playerDto)
     {
-        await _clanCommandHandler.InviteToClan(playerDto.PlayerBattleTag, clanId, actingPlayer);
+        var (canonical, error) = await ResolveOrReject(playerDto.PlayerBattleTag);
+        if (error != null) return error;
+        await _clanCommandHandler.InviteToClan(canonical, clanId, actingPlayer);
         return Ok();
     }
 
@@ -71,7 +76,9 @@ public class ClanController(
         string actingPlayer,
         [FromBody] PlayerDto playerDto)
     {
-        await _clanCommandHandler.RevokeInvitationToClan(playerDto.PlayerBattleTag, clanId, actingPlayer);
+        var (canonical, error) = await ResolveOrReject(playerDto.PlayerBattleTag);
+        if (error != null) return error;
+        await _clanCommandHandler.RevokeInvitationToClan(canonical, clanId, actingPlayer);
         return Ok();
     }
 
@@ -82,7 +89,9 @@ public class ClanController(
         string actingPlayer,
         [FromBody] PlayerDto playerDto)
     {
-        var clan = await _clanCommandHandler.SwitchChieftain(playerDto.PlayerBattleTag, clanId, actingPlayer);
+        var (canonical, error) = await ResolveOrReject(playerDto.PlayerBattleTag);
+        if (error != null) return error;
+        var clan = await _clanCommandHandler.SwitchChieftain(canonical, clanId, actingPlayer);
         return Ok(clan);
     }
 
@@ -94,7 +103,9 @@ public class ClanController(
         string actingPlayer,
         [FromBody] PlayerDto playerDto)
     {
-        var clan = await _clanCommandHandler.AddShamanToClan(playerDto.PlayerBattleTag, clanId, actingPlayer);
+        var (canonical, error) = await ResolveOrReject(playerDto.PlayerBattleTag);
+        if (error != null) return error;
+        var clan = await _clanCommandHandler.AddShamanToClan(canonical, clanId, actingPlayer);
         return Ok(clan);
     }
 
@@ -105,7 +116,9 @@ public class ClanController(
         string actingPlayer,
         string shamanId)
     {
-        var clan = await _clanCommandHandler.RemoveShamanFromClan(shamanId, clanId, actingPlayer);
+        var (canonical, error) = await ResolveOrReject(shamanId);
+        if (error != null) return error;
+        var clan = await _clanCommandHandler.RemoveShamanFromClan(canonical, clanId, actingPlayer);
         return Ok(clan);
     }
 
@@ -126,7 +139,9 @@ public class ClanController(
         string actingPlayer,
         string battleTag)
     {
-        var clan = await _clanCommandHandler.KickPlayer(battleTag, clanId, actingPlayer);
+        var (canonical, error) = await ResolveOrReject(battleTag);
+        if (error != null) return error;
+        var clan = await _clanCommandHandler.KickPlayer(canonical, clanId, actingPlayer);
         return Ok(clan);
     }
 
@@ -144,5 +159,15 @@ public class ClanController(
     {
         var clan = await _clanCommandHandler.RejectInvite(clanId, battleTag);
         return Ok(clan);
+    }
+
+    private async Task<(string canonical, IActionResult error)> ResolveOrReject(string input)
+    {
+        var canonical = await _battleTagResolver.ResolveCanonical(input);
+        if (canonical == null)
+            return (null, BadRequest(new { error = "user_not_found", input }));
+        if (canonical != input)
+            return (null, BadRequest(new { error = "non_canonical_battletag", input, canonical }));
+        return (canonical, null);
     }
 }

--- a/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
+++ b/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
@@ -24,7 +24,8 @@ public class WebsiteBackendHub(
     IFriendRequestCache friendRequestCache,
     IPersonalSettingsRepository personalSettingsRepository,
     IFriendCommandHandler friendCommandHandler,
-    TracingService tracingService
+    TracingService tracingService,
+    IBattleTagResolver battleTagResolver
 ) : Hub
 {
     static WebsiteBackendHub()
@@ -52,6 +53,7 @@ public class WebsiteBackendHub(
     private readonly IPersonalSettingsRepository _personalSettingsRepository = personalSettingsRepository;
     private readonly IFriendCommandHandler _friendCommandHandler = friendCommandHandler;
     private readonly TracingService _tracingService = tracingService;
+    private readonly IBattleTagResolver _battleTagResolver = battleTagResolver;
 
 
     [NoTrace]
@@ -118,6 +120,14 @@ public class WebsiteBackendHub(
 
     public async Task MakeFriendRequest(FriendRequest req)
     {
+        var jwtBattleTag = _connections.GetUser(Context.ConnectionId)?.BattleTag;
+        if (jwtBattleTag == null)
+        {
+            await Clients.Caller.SendAsync("BattleTagResolutionError", new { reason = "not_authenticated" });
+            return;
+        }
+        req.Sender = jwtBattleTag;
+
         try
         {
             PersonalSetting personalSetting =
@@ -157,6 +167,14 @@ public class WebsiteBackendHub(
 
     public async Task DeleteOutgoingFriendRequest(FriendRequest req)
     {
+        var jwtBattleTag = _connections.GetUser(Context.ConnectionId)?.BattleTag;
+        if (jwtBattleTag == null)
+        {
+            await Clients.Caller.SendAsync("BattleTagResolutionError", new { reason = "not_authenticated" });
+            return;
+        }
+        req.Sender = jwtBattleTag;
+
         try
         {
             var request = await _friendRequestCache.LoadFriendRequest(req) ?? throw new ValidationException("Could not find a friend request to delete.");
@@ -182,6 +200,14 @@ public class WebsiteBackendHub(
 
     public async Task AcceptIncomingFriendRequest(FriendRequest req)
     {
+        var jwtBattleTag = _connections.GetUser(Context.ConnectionId)?.BattleTag;
+        if (jwtBattleTag == null)
+        {
+            await Clients.Caller.SendAsync("BattleTagResolutionError", new { reason = "not_authenticated" });
+            return;
+        }
+        req.Receiver = jwtBattleTag;
+
         try
         {
             var currentUserFriendlist = await _friendCommandHandler.LoadFriendList(req.Receiver);
@@ -221,6 +247,14 @@ public class WebsiteBackendHub(
 
     public async Task DenyIncomingFriendRequest(FriendRequest req)
     {
+        var jwtBattleTag = _connections.GetUser(Context.ConnectionId)?.BattleTag;
+        if (jwtBattleTag == null)
+        {
+            await Clients.Caller.SendAsync("BattleTagResolutionError", new { reason = "not_authenticated" });
+            return;
+        }
+        req.Receiver = jwtBattleTag;
+
         try
         {
             var request = await _friendRequestCache.LoadFriendRequest(req) ?? throw new ValidationException("Could not find a friend request to deny.");
@@ -246,6 +280,14 @@ public class WebsiteBackendHub(
 
     public async Task BlockIncomingFriendRequest(FriendRequest req)
     {
+        var jwtBattleTag = _connections.GetUser(Context.ConnectionId)?.BattleTag;
+        if (jwtBattleTag == null)
+        {
+            await Clients.Caller.SendAsync("BattleTagResolutionError", new { reason = "not_authenticated" });
+            return;
+        }
+        req.Receiver = jwtBattleTag;
+
         try
         {
             var currentUserFriendlist = await _friendCommandHandler.LoadFriendList(req.Receiver);

--- a/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
+++ b/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
@@ -146,7 +146,7 @@ public class WebsiteBackendHub(
             PersonalSetting personalSetting =
                 await _personalSettingsRepository.Find(req.Receiver) ?? throw new ValidationException($"Player {req.Receiver} not found.");
 
-            if (req.Sender.Equals(req.Receiver, StringComparison.CurrentCultureIgnoreCase))
+            if (req.Sender == req.Receiver)
             {
                 throw new ValidationException("Cannot request yourself as a friend.");
             }

--- a/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
+++ b/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
@@ -128,6 +128,19 @@ public class WebsiteBackendHub(
         }
         req.Sender = jwtBattleTag;
 
+        var canonicalReceiver = await _battleTagResolver.ResolveCanonical(req.Receiver);
+        if (canonicalReceiver == null || canonicalReceiver != req.Receiver)
+        {
+            await Clients.Caller.SendAsync("BattleTagResolutionError", new
+            {
+                reason = canonicalReceiver == null ? "user_not_found" : "non_canonical_battletag",
+                input = req.Receiver,
+                canonical = canonicalReceiver
+            });
+            return;
+        }
+        req.Receiver = canonicalReceiver;
+
         try
         {
             PersonalSetting personalSetting =
@@ -175,6 +188,19 @@ public class WebsiteBackendHub(
         }
         req.Sender = jwtBattleTag;
 
+        var canonicalReceiver = await _battleTagResolver.ResolveCanonical(req.Receiver);
+        if (canonicalReceiver == null || canonicalReceiver != req.Receiver)
+        {
+            await Clients.Caller.SendAsync("BattleTagResolutionError", new
+            {
+                reason = canonicalReceiver == null ? "user_not_found" : "non_canonical_battletag",
+                input = req.Receiver,
+                canonical = canonicalReceiver
+            });
+            return;
+        }
+        req.Receiver = canonicalReceiver;
+
         try
         {
             var request = await _friendRequestCache.LoadFriendRequest(req) ?? throw new ValidationException("Could not find a friend request to delete.");
@@ -207,6 +233,19 @@ public class WebsiteBackendHub(
             return;
         }
         req.Receiver = jwtBattleTag;
+
+        var canonicalSender = await _battleTagResolver.ResolveCanonical(req.Sender);
+        if (canonicalSender == null || canonicalSender != req.Sender)
+        {
+            await Clients.Caller.SendAsync("BattleTagResolutionError", new
+            {
+                reason = canonicalSender == null ? "user_not_found" : "non_canonical_battletag",
+                input = req.Sender,
+                canonical = canonicalSender
+            });
+            return;
+        }
+        req.Sender = canonicalSender;
 
         try
         {
@@ -255,6 +294,19 @@ public class WebsiteBackendHub(
         }
         req.Receiver = jwtBattleTag;
 
+        var canonicalSender = await _battleTagResolver.ResolveCanonical(req.Sender);
+        if (canonicalSender == null || canonicalSender != req.Sender)
+        {
+            await Clients.Caller.SendAsync("BattleTagResolutionError", new
+            {
+                reason = canonicalSender == null ? "user_not_found" : "non_canonical_battletag",
+                input = req.Sender,
+                canonical = canonicalSender
+            });
+            return;
+        }
+        req.Sender = canonicalSender;
+
         try
         {
             var request = await _friendRequestCache.LoadFriendRequest(req) ?? throw new ValidationException("Could not find a friend request to deny.");
@@ -287,6 +339,19 @@ public class WebsiteBackendHub(
             return;
         }
         req.Receiver = jwtBattleTag;
+
+        var canonicalSender = await _battleTagResolver.ResolveCanonical(req.Sender);
+        if (canonicalSender == null || canonicalSender != req.Sender)
+        {
+            await Clients.Caller.SendAsync("BattleTagResolutionError", new
+            {
+                reason = canonicalSender == null ? "user_not_found" : "non_canonical_battletag",
+                input = req.Sender,
+                canonical = canonicalSender
+            });
+            return;
+        }
+        req.Sender = canonicalSender;
 
         try
         {
@@ -324,6 +389,20 @@ public class WebsiteBackendHub(
         {
             return;
         }
+
+        var canonicalBattleTag = await _battleTagResolver.ResolveCanonical(battleTag);
+        if (canonicalBattleTag == null || canonicalBattleTag != battleTag)
+        {
+            await Clients.Caller.SendAsync("BattleTagResolutionError", new
+            {
+                reason = canonicalBattleTag == null ? "user_not_found" : "non_canonical_battletag",
+                input = battleTag,
+                canonical = canonicalBattleTag
+            });
+            return;
+        }
+        battleTag = canonicalBattleTag;
+
         try
         {
             var friendList = await _friendCommandHandler.LoadFriendList(currentUser);
@@ -351,6 +430,20 @@ public class WebsiteBackendHub(
         {
             return;
         }
+
+        var canonicalBattleTag = await _battleTagResolver.ResolveCanonical(battleTag);
+        if (canonicalBattleTag == null || canonicalBattleTag != battleTag)
+        {
+            await Clients.Caller.SendAsync("BattleTagResolutionError", new
+            {
+                reason = canonicalBattleTag == null ? "user_not_found" : "non_canonical_battletag",
+                input = battleTag,
+                canonical = canonicalBattleTag
+            });
+            return;
+        }
+        battleTag = canonicalBattleTag;
+
         try
         {
             var friendList = await _friendCommandHandler.LoadFriendList(currentUser);
@@ -382,6 +475,20 @@ public class WebsiteBackendHub(
         {
             return;
         }
+
+        var canonicalFriend = await _battleTagResolver.ResolveCanonical(friend);
+        if (canonicalFriend == null || canonicalFriend != friend)
+        {
+            await Clients.Caller.SendAsync("BattleTagResolutionError", new
+            {
+                reason = canonicalFriend == null ? "user_not_found" : "non_canonical_battletag",
+                input = friend,
+                canonical = canonicalFriend
+            });
+            return;
+        }
+        friend = canonicalFriend;
+
         try
         {
             var currentUserFriendlist = await _friendCommandHandler.LoadFriendList(currentUser);

--- a/W3ChampionsStatisticService/PersonalSettings/PersonalSettingsController.cs
+++ b/W3ChampionsStatisticService/PersonalSettings/PersonalSettingsController.cs
@@ -29,7 +29,8 @@ public class PersonalSettingsController(
             PersonalSetting setting = await _personalSettingsRepository.Load(battleTag);
             if (setting == null)
             {
-                bool userExists = await _identityServiceClient.UserExists(battleTag);
+                // TEMP: migrated to ResolveCanonical in Task 3b
+                var userExists = await _identityServiceClient.ResolveCanonicalBattleTag(battleTag) != null;
                 if (!userExists)
                 {
                     return NotFound($"Personal settings of {battleTag} not found.");

--- a/W3ChampionsStatisticService/PersonalSettings/PersonalSettingsController.cs
+++ b/W3ChampionsStatisticService/PersonalSettings/PersonalSettingsController.cs
@@ -15,29 +15,27 @@ namespace W3ChampionsStatisticService.PersonalSettings;
 public class PersonalSettingsController(
     IPersonalSettingsRepository personalSettingsRepository,
     PortraitCommandHandler commandHandler,
-    IdentityServiceClient identityServiceClient) : ControllerBase
+    IBattleTagResolver battleTagResolver) : ControllerBase
 {
     private readonly IPersonalSettingsRepository _personalSettingsRepository = personalSettingsRepository;
     private readonly PortraitCommandHandler _commandHandler = commandHandler;
-    private readonly IdentityServiceClient _identityServiceClient = identityServiceClient;
+    private readonly IBattleTagResolver _battleTagResolver = battleTagResolver;
 
     [HttpGet("{battleTag}")]
     public async Task<IActionResult> GetPersonalSetting(string battleTag)
     {
         try
         {
-            PersonalSetting setting = await _personalSettingsRepository.Load(battleTag);
-            if (setting == null)
-            {
-                // TEMP: migrated to ResolveCanonical in Task 3b
-                var userExists = await _identityServiceClient.ResolveCanonicalBattleTag(battleTag) != null;
-                if (!userExists)
-                {
-                    return NotFound($"Personal settings of {battleTag} not found.");
-                }
-                setting = new PersonalSetting(battleTag);
-            }
-            return Ok(setting);
+            var canonical = await _battleTagResolver.ResolveCanonical(battleTag);
+            if (canonical == null)
+                return NotFound();
+
+            // Load (not Find) so that RaceWins is populated from PlayerOverallStats,
+            // preserving the join that the original implementation provided.
+            // Returns null when the document doesn't exist yet; we hand back a
+            // default PersonalSetting in that case without writing to the DB.
+            var settings = await _personalSettingsRepository.Load(canonical);
+            return Ok(settings ?? new PersonalSetting(canonical));
         }
         catch
         {

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
@@ -13,6 +13,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Web;
 
 namespace W3ChampionsStatisticService.PlayerProfiles;
 
@@ -26,7 +27,7 @@ public class PlayersController(
     IClanRepository clanRepository,
     PlayerAkaProvider playerAkaProvider,
     PlayerService playerService,
-    IdentityServiceClient identityServiceClient) : ControllerBase
+    IBattleTagResolver battleTagResolver) : ControllerBase
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;
     private readonly GameModeStatQueryHandler _queryHandler = queryHandler;
@@ -34,7 +35,7 @@ public class PlayersController(
     private readonly IClanRepository _clanRepository = clanRepository;
     private readonly PlayerAkaProvider _playerAkaProvider = playerAkaProvider;
     private readonly PlayerService _playerService = playerService;
-    private readonly IdentityServiceClient _identityServiceClient = identityServiceClient;
+    private readonly IBattleTagResolver _battleTagResolver = battleTagResolver;
 
     [HttpGet("global-search")]
     public async Task<IActionResult> GlobalSearchPlayer(string search, string lastRelevanceId = "", int pageSize = 20)
@@ -47,23 +48,18 @@ public class PlayersController(
     [HttpGet("{battleTag}")]
     public async Task<IActionResult> GetPlayer([FromRoute] string battleTag)
     {
-        PlayerOverallStats player = await _playerRepository.LoadPlayerOverallStats(battleTag);
+        var canonical = await _battleTagResolver.ResolveCanonical(battleTag);
+        if (canonical == null)
+            return NotFound($"Player {battleTag} not found.");
+        if (canonical != battleTag)
+            return RedirectPermanent($"/api/players/{HttpUtility.UrlEncode(canonical)}");
 
+        PlayerOverallStats player = await _playerRepository.LoadPlayerOverallStats(canonical);
         if (player == null)
-        {
-            // TEMP: migrated to ResolveCanonical in Task 3
-            var userExists = await _identityServiceClient.ResolveCanonicalBattleTag(battleTag) != null;
-            if (!userExists)
-            {
-                return NotFound($"Player {battleTag} not found.");
-            }
-            player = PlayerOverallStats.Create(battleTag);
-        }
+            player = PlayerOverallStats.Create(canonical);
 
-        // Akas are stored in cache - preferences for showing akas are stored in DB
-        PersonalSetting settings = await _personalSettingsRepository.LoadOrCreate(battleTag);
-        player.PlayerAkaData = await _playerAkaProvider.GetAkaDataByPreferencesAsync(battleTag, settings);
-
+        PersonalSetting settings = await _personalSettingsRepository.LoadOrCreate(canonical);
+        player.PlayerAkaData = await _playerAkaProvider.GetAkaDataByPreferencesAsync(canonical, settings);
         await _playerRepository.UpsertPlayer(player);
 
         return Ok(player);

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
@@ -51,7 +51,8 @@ public class PlayersController(
 
         if (player == null)
         {
-            bool userExists = await _identityServiceClient.UserExists(battleTag);
+            // TEMP: migrated to ResolveCanonical in Task 3
+            var userExists = await _identityServiceClient.ResolveCanonicalBattleTag(battleTag) != null;
             if (!userExists)
             {
                 return NotFound($"Player {battleTag} not found.");

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -214,6 +214,7 @@ builder.Services.AddInterceptedTransient<PlayerStatisticsService>();
 builder.Services.AddInterceptedTransient<PlayerService>();
 builder.Services.AddInterceptedTransient<MatchService>();
 builder.Services.AddInterceptedTransient<IdentityServiceClient>();
+builder.Services.AddInterceptedTransient<IBattleTagResolver, BattleTagResolver>();
 builder.Services.AddInterceptedTransient<ILogsRepository, LogsRepository>();
 
 // Friends

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -195,7 +195,6 @@ builder.Services.AddInterceptedTransient<TurnstileVerificationFilter>();
 
 // Turnstile service for captcha verification
 builder.Services.AddHttpClient<ITurnstileService, TurnstileService>();
-builder.Services.AddMemoryCache();
 
 // Rate limiting services
 builder.Services.AddInterceptedSingleton<W3ChampionsStatisticService.RateLimiting.Repositories.IApiTokenRepository, W3ChampionsStatisticService.RateLimiting.Repositories.ApiTokenRepository>();

--- a/W3ChampionsStatisticService/Rewards/RewardsController.cs
+++ b/W3ChampionsStatisticService/Rewards/RewardsController.cs
@@ -1,8 +1,11 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using W3C.Contracts.Admin.Permission;
 using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.Rewards.Portraits;
+using W3ChampionsStatisticService.Services;
 using W3ChampionsStatisticService.WebApi.ActionFilters;
 using W3C.Domain.Tracing;
 
@@ -13,15 +16,20 @@ namespace W3ChampionsStatisticService.Rewards;
 [Trace]
 public class RewardsController(
     IPortraitRepository portraitRepository,
-    PortraitCommandHandler portraitCommandHandler) : ControllerBase
+    PortraitCommandHandler portraitCommandHandler,
+    IBattleTagResolver battleTagResolver) : ControllerBase
 {
     private readonly PortraitCommandHandler _portraitCommandHandler = portraitCommandHandler;
     private readonly IPortraitRepository _portraitRepository = portraitRepository;
+    private readonly IBattleTagResolver _battleTagResolver = battleTagResolver;
 
     [HttpPut("portraits")]
     [BearerHasPermissionFilter(Permission = EPermission.Content)]
     public async Task<IActionResult> PutPortraits([FromBody] PortraitsCommand command)
     {
+        var rejection = await ValidateBnetTagsCanonical(command.BnetTags);
+        if (rejection != null) return rejection;
+
         await _portraitCommandHandler.UpsertSpecialPortraits(command);
         return Ok();
     }
@@ -30,8 +38,24 @@ public class RewardsController(
     [BearerHasPermissionFilter(Permission = EPermission.Content)]
     public async Task<IActionResult> DeletePortraits([FromBody] PortraitsCommand command)
     {
+        var rejection = await ValidateBnetTagsCanonical(command.BnetTags);
+        if (rejection != null) return rejection;
+
         await _portraitCommandHandler.DeleteSpecialPortraits(command);
         return Ok();
+    }
+
+    private async Task<IActionResult> ValidateBnetTagsCanonical(List<string> bnetTags)
+    {
+        if (bnetTags == null || bnetTags.Count == 0) return null;
+        var resolution = await _battleTagResolver.ResolveCanonicalBatch(bnetTags);
+        var failures = bnetTags
+            .Select(i => new { input = i, canonical = resolution[i] })
+            .Where(r => r.canonical == null || r.canonical != r.input)
+            .ToList();
+        if (failures.Count > 0)
+            return BadRequest(new { error = "non_canonical_or_unknown_battletags", details = failures });
+        return null;
     }
 
     [HttpGet("portrait-definitions")]

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -87,12 +87,12 @@ public class PatreonDriftDetectionService(
         {
             if (patreonUserIdToAccountLink.TryGetValue(member.PatreonUserId, out var accountLink))
             {
-                patreonByBattleTag[accountLink.BattleTag.ToLowerInvariant()] = member;
+                patreonByBattleTag[accountLink.BattleTag] = member;
             }
         }
 
         var internalByUserId = internalAssociations
-            .GroupBy(a => a.UserId.ToLowerInvariant())
+            .GroupBy(a => a.UserId)
             .ToDictionary(g => g.Key, g => g.ToList());
 
         // Find missing members (in Patreon but not in our system)

--- a/W3ChampionsStatisticService/Services/BattleTagResolver.cs
+++ b/W3ChampionsStatisticService/Services/BattleTagResolver.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using W3C.Domain.Tracing;
+
+namespace W3ChampionsStatisticService.Services;
+
+[Trace]
+public class BattleTagResolver(IdentityServiceClient identityClient, IMemoryCache cache) : IBattleTagResolver
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+    private const string CacheKeyPrefix = "battletag-canonical:";
+
+    private readonly IdentityServiceClient _identityClient = identityClient;
+    private readonly IMemoryCache _cache = cache;
+
+    public async Task<string> ResolveCanonical(string input)
+    {
+        if (input == null) return null;
+        var cacheKey = CacheKeyPrefix + input.ToLowerInvariant();
+        if (_cache.TryGetValue<string>(cacheKey, out var cached))
+            return cached;
+
+        var canonical = await _identityClient.ResolveCanonicalBattleTag(input);
+        _cache.Set(cacheKey, canonical, CacheTtl);
+        return canonical;
+    }
+
+    public async Task<IDictionary<string, string>> ResolveCanonicalBatch(IEnumerable<string> inputs)
+    {
+        var inputList = inputs?.ToList() ?? new List<string>();
+        var tasks = inputList.Select(async input => new { input, canonical = await ResolveCanonical(input) });
+        var resolved = await Task.WhenAll(tasks);
+        return resolved.ToDictionary(r => r.input, r => r.canonical);
+    }
+}

--- a/W3ChampionsStatisticService/Services/BattleTagResolver.cs
+++ b/W3ChampionsStatisticService/Services/BattleTagResolver.cs
@@ -30,8 +30,8 @@ public class BattleTagResolver(IdentityServiceClient identityClient, IMemoryCach
 
     public async Task<IDictionary<string, string>> ResolveCanonicalBatch(IEnumerable<string> inputs)
     {
-        var inputList = inputs?.ToList() ?? new List<string>();
-        var tasks = inputList.Select(async input => new { input, canonical = await ResolveCanonical(input) });
+        var distinctInputs = inputs?.Where(i => i != null).Distinct().ToList() ?? new List<string>();
+        var tasks = distinctInputs.Select(async input => new { input, canonical = await ResolveCanonical(input) });
         var resolved = await Task.WhenAll(tasks);
         return resolved.ToDictionary(r => r.input, r => r.canonical);
     }

--- a/W3ChampionsStatisticService/Services/IBattleTagResolver.cs
+++ b/W3ChampionsStatisticService/Services/IBattleTagResolver.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace W3ChampionsStatisticService.Services;
+
+public interface IBattleTagResolver
+{
+    /// <summary>
+    /// Resolves an arbitrary-cased BattleTag to its canonical form via identification-service.
+    /// Returns canonical-cased BattleTag if the user exists; null if not found.
+    /// Cached for 5 minutes (positive and negative results).
+    /// </summary>
+    Task<string> ResolveCanonical(string input);
+
+    /// <summary>
+    /// Bulk variant for admin endpoints that take BattleTag lists.
+    /// Returns a map from input → canonical (null if not found).
+    /// </summary>
+    /// <remarks>
+    /// IMPLEMENTATION NOTE: identification-service has no batch /api/users/exists endpoint.
+    /// This method makes N parallel single-tag calls. For N &gt; ~50, consider adding a
+    /// batch endpoint to identification-service. TODO: track via follow-up issue.
+    /// </remarks>
+    Task<IDictionary<string, string>> ResolveCanonicalBatch(IEnumerable<string> inputs);
+}

--- a/W3ChampionsStatisticService/Services/IdentityServiceClient.cs
+++ b/W3ChampionsStatisticService/Services/IdentityServiceClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -12,14 +12,15 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Services;
 
 [Trace]
-public class IdentityServiceClient()
+public class IdentityServiceClient(HttpClient httpClient = null)
 {
     private static readonly string IdentityApiUrl = Environment.GetEnvironmentVariable("IDENTIFICATION_SERVICE_URI") ?? "https://identification-service.test.w3champions.com";
 
+    private readonly HttpClient _httpClient = httpClient ?? new HttpClient();
+
     public async Task<List<Permission>> GetPermissions([NoTrace] string authorization)
     {
-        var httpClient = new HttpClient();
-        var response = await httpClient.GetAsync($"{IdentityApiUrl}/api/permissions?authorization={authorization}");
+        var response = await _httpClient.GetAsync($"{IdentityApiUrl}/api/permissions?authorization={authorization}");
         var content = await response.Content.ReadAsStringAsync();
         if (string.IsNullOrEmpty(content)) return null;
         if (response.StatusCode != HttpStatusCode.OK)
@@ -37,12 +38,11 @@ public class IdentityServiceClient()
 
     public async Task<HttpStatusCode> AddAdmin(Permission permission, [NoTrace] string authorization)
     {
-        var httpClient = new HttpClient();
         var serializedObject = JsonConvert.SerializeObject(permission);
         var buffer = System.Text.Encoding.UTF8.GetBytes(serializedObject);
         var byteContent = new ByteArrayContent(buffer);
         byteContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-        var response = await httpClient.PostAsync($"{IdentityApiUrl}/api/permissions?authorization={authorization}", byteContent);
+        var response = await _httpClient.PostAsync($"{IdentityApiUrl}/api/permissions?authorization={authorization}", byteContent);
         if (response.StatusCode != HttpStatusCode.OK)
         {
             var content = await response.Content.ReadAsStringAsync();
@@ -53,12 +53,11 @@ public class IdentityServiceClient()
 
     public async Task<HttpStatusCode> EditAdmin(Permission permission, [NoTrace] string authorization)
     {
-        var httpClient = new HttpClient();
         var serializedObject = JsonConvert.SerializeObject(permission);
         var buffer = System.Text.Encoding.UTF8.GetBytes(serializedObject);
         var byteContent = new ByteArrayContent(buffer);
         byteContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-        var response = await httpClient.PutAsync($"{IdentityApiUrl}/api/permissions?authorization={authorization}", byteContent);
+        var response = await _httpClient.PutAsync($"{IdentityApiUrl}/api/permissions?authorization={authorization}", byteContent);
         if (response.StatusCode != HttpStatusCode.OK)
         {
             var content = await response.Content.ReadAsStringAsync();
@@ -69,9 +68,8 @@ public class IdentityServiceClient()
 
     public async Task<HttpStatusCode> DeleteAdmin(string id, [NoTrace] string authorization)
     {
-        var httpClient = new HttpClient();
         var encodedTag = HttpUtility.UrlEncode(id);
-        var response = await httpClient.DeleteAsync($"{IdentityApiUrl}/api/permissions?id={encodedTag}&authorization={authorization}");
+        var response = await _httpClient.DeleteAsync($"{IdentityApiUrl}/api/permissions?id={encodedTag}&authorization={authorization}");
         if (response.StatusCode != HttpStatusCode.OK)
         {
             var content = await response.Content.ReadAsStringAsync();
@@ -80,12 +78,30 @@ public class IdentityServiceClient()
         return response.StatusCode;
     }
 
-    public async Task<bool> UserExists(string battletag)
+    // UserExists is retired. Both call sites (PlayersController.GetPlayer and
+    // PersonalSettingsController.GetPersonalSetting) migrate to ResolveCanonicalBattleTag
+    // in this same change. The bool-returning shape is gone; callers explicitly handle
+    // the null/canonical/non-canonical cases.
+
+    /// <summary>
+    /// Resolves an arbitrary-cased BattleTag to its canonical form by calling
+    /// identification-service's /api/users/exists. Returns null if the user doesn't exist.
+    /// </summary>
+    public virtual async Task<string> ResolveCanonicalBattleTag(string battletag)
     {
-        var httpClient = new HttpClient();
+        if (battletag == null) return null;
         var encodedTag = HttpUtility.UrlEncode(battletag);
-        string url = $"{IdentityApiUrl}/api/users/exists?id={encodedTag}";
-        var response = await httpClient.GetAsync(url);
-        return response.StatusCode == HttpStatusCode.OK;
+        var response = await _httpClient.GetAsync($"{IdentityApiUrl}/api/users/exists?id={encodedTag}");
+        if (response.StatusCode == HttpStatusCode.NotFound) return null;
+        if (response.StatusCode != HttpStatusCode.OK)
+            throw new HttpRequestException($"Unexpected status from identification-service: {response.StatusCode}", null, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync();
+        var body = JsonConvert.DeserializeObject<UserExistsResponse>(content);
+        return body?.Id;
+    }
+
+    private class UserExistsResponse
+    {
+        public string Id { get; set; }
     }
 }

--- a/W3ChampionsStatisticService/Tournaments/TournamentsController.cs
+++ b/W3ChampionsStatisticService/Tournaments/TournamentsController.cs
@@ -6,6 +6,7 @@ using W3ChampionsStatisticService.WebApi.ActionFilters;
 using W3ChampionsStatisticService.Ports;
 using W3C.Contracts.Admin.Permission;
 using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.Services;
 
 namespace W3ChampionsStatisticService.Tournaments;
 
@@ -14,11 +15,13 @@ namespace W3ChampionsStatisticService.Tournaments;
 [Trace]
 public class TournamentsController(
     MatchmakingServiceClient matchmakingServiceRepository,
-    IPersonalSettingsRepository personalSettingsRepository
+    IPersonalSettingsRepository personalSettingsRepository,
+    IBattleTagResolver battleTagResolver
     ) : ControllerBase
 {
     private readonly IPersonalSettingsRepository _personalSettingsRepository = personalSettingsRepository;
     private readonly MatchmakingServiceClient _matchmakingServiceRepository = matchmakingServiceRepository;
+    private readonly IBattleTagResolver _battleTagResolver = battleTagResolver;
 
     [HttpGet("")]
     public async Task<IActionResult> GetTournaments()
@@ -68,8 +71,14 @@ public class TournamentsController(
     [BearerHasPermissionFilter(Permission = EPermission.Tournaments)]
     public async Task<IActionResult> RegisterPlayer(string id, [FromBody] RegisterPlayerBody body)
     {
-        var personalSetting = await _personalSettingsRepository.LoadOrCreate(body.BattleTag);
-        var tournament = await _matchmakingServiceRepository.RegisterPlayer(id, body.BattleTag, body.Race, personalSetting.CountryCode);
+        var canonical = await _battleTagResolver.ResolveCanonical(body.BattleTag);
+        if (canonical == null)
+            return BadRequest(new { error = "user_not_found", input = body.BattleTag });
+        if (canonical != body.BattleTag)
+            return BadRequest(new { error = "non_canonical_battletag", input = body.BattleTag, canonical });
+
+        var personalSetting = await _personalSettingsRepository.LoadOrCreate(canonical);
+        var tournament = await _matchmakingServiceRepository.RegisterPlayer(id, canonical, body.Race, personalSetting.CountryCode);
         return Ok(tournament);
     }
 
@@ -77,7 +86,13 @@ public class TournamentsController(
     [BearerHasPermissionFilter(Permission = EPermission.Tournaments)]
     public async Task<IActionResult> UnregisterPlayer(string id, [FromBody] UnregisterPlayerBody body)
     {
-        var tournament = await _matchmakingServiceRepository.UnregisterPlayer(id, body.BattleTag);
+        var canonical = await _battleTagResolver.ResolveCanonical(body.BattleTag);
+        if (canonical == null)
+            return BadRequest(new { error = "user_not_found", input = body.BattleTag });
+        if (canonical != body.BattleTag)
+            return BadRequest(new { error = "non_canonical_battletag", input = body.BattleTag, canonical });
+
+        var tournament = await _matchmakingServiceRepository.UnregisterPlayer(id, canonical);
         return Ok(tournament);
     }
 

--- a/WC3ChampionsStatisticService.UnitTests/Hubs/WebsiteBackendHubTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Hubs/WebsiteBackendHubTests.cs
@@ -121,6 +121,11 @@ public class WebsiteBackendHubTests
         mockCaller = new Mock<ISingleClientProxy>();
         mockClients.Setup(clients => clients.Caller).Returns(mockCaller.Object);
         _battleTagResolverMock = new Mock<IBattleTagResolver>();
+        // Default: every BattleTag resolves as canonical (returns input unchanged).
+        // Individual tests override this for non-canonical or not-found scenarios.
+        _battleTagResolverMock
+            .Setup(r => r.ResolveCanonical(It.IsAny<string>()))
+            .ReturnsAsync((string input) => input);
     }
 
     private WebsiteBackendHub CreateHub(IFriendCommandHandler friendCommandHandler)
@@ -362,6 +367,11 @@ public class WebsiteBackendHubTests
             .Setup(r => r.Find(It.IsAny<string>()))
             .ReturnsAsync(new PersonalSetting("Receiver#9999"));
 
+        // Receiver is canonical so canonicalization passes through
+        _battleTagResolverMock
+            .Setup(r => r.ResolveCanonical("Receiver#9999"))
+            .ReturnsAsync("Receiver#9999");
+
         var hub = CreateHub(friendCommandHandlerMock.Object);
         SetHubContext(hub, "connection-id-1");
         connections.Add("connection-id-1", new WebSocketUser { BattleTag = "JwtUser#1234", ConnectionId = "connection-id-1" });
@@ -380,6 +390,62 @@ public class WebsiteBackendHubTests
         // Assert: Sender must be overwritten with JWT BattleTag
         Assert.IsNotNull(capturedReq, "CreateFriendRequest should have been called.");
         Assert.AreEqual("JwtUser#1234", capturedReq.Sender, "Sender must be overwritten with JWT BattleTag.");
+    }
+
+    [Test]
+    public async Task MakeFriendRequest_NonCanonicalReceiver_EmitsErrorEvent()
+    {
+        // Arrange: client sends a non-canonical (lowercase) Receiver
+        IFriendCommandHandler friendCommandHandler = new TestFriendCommandHandler(friendRepository, friendListCache, friendRequestCache);
+
+        _battleTagResolverMock
+            .Setup(r => r.ResolveCanonical("torren#11438"))
+            .ReturnsAsync("TORREN#11438"); // canonical differs — non-canonical input
+
+        var hub = CreateHub(friendCommandHandler);
+        SetHubContext(hub, "connection-id-1");
+        connections.Add("connection-id-1", new WebSocketUser { BattleTag = "Sender#1234", ConnectionId = "connection-id-1" });
+
+        var req = new FriendRequest("Sender#1234", "torren#11438");
+
+        // Act
+        await hub.MakeFriendRequest(req);
+
+        // Assert: error event emitted, handler NOT called
+        mockCaller.Verify(c => c.SendCoreAsync("BattleTagResolutionError", It.IsAny<object[]>(), default), Times.Once);
+    }
+
+    [Test]
+    public async Task MakeFriendRequest_CanonicalReceiver_ProceedsToCreate()
+    {
+        // Arrange: client sends a properly-canonical Receiver
+        var friendCommandHandlerMock = new Mock<IFriendCommandHandler>();
+        friendCommandHandlerMock
+            .Setup(h => h.LoadFriendList(It.IsAny<string>()))
+            .ReturnsAsync((string bt) => new Friendlist(bt));
+        friendCommandHandlerMock
+            .Setup(h => h.CreateFriendRequest(It.IsAny<FriendRequest>()))
+            .Returns(Task.CompletedTask);
+
+        personalSettingsRepo
+            .Setup(r => r.Find(It.IsAny<string>()))
+            .ReturnsAsync(new PersonalSetting("TORREN#11438"));
+
+        _battleTagResolverMock
+            .Setup(r => r.ResolveCanonical("TORREN#11438"))
+            .ReturnsAsync("TORREN#11438"); // canonical matches input — passes through
+
+        var hub = CreateHub(friendCommandHandlerMock.Object);
+        SetHubContext(hub, "connection-id-1");
+        connections.Add("connection-id-1", new WebSocketUser { BattleTag = "Sender#1234", ConnectionId = "connection-id-1" });
+
+        var req = new FriendRequest("Sender#1234", "TORREN#11438");
+
+        // Act
+        await hub.MakeFriendRequest(req);
+
+        // Assert: CreateFriendRequest was called (flow proceeded)
+        friendCommandHandlerMock.Verify(h => h.CreateFriendRequest(It.IsAny<FriendRequest>()), Times.Once);
     }
 
     // Helper mock for HubCallerContext

--- a/WC3ChampionsStatisticService.UnitTests/Hubs/WebsiteBackendHubTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Hubs/WebsiteBackendHubTests.cs
@@ -104,6 +104,7 @@ public class WebsiteBackendHubTests
     private TracingService tracingService;
     private Mock<IHubCallerClients> mockClients;
     private Mock<ISingleClientProxy> mockCaller;
+    private Mock<IBattleTagResolver> _battleTagResolverMock;
 
     [SetUp]
     public void SetUp()
@@ -119,6 +120,7 @@ public class WebsiteBackendHubTests
         mockClients = new Mock<IHubCallerClients>();
         mockCaller = new Mock<ISingleClientProxy>();
         mockClients.Setup(clients => clients.Caller).Returns(mockCaller.Object);
+        _battleTagResolverMock = new Mock<IBattleTagResolver>();
     }
 
     private WebsiteBackendHub CreateHub(IFriendCommandHandler friendCommandHandler)
@@ -130,7 +132,8 @@ public class WebsiteBackendHubTests
             friendRequestCache,
             personalSettingsRepo.Object,
             friendCommandHandler,
-            tracingService
+            tracingService,
+            _battleTagResolverMock.Object
         );
         typeof(Hub).GetProperty("Clients").SetValue(hub, mockClients.Object);
         return hub;
@@ -344,6 +347,39 @@ public class WebsiteBackendHubTests
                 Assert.That(reqInCache3, Is.Null);
                 break;
         }
+    }
+
+    [Test]
+    public async Task MakeFriendRequest_OverwritesPayloadSenderWithJwtBattleTag()
+    {
+        // Arrange: attacker sends a request claiming to be "Impersonated#5678", but JWT says "JwtUser#1234"
+        var friendCommandHandlerMock = new Mock<IFriendCommandHandler>();
+        friendCommandHandlerMock
+            .Setup(h => h.LoadFriendList(It.IsAny<string>()))
+            .ReturnsAsync((string bt) => new Friendlist(bt));
+
+        personalSettingsRepo
+            .Setup(r => r.Find(It.IsAny<string>()))
+            .ReturnsAsync(new PersonalSetting("Receiver#9999"));
+
+        var hub = CreateHub(friendCommandHandlerMock.Object);
+        SetHubContext(hub, "connection-id-1");
+        connections.Add("connection-id-1", new WebSocketUser { BattleTag = "JwtUser#1234", ConnectionId = "connection-id-1" });
+
+        FriendRequest capturedReq = null;
+        friendCommandHandlerMock
+            .Setup(h => h.CreateFriendRequest(It.IsAny<FriendRequest>()))
+            .Callback<FriendRequest>(r => capturedReq = r)
+            .Returns(Task.CompletedTask);
+
+        var req = new FriendRequest("Impersonated#5678", "Receiver#9999"); // attacker-controllable Sender
+
+        // Act
+        await hub.MakeFriendRequest(req);
+
+        // Assert: Sender must be overwritten with JWT BattleTag
+        Assert.IsNotNull(capturedReq, "CreateFriendRequest should have been called.");
+        Assert.AreEqual("JwtUser#1234", capturedReq.Sender, "Sender must be overwritten with JWT BattleTag.");
     }
 
     // Helper mock for HubCallerContext

--- a/WC3ChampionsStatisticService.UnitTests/Hubs/WebsiteBackendHubTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Hubs/WebsiteBackendHubTests.cs
@@ -416,6 +416,246 @@ public class WebsiteBackendHubTests
     }
 
     [Test]
+    public async Task AcceptIncomingFriendRequest_OverwritesPayloadReceiverWithJwtBattleTag()
+    {
+        // Arrange: attacker sends a request with forged Receiver, JWT says "JwtUser#1234"
+        var friendCommandHandlerMock = new Mock<IFriendCommandHandler>();
+        friendCommandHandlerMock
+            .Setup(h => h.LoadFriendList(It.IsAny<string>()))
+            .ReturnsAsync((string bt) => new Friendlist(bt));
+        friendCommandHandlerMock
+            .Setup(h => h.AddFriend(It.IsAny<Friendlist>(), It.IsAny<string>()))
+            .ReturnsAsync((Friendlist fl, string bt) => fl);
+        friendCommandHandlerMock
+            .Setup(h => h.DeleteFriendRequest(It.IsAny<FriendRequest>()))
+            .Returns(Task.CompletedTask);
+
+        // Use a mock IFriendRequestCache so we can fully control LoadFriendRequest
+        var friendRequestCacheMock = new Mock<IFriendRequestCache>();
+
+        // The pinned req will have {Sender="Sender#9999", Receiver="JwtUser#1234"}
+        var storedReq = new FriendRequest("Sender#9999", "JwtUser#1234");
+        // Return the stored request when the correct (JWT-pinned) parameters are used
+        friendRequestCacheMock
+            .Setup(c => c.LoadFriendRequest(It.IsAny<FriendRequest>()))
+            .ReturnsAsync((FriendRequest r) =>
+                r.Sender == "Sender#9999" && r.Receiver == "JwtUser#1234" ? storedReq : null);
+        friendRequestCacheMock
+            .Setup(c => c.LoadSentFriendRequests(It.IsAny<string>()))
+            .ReturnsAsync(new System.Collections.Generic.List<FriendRequest>());
+        friendRequestCacheMock
+            .Setup(c => c.LoadReceivedFriendRequests(It.IsAny<string>()))
+            .ReturnsAsync(new System.Collections.Generic.List<FriendRequest>());
+
+        // Sender is canonical so canonicalization passes through
+        _battleTagResolverMock
+            .Setup(r => r.ResolveCanonical("Sender#9999"))
+            .ReturnsAsync("Sender#9999");
+
+        // Build hub with the mock IFriendRequestCache instead of friendRequestCache
+        var hub = new WebsiteBackendHub(
+            authService.Object,
+            connections,
+            contextAccessor.Object,
+            friendRequestCacheMock.Object,
+            personalSettingsRepo.Object,
+            friendCommandHandlerMock.Object,
+            tracingService,
+            _battleTagResolverMock.Object
+        );
+        typeof(Hub).GetProperty("Clients").SetValue(hub, mockClients.Object);
+        SetHubContext(hub, "connection-id-1");
+        connections.Add("connection-id-1", new WebSocketUser { BattleTag = "JwtUser#1234", ConnectionId = "connection-id-1" });
+
+        var req = new FriendRequest("Sender#9999", "Impersonated#5678"); // forged Receiver
+
+        // Act
+        await hub.AcceptIncomingFriendRequest(req);
+
+        // Assert: LoadFriendRequest was called with the JWT-pinned Receiver (Sender#9999 + JwtUser#1234)
+        // If the Receiver was NOT pinned (still "Impersonated#5678"), the mock returns null and
+        // AcceptIncomingFriendRequest throws ValidationException — success response would not be sent.
+        friendRequestCacheMock.Verify(
+            c => c.LoadFriendRequest(It.Is<FriendRequest>(r => r.Sender == "Sender#9999" && r.Receiver == "JwtUser#1234")),
+            Times.Once,
+            "LoadFriendRequest must be called with the JWT-pinned Receiver."
+        );
+    }
+
+    [Test]
+    public async Task DenyIncomingFriendRequest_OverwritesPayloadReceiverWithJwtBattleTag()
+    {
+        // Arrange: attacker sends a request with forged Receiver, JWT says "JwtUser#1234"
+        var friendCommandHandlerMock = new Mock<IFriendCommandHandler>();
+        friendCommandHandlerMock
+            .Setup(h => h.LoadFriendList(It.IsAny<string>()))
+            .ReturnsAsync((string bt) => new Friendlist(bt));
+        friendCommandHandlerMock
+            .Setup(h => h.DeleteFriendRequest(It.IsAny<FriendRequest>()))
+            .Returns(Task.CompletedTask);
+
+        var friendRequestCacheMock = new Mock<IFriendRequestCache>();
+        var storedReq = new FriendRequest("Sender#9999", "JwtUser#1234");
+        friendRequestCacheMock
+            .Setup(c => c.LoadSentFriendRequests(It.IsAny<string>()))
+            .ReturnsAsync(new System.Collections.Generic.List<FriendRequest>());
+        friendRequestCacheMock
+            .Setup(c => c.LoadReceivedFriendRequests(It.IsAny<string>()))
+            .ReturnsAsync(new System.Collections.Generic.List<FriendRequest>());
+        friendRequestCacheMock
+            .Setup(c => c.LoadFriendRequest(It.IsAny<FriendRequest>()))
+            .ReturnsAsync((FriendRequest r) =>
+                r.Sender == "Sender#9999" && r.Receiver == "JwtUser#1234" ? storedReq : null);
+
+        _battleTagResolverMock
+            .Setup(r => r.ResolveCanonical("Sender#9999"))
+            .ReturnsAsync("Sender#9999");
+
+        var hub = new WebsiteBackendHub(
+            authService.Object,
+            connections,
+            contextAccessor.Object,
+            friendRequestCacheMock.Object,
+            personalSettingsRepo.Object,
+            friendCommandHandlerMock.Object,
+            tracingService,
+            _battleTagResolverMock.Object
+        );
+        typeof(Hub).GetProperty("Clients").SetValue(hub, mockClients.Object);
+        SetHubContext(hub, "connection-id-1");
+        connections.Add("connection-id-1", new WebSocketUser { BattleTag = "JwtUser#1234", ConnectionId = "connection-id-1" });
+
+        var req = new FriendRequest("Sender#9999", "Impersonated#5678"); // forged Receiver
+
+        // Act
+        await hub.DenyIncomingFriendRequest(req);
+
+        // Assert: LoadFriendRequest was called with the JWT-pinned Receiver
+        // If the Receiver was NOT pinned (still "Impersonated#5678"), the mock returns null and
+        // DenyIncomingFriendRequest throws ValidationException — the success path is not reached.
+        friendRequestCacheMock.Verify(
+            c => c.LoadFriendRequest(It.Is<FriendRequest>(r => r.Sender == "Sender#9999" && r.Receiver == "JwtUser#1234")),
+            Times.Once,
+            "LoadFriendRequest must be called with the JWT-pinned Receiver."
+        );
+    }
+
+    [Test]
+    public async Task BlockIncomingFriendRequest_OverwritesPayloadReceiverWithJwtBattleTag()
+    {
+        // Arrange: attacker sends a request with forged Receiver, JWT says "JwtUser#1234"
+        var friendCommandHandlerMock = new Mock<IFriendCommandHandler>();
+        friendCommandHandlerMock
+            .Setup(h => h.LoadFriendList(It.IsAny<string>()))
+            .ReturnsAsync((string bt) => new Friendlist(bt));
+        friendCommandHandlerMock
+            .Setup(h => h.UpsertFriendList(It.IsAny<Friendlist>()))
+            .Returns(Task.CompletedTask);
+        friendCommandHandlerMock
+            .Setup(h => h.DeleteFriendRequest(It.IsAny<FriendRequest>()))
+            .Returns(Task.CompletedTask);
+
+        var friendRequestCacheMock = new Mock<IFriendRequestCache>();
+        var storedReq = new FriendRequest("Sender#9999", "JwtUser#1234");
+        friendRequestCacheMock
+            .Setup(c => c.LoadSentFriendRequests(It.IsAny<string>()))
+            .ReturnsAsync(new System.Collections.Generic.List<FriendRequest>());
+        friendRequestCacheMock
+            .Setup(c => c.LoadReceivedFriendRequests(It.IsAny<string>()))
+            .ReturnsAsync(new System.Collections.Generic.List<FriendRequest>());
+        friendRequestCacheMock
+            .Setup(c => c.LoadFriendRequest(It.IsAny<FriendRequest>()))
+            .ReturnsAsync((FriendRequest r) =>
+                r.Sender == "Sender#9999" && r.Receiver == "JwtUser#1234" ? storedReq : null);
+
+        _battleTagResolverMock
+            .Setup(r => r.ResolveCanonical("Sender#9999"))
+            .ReturnsAsync("Sender#9999");
+
+        var hub = new WebsiteBackendHub(
+            authService.Object,
+            connections,
+            contextAccessor.Object,
+            friendRequestCacheMock.Object,
+            personalSettingsRepo.Object,
+            friendCommandHandlerMock.Object,
+            tracingService,
+            _battleTagResolverMock.Object
+        );
+        typeof(Hub).GetProperty("Clients").SetValue(hub, mockClients.Object);
+        SetHubContext(hub, "connection-id-1");
+        connections.Add("connection-id-1", new WebSocketUser { BattleTag = "JwtUser#1234", ConnectionId = "connection-id-1" });
+
+        var req = new FriendRequest("Sender#9999", "Impersonated#5678"); // forged Receiver
+
+        // Act
+        await hub.BlockIncomingFriendRequest(req);
+
+        // Assert: LoadFriendRequest was called with the JWT-pinned Receiver
+        friendRequestCacheMock.Verify(
+            c => c.LoadFriendRequest(It.Is<FriendRequest>(r => r.Sender == "Sender#9999" && r.Receiver == "JwtUser#1234")),
+            Times.Once,
+            "LoadFriendRequest must be called with the JWT-pinned Receiver."
+        );
+    }
+
+    [Test]
+    public async Task DeleteOutgoingFriendRequest_OverwritesPayloadSenderWithJwtBattleTag()
+    {
+        // Arrange: attacker sends a request with forged Sender, JWT says "JwtUser#1234"
+        var friendCommandHandlerMock = new Mock<IFriendCommandHandler>();
+        friendCommandHandlerMock
+            .Setup(h => h.LoadFriendList(It.IsAny<string>()))
+            .ReturnsAsync((string bt) => new Friendlist(bt));
+        friendCommandHandlerMock
+            .Setup(h => h.DeleteFriendRequest(It.IsAny<FriendRequest>()))
+            .Returns(Task.CompletedTask);
+
+        var friendRequestCacheMock = new Mock<IFriendRequestCache>();
+        var storedReq = new FriendRequest("JwtUser#1234", "Receiver#9999");
+        friendRequestCacheMock
+            .Setup(c => c.LoadSentFriendRequests(It.IsAny<string>()))
+            .ReturnsAsync(new System.Collections.Generic.List<FriendRequest>());
+        friendRequestCacheMock
+            .Setup(c => c.LoadReceivedFriendRequests(It.IsAny<string>()))
+            .ReturnsAsync(new System.Collections.Generic.List<FriendRequest>());
+        friendRequestCacheMock
+            .Setup(c => c.LoadFriendRequest(It.IsAny<FriendRequest>()))
+            .ReturnsAsync((FriendRequest r) =>
+                r.Sender == "JwtUser#1234" && r.Receiver == "Receiver#9999" ? storedReq : null);
+
+        _battleTagResolverMock
+            .Setup(r => r.ResolveCanonical("Receiver#9999"))
+            .ReturnsAsync("Receiver#9999");
+
+        var hub = new WebsiteBackendHub(
+            authService.Object,
+            connections,
+            contextAccessor.Object,
+            friendRequestCacheMock.Object,
+            personalSettingsRepo.Object,
+            friendCommandHandlerMock.Object,
+            tracingService,
+            _battleTagResolverMock.Object
+        );
+        typeof(Hub).GetProperty("Clients").SetValue(hub, mockClients.Object);
+        SetHubContext(hub, "connection-id-1");
+        connections.Add("connection-id-1", new WebSocketUser { BattleTag = "JwtUser#1234", ConnectionId = "connection-id-1" });
+
+        var req = new FriendRequest("Impersonated#5678", "Receiver#9999"); // forged Sender
+
+        // Act
+        await hub.DeleteOutgoingFriendRequest(req);
+
+        // Assert: LoadFriendRequest was called with the JWT-pinned Sender
+        friendRequestCacheMock.Verify(
+            c => c.LoadFriendRequest(It.Is<FriendRequest>(r => r.Sender == "JwtUser#1234" && r.Receiver == "Receiver#9999")),
+            Times.Once,
+            "LoadFriendRequest must be called with the JWT-pinned Sender."
+        );
+    }
+
+    [Test]
     public async Task MakeFriendRequest_CanonicalReceiver_ProceedsToCreate()
     {
         // Arrange: client sends a properly-canonical Receiver

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -1920,4 +1920,87 @@ public class PatreonDriftSyncTests
             a => a.UserId == "TestBattleTag#1234")), Times.Once,
             "Should create association only for the user with a linked account");
     }
+
+    [Test]
+    public async Task AnalyzeDrift_TierMismatch_UserIdIsCanonical()
+    {
+        // Regression test for drift detection casing canonicalization.
+        // After removing .ToLowerInvariant() from AnalyzeDrift, TierMismatch.UserId
+        // must be the canonical (mixed-case) BattleTag, not lowercased.
+        const string canonicalBattleTag = "TORREN#11438";
+        const string patreonUserId = "152572628";
+
+        var accountLink = new PatreonAccountLink(canonicalBattleTag, patreonUserId);
+        _mockPatreonLinkRepository.Setup(x => x.GetAll())
+            .ReturnsAsync(new List<PatreonAccountLink> { accountLink });
+
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping>
+            {
+                new ProductMapping
+                {
+                    Id = "bronze-mapping",
+                    ProductName = "Bronze Tier",
+                    Type = ProductMappingType.Tiered,
+                    RewardIds = new List<string> { "reward-bronze" },
+                    ProductProviders = new List<ProductProviderPair>
+                    {
+                        new ProductProviderPair { ProviderId = "patreon", ProductId = "6482051" }
+                    }
+                },
+                new ProductMapping
+                {
+                    Id = "gold-mapping",
+                    ProductName = "Gold Tier",
+                    Type = ProductMappingType.Tiered,
+                    RewardIds = new List<string> { "reward-gold" },
+                    ProductProviders = new List<ProductProviderPair>
+                    {
+                        new ProductProviderPair { ProviderId = "patreon", ProductId = "6482070" }
+                    }
+                }
+            });
+
+        // Patreon: user is active patron with Bronze and Gold entitlements
+        _mockPatreonApiClient.Setup(x => x.GetAllCampaignMembers())
+            .ReturnsAsync(new List<PatreonMember>
+            {
+                new PatreonMember
+                {
+                    Id = "patreon-member-id",
+                    PatreonUserId = patreonUserId,
+                    PatronStatus = "active_patron",
+                    LastChargeStatus = "Paid",
+                    EntitledTiers = new List<EntitledTier>
+                    {
+                        EntitledTierBuilder.Bronze(),
+                        EntitledTierBuilder.Gold()
+                    }
+                }
+            });
+
+        // Internal: user only has Bronze association (missing Gold)
+        _mockAssociationRepository.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>
+            {
+                new ProductMappingUserAssociation
+                {
+                    Id = "bronze-assoc",
+                    UserId = canonicalBattleTag,
+                    ProductMappingId = "bronze-mapping",
+                    ProviderId = "patreon",
+                    ProviderProductId = "6482051",
+                    Status = AssociationStatus.Active,
+                    AssignedAt = DateTime.UtcNow.AddDays(-30)
+                }
+            });
+
+        var driftResult = await _service.DetectDrift();
+
+        Assert.IsTrue(driftResult.HasDrift, "Should detect tier mismatch");
+        var mismatch = driftResult.MismatchedTiers.SingleOrDefault();
+        Assert.IsNotNull(mismatch, "Should report exactly one tier mismatch");
+        Assert.AreEqual(canonicalBattleTag, mismatch.UserId,
+            "TierMismatch.UserId must be the canonical-cased BattleTag (TORREN#11438), not lowercased");
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Services/BattleTagResolverTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Services/BattleTagResolverTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 using Moq;
@@ -109,5 +110,27 @@ public class BattleTagResolverTests
         Assert.AreEqual("TORREN#11438", result["torren#11438"]);
         Assert.AreEqual("TORREN#11438", result["TORREN#11438"]);
         _identityClientMock.Verify(c => c.ResolveCanonicalBattleTag(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ResolveCanonicalBatch_DuplicateInputs_DoesNotThrow()
+    {
+        _identityClientMock
+            .Setup(c => c.ResolveCanonicalBattleTag("torren#11438"))
+            .ReturnsAsync("TORREN#11438");
+
+        // Three strings: two exact duplicates and one differing only in case
+        // The cache key is lowercased, so all three map to the same cache entry.
+        // After dedup by Distinct(), "torren#11438" and "TORREN#11438" are two entries.
+        _identityClientMock
+            .Setup(c => c.ResolveCanonicalBattleTag("TORREN#11438"))
+            .ReturnsAsync("TORREN#11438");
+
+        var result = await _resolver.ResolveCanonicalBatch(new[] { "torren#11438", "torren#11438", "TORREN#11438" });
+
+        // Dictionary must not throw and all values must be the canonical form
+        Assert.IsTrue(result.Values.All(v => v == "TORREN#11438"));
+        // Exact duplicate "torren#11438" should only hit identity service once (deduped)
+        _identityClientMock.Verify(c => c.ResolveCanonicalBattleTag("torren#11438"), Times.Once);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Services/BattleTagResolverTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Services/BattleTagResolverTests.cs
@@ -1,0 +1,113 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsStatisticService.Services;
+
+namespace WC3ChampionsStatisticService.Tests.Services;
+
+[TestFixture]
+public class BattleTagResolverTests
+{
+    private Mock<IdentityServiceClient> _identityClientMock;
+    private IMemoryCache _cache;
+    private BattleTagResolver _resolver;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _identityClientMock = new Mock<IdentityServiceClient>(new System.Net.Http.HttpClient());
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _resolver = new BattleTagResolver(_identityClientMock.Object, _cache);
+    }
+
+    [Test]
+    public async Task ResolveCanonical_HitsIdentityServiceOnFirstCall()
+    {
+        _identityClientMock
+            .Setup(c => c.ResolveCanonicalBattleTag("torren#11438"))
+            .ReturnsAsync("TORREN#11438");
+
+        var result = await _resolver.ResolveCanonical("torren#11438");
+
+        Assert.AreEqual("TORREN#11438", result);
+        _identityClientMock.Verify(c => c.ResolveCanonicalBattleTag("torren#11438"), Times.Once);
+    }
+
+    [Test]
+    public async Task ResolveCanonical_ReturnsCachedValueOnSecondCall()
+    {
+        _identityClientMock
+            .Setup(c => c.ResolveCanonicalBattleTag(It.IsAny<string>()))
+            .ReturnsAsync("TORREN#11438");
+
+        await _resolver.ResolveCanonical("torren#11438");
+        await _resolver.ResolveCanonical("Torren#11438");
+        await _resolver.ResolveCanonical("TORREN#11438");
+
+        _identityClientMock.Verify(c => c.ResolveCanonicalBattleTag(It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ResolveCanonical_NullForNonexistentUser()
+    {
+        _identityClientMock
+            .Setup(c => c.ResolveCanonicalBattleTag("nonexistent#9999"))
+            .ReturnsAsync((string)null);
+
+        var result = await _resolver.ResolveCanonical("nonexistent#9999");
+
+        Assert.IsNull(result);
+    }
+
+    [Test]
+    public async Task ResolveCanonical_CachesNegativeResults()
+    {
+        _identityClientMock
+            .Setup(c => c.ResolveCanonicalBattleTag(It.IsAny<string>()))
+            .ReturnsAsync((string)null);
+
+        await _resolver.ResolveCanonical("nonexistent#9999");
+        await _resolver.ResolveCanonical("nonexistent#9999");
+
+        _identityClientMock.Verify(c => c.ResolveCanonicalBattleTag(It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ResolveCanonicalBatch_MixedHitsAndMisses_ReturnsMergedDictionary()
+    {
+        _identityClientMock
+            .Setup(c => c.ResolveCanonicalBattleTag("torren#11438"))
+            .ReturnsAsync("TORREN#11438");
+        _identityClientMock
+            .Setup(c => c.ResolveCanonicalBattleTag("faro#2494"))
+            .ReturnsAsync("Faro#2494");
+        _identityClientMock
+            .Setup(c => c.ResolveCanonicalBattleTag("ghost#0000"))
+            .ReturnsAsync((string)null);
+
+        var inputs = new[] { "torren#11438", "faro#2494", "ghost#0000" };
+        var result = await _resolver.ResolveCanonicalBatch(inputs);
+
+        Assert.AreEqual("TORREN#11438", result["torren#11438"]);
+        Assert.AreEqual("Faro#2494", result["faro#2494"]);
+        Assert.IsNull(result["ghost#0000"]);
+    }
+
+    [Test]
+    public async Task ResolveCanonicalBatch_AllCacheHits_DoesNotHitIdentityService()
+    {
+        _identityClientMock
+            .Setup(c => c.ResolveCanonicalBattleTag(It.IsAny<string>()))
+            .ReturnsAsync("TORREN#11438");
+
+        await _resolver.ResolveCanonical("torren#11438");
+        _identityClientMock.Reset();
+
+        var result = await _resolver.ResolveCanonicalBatch(new[] { "torren#11438", "TORREN#11438" });
+
+        Assert.AreEqual("TORREN#11438", result["torren#11438"]);
+        Assert.AreEqual("TORREN#11438", result["TORREN#11438"]);
+        _identityClientMock.Verify(c => c.ResolveCanonicalBattleTag(It.IsAny<string>()), Times.Never);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Services/IdentityServiceClientTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Services/IdentityServiceClientTests.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+using W3ChampionsStatisticService.Services;
+
+namespace WC3ChampionsStatisticService.Tests.Services;
+
+[TestFixture]
+public class IdentityServiceClientTests
+{
+    [Test]
+    public async Task ResolveCanonicalBattleTag_UserExists_ReturnsCanonicalIdFromBody()
+    {
+        // The endpoint returns 200 with body { "id": "TORREN#11438" } per Spec 1's contract.
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"id\":\"TORREN#11438\"}", System.Text.Encoding.UTF8, "application/json")
+            });
+
+        var client = new IdentityServiceClient(new HttpClient(handler.Object));
+        var canonical = await client.ResolveCanonicalBattleTag("torren#11438");
+
+        Assert.AreEqual("TORREN#11438", canonical);
+    }
+
+    [Test]
+    public async Task ResolveCanonicalBattleTag_UserNotFound_ReturnsNull()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        var client = new IdentityServiceClient(new HttpClient(handler.Object));
+        var canonical = await client.ResolveCanonicalBattleTag("nonexistent#9999");
+
+        Assert.IsNull(canonical);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Services/IdentityServiceClientTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Services/IdentityServiceClientTests.cs
@@ -43,4 +43,18 @@ public class IdentityServiceClientTests
 
         Assert.IsNull(canonical);
     }
+
+    [Test]
+    public void ResolveCanonicalBattleTag_ServerError_ThrowsHttpRequestException()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var client = new IdentityServiceClient(new HttpClient(handler.Object));
+
+        Assert.ThrowsAsync<HttpRequestException>(async () =>
+            await client.ResolveCanonicalBattleTag("torren#11438"));
+    }
 }


### PR DESCRIPTION
## Summary

Stops every code path that creates non-canonical BattleTag records and closes a SignalR impersonation vulnerability. Companion to identification-service PR #70 (consumes the new \`/api/users/exists\` canonical-id body).

### Background

Investigating the TORREN#11438 Bronze→Gold incident surfaced 218 users with casing-split records across 9 collections (e.g. \`TORREN#11438\` vs \`torren#11438\` rows for the same logical user). Root cause was \`PatreonDriftDetectionService\` lowercasing dict keys, propagated by every endpoint that accepted user-supplied BattleTag values without canonicalization.

### What changes

#### Foundation
- **New \`IBattleTagResolver\`** with single + batch APIs, backed by a 5-min \`IMemoryCache\`. Calls \`IdentityServiceClient.ResolveCanonicalBattleTag\` (the new endpoint from #70).
- **\`IdentityServiceClient\` refactored** for testability (constructor accepts optional \`HttpClient\`). The legacy \`UserExists\` (boolean-only) method is removed; both prior call sites migrate to canonical resolution.

#### Drift detection root fix (Bug 1 in the rewards-correctness incident)
- \`PatreonDriftDetectionService.AnalyzeDrift\`: dropped the two \`.ToLowerInvariant()\` calls on \`patreonByBattleTag\` and \`internalByUserId\` dict keys. \`TierMismatch.UserId\` is now canonical-cased; downstream queries operate on canonical keys.
- **Auto-heal effect:** legacy lowercase orphan rows in \`ProductMappingUserAssociation\` now fall into \`ExtraAssignment\` and get revoked on the next drift cycle.

#### Behavior matrix at every entry point
- **GET endpoints with writes** — 301 redirect to canonical URL: \`PlayersController.GetPlayer\`.
- **Read-only GET** — internal canonicalization, no 301: \`PersonalSettingsController.GetPersonalSetting\` (uses \`Load\` to preserve the \`PlayerOverallStats\` join; existing try/catch preserved).
- **Write endpoints — 400 hard-reject** on non-canonical or non-existent: \`TournamentsController.RegisterPlayer\` / \`UnregisterPlayer\`, \`RewardsController.PutPortraits\` / \`DeletePortraits\` (bulk via \`ResolveCanonicalBatch\`), \`ClanController\` ×6 endpoints (\`InviteToClan\`, \`RevokeInvitationToClan\`, \`SwitchChieftain\`, \`AddShamanToClan\`, \`RemoveShamanFromClan\`, \`KickPlayerFromClan\`).
- **Soft canonicalization** (per direction during execution — admin-tooling UX) — \`AdminController\`: \`UpdateProxies\`, \`PutChatBan\`, \`PostBannedPlayer\` 400 only on \`user_not_found\`; silently use canonical on case mismatch.
- **SignalR Hub × 8 methods** — \`req.Sender\` JWT-pinned (security fix), targets canonicalized, errors emitted as \`BattleTagResolutionError\` event.

#### Security fix in SignalR Hub
- Closed an impersonation vector: \`MakeFriendRequest\`, \`AcceptIncomingFriendRequest\`, \`DenyIncomingFriendRequest\`, \`BlockIncomingFriendRequest\`, \`DeleteOutgoingFriendRequest\` previously trusted client-supplied \`req.Sender\`. The Hub now overwrites the caller-side identity with the connection's authenticated BattleTag from \`_connections.GetUser(Context.ConnectionId)\`. Methods receiving \`string battleTag\` parameters (\`BlockPlayer\`, \`UnblockFriendRequestsFromPlayer\`, \`RemoveFriend\`) already sourced caller identity from the connection mapping.

### Strict-casing doctrine

- No Mongo collation, no case-insensitive comparisons in lookups, no defensive \`Equals(..., IgnoreCase)\` after canonicalization (boyscout: self-friend check switched from \`CurrentCultureIgnoreCase\` to \`==\` Ordinal).
- Canonicalize once at the boundary, then strict-equality everywhere internally.
- Battle.net's per-account casing is stable, so we don't invest in defensive handling for theoretical re-OAuth casing flips.

## Test plan

- [x] \`dotnet build\` clean.
- [x] \`dotnet format --verify-no-changes\` clean.
- [x] \`dotnet test\` 510 passed / 9 skipped (pre-existing) / 0 failed.
- [x] **\`IdentityServiceClientTests\`** (3): canonical-body parse, 404 → null, 500 → \`HttpRequestException\`.
- [x] **\`BattleTagResolverTests\`** (7): hits identity service first call, returns cached on second, null for nonexistent, caches negative results, batch with mixed hits/misses, batch all-cache-hits skips identity service, **batch with duplicate inputs does not throw** (hardening).
- [x] **\`AnalyzeDrift_TierMismatch_UserIdIsCanonical\`** regression test pins the drift fix (would FAIL pre-fix).
- [x] **5 Hub impersonation regression tests** — \`MakeFriendRequest\`, \`Accept\`, \`Deny\`, \`Block\`, \`DeleteOutgoing\` each verify the caller-side identity is overwritten with JWT BattleTag.
- [x] **2 Hub canonicalization tests** — \`MakeFriendRequest\` non-canonical Receiver emits \`BattleTagResolutionError\`; canonical proceeds to create.
- [x] Existing tests unaffected (default resolver mock setup passes inputs through transparently).
- [ ] Post-deploy: \`curl -I /api/players/torren%2311438\` returns 301 with \`Location: /api/players/TORREN%2311438\`.
- [ ] Post-deploy: drift detection cycle logs show \`Created association for user "TORREN#11438"\` (canonical, not lowercase).
- [ ] Post-deploy: SignalR Hub forged-Sender request is rewritten to JWT identity (verify via integration test against test env).

## Deploy ordering (REQUIRED)

This PR's \`BattleTagResolver\` consumes #70's new \`{ id }\` body shape from \`/api/users/exists\`. **identification-service PR #70 must be deployed before this PR is deployed**, otherwise the resolver receives empty bodies and returns null for everything → service degradation (404 on all GET, 400 on all writes).

Frontend coordination items (non-blocking; documented for follow-up):
- \`AdminTournaments.vue\`: parse the new 400 body for canonical hint.
- \`AdminAssignPortraits.vue\`: surface bulk-rejection details.
- \`InvitePlayerModal.vue\`: display canonical hint.
- \`launcher-e\`: add \`BattleTagResolutionError\` handler.

These ship in their own cadence; the backend rejects gracefully today.

## Follow-ups (NOT in this PR)

- One-off mongosh migration script (\`~/scratch/migrate-casing.js\`) cleans up the existing 218 split users post-deploy.