### PR TITLE
fix(rewards): drift revocation correctness — close orphan-RA bug + free-tier ignore + observability

### DIFF
--- a/W3C.Domain/Rewards/Repositories/IPatreonAccountLinkRepository.cs
+++ b/W3C.Domain/Rewards/Repositories/IPatreonAccountLinkRepository.cs
@@ -37,6 +37,12 @@ public interface IPatreonAccountLinkRepository
     Task Update(PatreonAccountLink link);
 
     /// <summary>
+    /// Refreshes the LastSyncAt timestamp on the link matching this battleTag, if one exists.
+    /// No-op if no link exists. Failures are caught + logged internally — never throws to caller.
+    /// </summary>
+    Task RefreshLastSyncAt(string battleTag);
+
+    /// <summary>
     /// Delete account link by ID
     /// </summary>
     Task Delete(string id);

--- a/W3C.Domain/Rewards/Repositories/IPatreonAccountLinkRepository.cs
+++ b/W3C.Domain/Rewards/Repositories/IPatreonAccountLinkRepository.cs
@@ -32,6 +32,11 @@ public interface IPatreonAccountLinkRepository
     Task<List<PatreonAccountLink>> GetAll();
 
     /// <summary>
+    /// Update an existing account link in-place (e.g. to refresh LastSyncAt)
+    /// </summary>
+    Task Update(PatreonAccountLink link);
+
+    /// <summary>
     /// Delete account link by ID
     /// </summary>
     Task Delete(string id);

--- a/W3ChampionsStatisticService/Rewards/BackgroundServices/RewardDriftDetectionBackgroundService.cs
+++ b/W3ChampionsStatisticService/Rewards/BackgroundServices/RewardDriftDetectionBackgroundService.cs
@@ -8,6 +8,20 @@ using W3ChampionsStatisticService.Rewards.Services;
 
 namespace W3ChampionsStatisticService.Rewards.BackgroundServices;
 
+/// <summary>
+/// Immutable snapshot of a single drift detection cycle.
+/// Assigned atomically via <see cref="Volatile"/> so readers always see a
+/// fully-formed value — never a mix of properties from two different cycles.
+/// </summary>
+public sealed record DriftRunSnapshot(
+    DateTime? StartedAtUtc,
+    DateTime? CompletedAtUtc,
+    bool Succeeded,
+    string ErrorMessage,
+    int MembersAdded,
+    int AssignmentsRevoked,
+    int TiersUpdated);
+
 public class RewardDriftDetectionBackgroundService : BackgroundService
 {
     private readonly IServiceProvider _serviceProvider;
@@ -17,14 +31,16 @@ public class RewardDriftDetectionBackgroundService : BackgroundService
     private readonly bool _autoSyncEnabled;
     private readonly bool _syncDryRun;
 
-    // Last-run state — populated by each scheduled cycle
-    public DateTime? LastRunStartedAtUtc { get; private set; }
-    public DateTime? LastRunCompletedAtUtc { get; private set; }
-    public bool LastRunSucceeded { get; private set; }
-    public string LastRunErrorMessage { get; private set; }
-    public int LastRunMembersAdded { get; private set; }
-    public int LastRunAssignmentsRevoked { get; private set; }
-    public int LastRunTiersUpdated { get; private set; }
+    // Atomic snapshot of the most recent drift cycle. Single reference assignment
+    // is atomic on .NET; Volatile.Read/Write provide the required memory-barrier.
+    // Null until the first cycle completes (or starts).
+    private DriftRunSnapshot _lastRun;
+
+    /// <summary>
+    /// Returns the snapshot from the most recent (or in-flight) drift cycle,
+    /// or null if no cycle has run yet.
+    /// </summary>
+    public virtual DriftRunSnapshot LastRun => Volatile.Read(ref _lastRun);
 
     public RewardDriftDetectionBackgroundService(
         IServiceProvider serviceProvider,
@@ -39,14 +55,9 @@ public class RewardDriftDetectionBackgroundService : BackgroundService
             ? interval
             : 60; // Default 1 hour
 
-        var enabledStr = Environment.GetEnvironmentVariable("REWARDS_DRIFT_DETECTION_ENABLED");
-        _enabled = enabledStr?.ToLower() == "true"; // Default disabled
-
-        var autoSyncStr = Environment.GetEnvironmentVariable("REWARDS_DRIFT_AUTO_SYNC_ENABLED");
-        _autoSyncEnabled = autoSyncStr?.ToLower() == "true"; // Default disabled
-
-        var dryRunStr = Environment.GetEnvironmentVariable("REWARDS_DRIFT_SYNC_DRY_RUN");
-        _syncDryRun = string.IsNullOrEmpty(dryRunStr) || dryRunStr.ToLower() == "true"; // Default true for safety
+        _enabled = bool.TryParse(Environment.GetEnvironmentVariable("REWARDS_DRIFT_DETECTION_ENABLED"), out var e) ? e : false; // Default disabled
+        _autoSyncEnabled = bool.TryParse(Environment.GetEnvironmentVariable("REWARDS_DRIFT_AUTO_SYNC_ENABLED"), out var a) ? a : false; // Default disabled
+        _syncDryRun = bool.TryParse(Environment.GetEnvironmentVariable("REWARDS_DRIFT_SYNC_DRY_RUN"), out var d) ? d : true; // Default true for safety
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -83,7 +94,17 @@ public class RewardDriftDetectionBackgroundService : BackgroundService
     {
         _logger.LogInformation("Starting scheduled drift detection run");
 
-        LastRunStartedAtUtc = DateTime.UtcNow;
+        var startedAt = DateTime.UtcNow;
+
+        // Record that a cycle is in-flight before doing any work.
+        Volatile.Write(ref _lastRun, new DriftRunSnapshot(
+            StartedAtUtc: startedAt,
+            CompletedAtUtc: null,
+            Succeeded: false,
+            ErrorMessage: null,
+            MembersAdded: 0,
+            AssignmentsRevoked: 0,
+            TiersUpdated: 0));
 
         using var scope = _serviceProvider.CreateScope();
 
@@ -163,20 +184,32 @@ public class RewardDriftDetectionBackgroundService : BackgroundService
 
             _logger.LogInformation("Scheduled drift detection run completed");
 
-            LastRunCompletedAtUtc = DateTime.UtcNow;
-            LastRunSucceeded = true;
-            LastRunErrorMessage = null;
-            LastRunMembersAdded = membersAdded;
-            LastRunAssignmentsRevoked = assignmentsRevoked;
-            LastRunTiersUpdated = tiersUpdated;
+            // Atomically publish the success snapshot — all counts are consistent.
+            Volatile.Write(ref _lastRun, new DriftRunSnapshot(
+                StartedAtUtc: startedAt,
+                CompletedAtUtc: DateTime.UtcNow,
+                Succeeded: true,
+                ErrorMessage: null,
+                MembersAdded: membersAdded,
+                AssignmentsRevoked: assignmentsRevoked,
+                TiersUpdated: tiersUpdated));
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error during scheduled drift detection");
 
-            LastRunCompletedAtUtc = DateTime.UtcNow;
-            LastRunSucceeded = false;
-            LastRunErrorMessage = ex.Message;
+            // Failure snapshot — counts explicitly 0 to avoid stale values from a
+            // prior successful cycle leaking through on the error path.
+            Volatile.Write(ref _lastRun, new DriftRunSnapshot(
+                StartedAtUtc: startedAt,
+                CompletedAtUtc: DateTime.UtcNow,
+                Succeeded: false,
+                ErrorMessage: ex.Message,
+                MembersAdded: 0,
+                AssignmentsRevoked: 0,
+                TiersUpdated: 0));
+
+            throw;
         }
     }
 }

--- a/W3ChampionsStatisticService/Rewards/BackgroundServices/RewardDriftDetectionBackgroundService.cs
+++ b/W3ChampionsStatisticService/Rewards/BackgroundServices/RewardDriftDetectionBackgroundService.cs
@@ -17,6 +17,15 @@ public class RewardDriftDetectionBackgroundService : BackgroundService
     private readonly bool _autoSyncEnabled;
     private readonly bool _syncDryRun;
 
+    // Last-run state — populated by each scheduled cycle
+    public DateTime? LastRunStartedAtUtc { get; private set; }
+    public DateTime? LastRunCompletedAtUtc { get; private set; }
+    public bool LastRunSucceeded { get; private set; }
+    public string LastRunErrorMessage { get; private set; }
+    public int LastRunMembersAdded { get; private set; }
+    public int LastRunAssignmentsRevoked { get; private set; }
+    public int LastRunTiersUpdated { get; private set; }
+
     public RewardDriftDetectionBackgroundService(
         IServiceProvider serviceProvider,
         ILogger<RewardDriftDetectionBackgroundService> logger)
@@ -74,10 +83,16 @@ public class RewardDriftDetectionBackgroundService : BackgroundService
     {
         _logger.LogInformation("Starting scheduled drift detection run");
 
+        LastRunStartedAtUtc = DateTime.UtcNow;
+
         using var scope = _serviceProvider.CreateScope();
 
         try
         {
+            int membersAdded = 0;
+            int assignmentsRevoked = 0;
+            int tiersUpdated = 0;
+
             // Run Patreon drift detection
             var patreonDriftService = scope.ServiceProvider.GetService<PatreonDriftDetectionService>();
             if (patreonDriftService != null)
@@ -99,6 +114,10 @@ public class RewardDriftDetectionBackgroundService : BackgroundService
                         {
                             _logger.LogInformation("Starting automatic drift synchronization. DryRun: {DryRun}", _syncDryRun);
                             var syncResult = await patreonDriftService.SyncDrift(patreonResult, _syncDryRun);
+
+                            membersAdded = syncResult.MembersAdded;
+                            assignmentsRevoked = syncResult.AssignmentsRevoked;
+                            tiersUpdated = syncResult.TiersUpdated;
 
                             if (syncResult.Success)
                             {
@@ -143,10 +162,21 @@ public class RewardDriftDetectionBackgroundService : BackgroundService
             // }
 
             _logger.LogInformation("Scheduled drift detection run completed");
+
+            LastRunCompletedAtUtc = DateTime.UtcNow;
+            LastRunSucceeded = true;
+            LastRunErrorMessage = null;
+            LastRunMembersAdded = membersAdded;
+            LastRunAssignmentsRevoked = assignmentsRevoked;
+            LastRunTiersUpdated = tiersUpdated;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error during scheduled drift detection");
+
+            LastRunCompletedAtUtc = DateTime.UtcNow;
+            LastRunSucceeded = false;
+            LastRunErrorMessage = ex.Message;
         }
     }
 }

--- a/W3ChampionsStatisticService/Rewards/Controllers/AdminRewardController.cs
+++ b/W3ChampionsStatisticService/Rewards/Controllers/AdminRewardController.cs
@@ -27,6 +27,7 @@ public class AdminRewardController(
     IProductMappingReconciliationService reconciliationService,
     PatreonDriftDetectionService patreonDriftService,
     IAuditLogService auditLogService,
+    IOrphanRewardService orphanRewardService,
     ILogger<AdminRewardController> logger) : ControllerBase
 {
     private readonly IRewardAssignmentRepository _assignmentRepo = assignmentRepo;
@@ -35,6 +36,7 @@ public class AdminRewardController(
     private readonly IProductMappingReconciliationService _reconciliationService = reconciliationService;
     private readonly PatreonDriftDetectionService _patreonDriftService = patreonDriftService;
     private readonly IAuditLogService _auditLogService = auditLogService;
+    private readonly IOrphanRewardService _orphanRewardService = orphanRewardService;
     private readonly ILogger<AdminRewardController> _logger = logger;
 
     [HttpGet("summary")]
@@ -439,4 +441,68 @@ public class AdminRewardController(
             return StatusCode(500, new { error = "Bulk reconciliation failed", details = ex.Message });
         }
     }
+
+    /// <summary>
+    /// Lists active patreon RewardAssignments that have no backing active PMUA and whose
+    /// owner is not an active patron. Read-only — does not revoke. Pair with the POST
+    /// orphan-rewards/revoke endpoint to clean up after manual review.
+    /// </summary>
+    [HttpGet("orphan-rewards")]
+    [CheckIfBattleTagIsAdmin]
+    public async Task<IActionResult> GetOrphanRewards()
+    {
+        try
+        {
+            var report = await _orphanRewardService.DetectOrphans();
+            return Ok(report);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to detect orphan rewards");
+            return StatusCode(500, new { error = "orphan_detection_failed", details = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Revokes orphan RewardAssignments for the specified user IDs. The service re-detects
+    /// orphans against fresh data internally — any user in the request body who is no longer
+    /// an orphan at execution time is skipped and surfaced in the result.
+    /// </summary>
+    [HttpPost("orphan-rewards/revoke")]
+    [CheckIfBattleTagIsAdmin]
+    [InjectActingPlayerAuthCode]
+    public async Task<IActionResult> RevokeOrphanRewards(
+        [FromBody] OrphanRevocationRequest request,
+        [FromQuery] string actingPlayer)
+    {
+        if (request?.UserIds == null || request.UserIds.Count == 0)
+        {
+            return BadRequest(new { error = "user_ids_required" });
+        }
+
+        try
+        {
+            var result = await _orphanRewardService.RevokeOrphans(request.UserIds.ToHashSet(), actingPlayer);
+            await _auditLogService.LogAdminAction(actingPlayer, "ORPHAN_REWARDS_REVOKE", "RewardAssignment", "bulk",
+                metadata: new Dictionary<string, object>
+                {
+                    ["request_user_count"] = request.UserIds.Count,
+                    ["users_touched"] = result.UsersTouched,
+                    ["assignments_revoked"] = result.AssignmentsRevoked,
+                    ["skipped_count"] = result.SkippedUserIdsNotInLatestDetection.Count,
+                    ["error_count"] = result.Errors.Count
+                });
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to revoke orphan rewards");
+            return StatusCode(500, new { error = "orphan_revocation_failed", details = ex.Message });
+        }
+    }
+}
+
+public class OrphanRevocationRequest
+{
+    public List<string> UserIds { get; set; } = new();
 }

--- a/W3ChampionsStatisticService/Rewards/Controllers/PatreonWebhookController.cs
+++ b/W3ChampionsStatisticService/Rewards/Controllers/PatreonWebhookController.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Serilog;
 using W3C.Domain.Rewards.Abstractions;
 using W3C.Domain.Rewards.Entities;
 using W3C.Domain.Rewards.Events;
@@ -22,12 +23,14 @@ public class PatreonWebhookController(
     IProductMappingUserAssociationRepository associationRepository,
     IProductMappingRepository productMappingRepository,
     IProductMappingReconciliationService reconciliationService,
+    IPatreonAccountLinkRepository patreonAccountLinkRepository,
     ILogger<PatreonWebhookController> logger) : ControllerBase
 {
     private readonly PatreonProvider _patreonProvider = patreonProvider;
     private readonly IProductMappingUserAssociationRepository _associationRepository = associationRepository;
     private readonly IProductMappingRepository _productMappingRepository = productMappingRepository;
     private readonly IProductMappingReconciliationService _reconciliationService = reconciliationService;
+    private readonly IPatreonAccountLinkRepository _patreonAccountLinkRepository = patreonAccountLinkRepository;
     private readonly ILogger<PatreonWebhookController> _logger = logger;
 
     [HttpPost]
@@ -66,6 +69,21 @@ public class PatreonWebhookController(
 
             // Immediately trigger user-specific reconciliation to create/update reward assignments
             var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(rewardEvent.UserId, rewardEvent.EventId, dryRun: false);
+
+            // Refresh LastSyncAt on the account link — non-fatal bookkeeping
+            try
+            {
+                var link = await _patreonAccountLinkRepository.GetByBattleTag(rewardEvent.UserId);
+                if (link != null)
+                {
+                    link.UpdateLastSync();
+                    await _patreonAccountLinkRepository.Update(link);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to update LastSyncAt for {BattleTag} after webhook", rewardEvent.UserId);
+            }
 
             _logger.LogInformation("Successfully processed Patreon webhook for user {UserId} with {TierCount} entitled tiers. Associations: {AssociationCount}, Rewards Added: {Added}, Rewards Revoked: {Revoked}",
                 rewardEvent.UserId, rewardEvent.EntitledTiers.Count, associationResults.Count, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);

--- a/W3ChampionsStatisticService/Rewards/Controllers/PatreonWebhookController.cs
+++ b/W3ChampionsStatisticService/Rewards/Controllers/PatreonWebhookController.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Serilog;
 using W3C.Domain.Rewards.Abstractions;
 using W3C.Domain.Rewards.Entities;
 using W3C.Domain.Rewards.Events;
@@ -71,19 +70,7 @@ public class PatreonWebhookController(
             var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(rewardEvent.UserId, rewardEvent.EventId, dryRun: false);
 
             // Refresh LastSyncAt on the account link — non-fatal bookkeeping
-            try
-            {
-                var link = await _patreonAccountLinkRepository.GetByBattleTag(rewardEvent.UserId);
-                if (link != null)
-                {
-                    link.UpdateLastSync();
-                    await _patreonAccountLinkRepository.Update(link);
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Warning(ex, "Failed to update LastSyncAt for {BattleTag} after webhook", rewardEvent.UserId);
-            }
+            await _patreonAccountLinkRepository.RefreshLastSyncAt(rewardEvent.UserId);
 
             _logger.LogInformation("Successfully processed Patreon webhook for user {UserId} with {TierCount} entitled tiers. Associations: {AssociationCount}, Rewards Added: {Added}, Rewards Revoked: {Revoked}",
                 rewardEvent.UserId, rewardEvent.EntitledTiers.Count, associationResults.Count, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);

--- a/W3ChampionsStatisticService/Rewards/Controllers/RewardDriftDetectionController.cs
+++ b/W3ChampionsStatisticService/Rewards/Controllers/RewardDriftDetectionController.cs
@@ -142,21 +142,23 @@ public class RewardDriftDetectionController(
         var dryRun = ParseBool("REWARDS_DRIFT_SYNC_DRY_RUN", true);
         var ignoredTierIds = Environment.GetEnvironmentVariable("REWARDS_PATREON_IGNORED_TIER_IDS") ?? "";
 
+        var snapshot = _backgroundService.LastRun;
+
         return Ok(new
         {
             detectionEnabled,
             autoSyncEnabled,
             dryRun,
             ignoredTierIds,
-            lastRun = new
+            lastRun = snapshot == null ? null : (object)new
             {
-                startedAtUtc = _backgroundService.LastRunStartedAtUtc?.ToString("O"),
-                completedAtUtc = _backgroundService.LastRunCompletedAtUtc?.ToString("O"),
-                succeeded = _backgroundService.LastRunSucceeded,
-                errorMessage = _backgroundService.LastRunErrorMessage,
-                membersAdded = _backgroundService.LastRunMembersAdded,
-                assignmentsRevoked = _backgroundService.LastRunAssignmentsRevoked,
-                tiersUpdated = _backgroundService.LastRunTiersUpdated
+                startedAtUtc = snapshot.StartedAtUtc?.ToString("O"),
+                completedAtUtc = snapshot.CompletedAtUtc?.ToString("O"),
+                succeeded = snapshot.Succeeded,
+                errorMessage = snapshot.ErrorMessage,
+                membersAdded = snapshot.MembersAdded,
+                assignmentsRevoked = snapshot.AssignmentsRevoked,
+                tiersUpdated = snapshot.TiersUpdated
             },
             providers = new[]
             {

--- a/W3ChampionsStatisticService/Rewards/Controllers/RewardDriftDetectionController.cs
+++ b/W3ChampionsStatisticService/Rewards/Controllers/RewardDriftDetectionController.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using W3ChampionsStatisticService.Rewards.BackgroundServices;
 using W3ChampionsStatisticService.Rewards.Services;
 using W3ChampionsStatisticService.WebApi.ActionFilters;
 using W3C.Domain.Common.Services;
@@ -15,11 +16,13 @@ namespace W3ChampionsStatisticService.Rewards.Controllers;
 public class RewardDriftDetectionController(
     PatreonDriftDetectionService patreonDriftService,
     IAuditLogService auditLogService,
-    ILogger<RewardDriftDetectionController> logger) : ControllerBase
+    ILogger<RewardDriftDetectionController> logger,
+    RewardDriftDetectionBackgroundService backgroundService) : ControllerBase
 {
     private readonly PatreonDriftDetectionService _patreonDriftService = patreonDriftService;
     private readonly IAuditLogService _auditLogService = auditLogService;
     private readonly ILogger<RewardDriftDetectionController> _logger = logger;
+    private readonly RewardDriftDetectionBackgroundService _backgroundService = backgroundService;
 
     [HttpPost("patreon/detect")]
     [CheckIfBattleTagIsAdmin]
@@ -127,14 +130,38 @@ public class RewardDriftDetectionController(
     [CheckIfBattleTagIsAdmin]
     public IActionResult GetDriftDetectionStatus()
     {
-        // This could be enhanced to return last run time, next scheduled run, etc.
+        static bool ParseBool(string envVar, bool defaultValue)
+        {
+            var raw = Environment.GetEnvironmentVariable(envVar);
+            if (string.IsNullOrEmpty(raw)) return defaultValue;
+            return bool.TryParse(raw, out var parsed) ? parsed : defaultValue;
+        }
+
+        var detectionEnabled = ParseBool("REWARDS_DRIFT_DETECTION_ENABLED", false);
+        var autoSyncEnabled = ParseBool("REWARDS_DRIFT_AUTO_SYNC_ENABLED", false);
+        var dryRun = ParseBool("REWARDS_DRIFT_SYNC_DRY_RUN", true);
+        var ignoredTierIds = Environment.GetEnvironmentVariable("REWARDS_PATREON_IGNORED_TIER_IDS") ?? "";
+
         return Ok(new
         {
-            enabled = true, // This should come from configuration
+            detectionEnabled,
+            autoSyncEnabled,
+            dryRun,
+            ignoredTierIds,
+            lastRun = new
+            {
+                startedAtUtc = _backgroundService.LastRunStartedAtUtc?.ToString("O"),
+                completedAtUtc = _backgroundService.LastRunCompletedAtUtc?.ToString("O"),
+                succeeded = _backgroundService.LastRunSucceeded,
+                errorMessage = _backgroundService.LastRunErrorMessage,
+                membersAdded = _backgroundService.LastRunMembersAdded,
+                assignmentsRevoked = _backgroundService.LastRunAssignmentsRevoked,
+                tiersUpdated = _backgroundService.LastRunTiersUpdated
+            },
             providers = new[]
             {
                 new { provider = "patreon", available = true },
-                new { provider = "kofi", available = false } // Not implemented yet
+                new { provider = "kofi", available = false }
             }
         });
     }

--- a/W3ChampionsStatisticService/Rewards/Extensions/RewardServiceExtensions.cs
+++ b/W3ChampionsStatisticService/Rewards/Extensions/RewardServiceExtensions.cs
@@ -52,6 +52,9 @@ public static class RewardServiceExtensions
         services.AddInterceptedTransient<IProductMappingReconciliationService, ProductMappingReconciliationService>();
         services.AddInterceptedTransient<ProductMappingReconciliationService>();
 
+        // Orphan reward cleanup service
+        services.AddInterceptedTransient<IOrphanRewardService, OrphanRewardService>();
+
         // Background services
         services.AddHostedService<RewardDriftDetectionBackgroundService>();
 

--- a/W3ChampionsStatisticService/Rewards/Extensions/RewardServiceExtensions.cs
+++ b/W3ChampionsStatisticService/Rewards/Extensions/RewardServiceExtensions.cs
@@ -55,8 +55,10 @@ public static class RewardServiceExtensions
         // Orphan reward cleanup service
         services.AddInterceptedTransient<IOrphanRewardService, OrphanRewardService>();
 
-        // Background services
-        services.AddHostedService<RewardDriftDetectionBackgroundService>();
+        // Background services — registered as singleton so the controller can resolve
+        // the same running instance to read last-run state properties.
+        services.AddSingleton<RewardDriftDetectionBackgroundService>();
+        services.AddHostedService(sp => sp.GetRequiredService<RewardDriftDetectionBackgroundService>());
 
         return services;
     }

--- a/W3ChampionsStatisticService/Rewards/Repositories/PatreonAccountLinkRepository.cs
+++ b/W3ChampionsStatisticService/Rewards/Repositories/PatreonAccountLinkRepository.cs
@@ -212,6 +212,23 @@ public class PatreonAccountLinkRepository(
         await collection.ReplaceOneAsync(filter, link);
     }
 
+    public async Task RefreshLastSyncAt(string battleTag)
+    {
+        try
+        {
+            var link = await GetByBattleTag(battleTag);
+            if (link != null)
+            {
+                link.UpdateLastSync();
+                await Update(link);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to refresh LastSyncAt for {BattleTag}", battleTag);
+        }
+    }
+
     public Task<List<PatreonAccountLink>> GetAll()
     {
         return LoadAll<PatreonAccountLink>();

--- a/W3ChampionsStatisticService/Rewards/Repositories/PatreonAccountLinkRepository.cs
+++ b/W3ChampionsStatisticService/Rewards/Repositories/PatreonAccountLinkRepository.cs
@@ -205,6 +205,13 @@ public class PatreonAccountLinkRepository(
         }
     }
 
+    public async Task Update(PatreonAccountLink link)
+    {
+        var collection = CreateCollection<PatreonAccountLink>();
+        var filter = Builders<PatreonAccountLink>.Filter.Eq(x => x.Id, link.Id);
+        await collection.ReplaceOneAsync(filter, link);
+    }
+
     public Task<List<PatreonAccountLink>> GetAll()
     {
         return LoadAll<PatreonAccountLink>();

--- a/W3ChampionsStatisticService/Rewards/Services/IOrphanRewardService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/IOrphanRewardService.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace W3ChampionsStatisticService.Rewards.Services;
+
+public interface IOrphanRewardService
+{
+    /// <summary>
+    /// Detects active patreon RewardAssignments with no backing active PMUA and whose user is
+    /// not an active Patreon member.
+    /// </summary>
+    Task<OrphanRewardReport> DetectOrphans();
+
+    /// <summary>
+    /// Revokes the orphan RewardAssignments. Always runs DetectOrphans internally to ensure
+    /// the data is fresh — the admin endpoint passes the previously-shown report's user list
+    /// (or a subset) for safety, but the service re-validates before any revocation.
+    /// </summary>
+    Task<OrphanRewardRevocationResult> RevokeOrphans(IReadOnlySet<string> approvedUserIds, string actorBattleTag);
+}
+
+/// <summary>
+/// Detection result. Each entry represents one user with at least one orphan RA.
+/// </summary>
+public class OrphanRewardReport
+{
+    public System.DateTime DetectedAtUtc { get; set; }
+    public List<OrphanRewardEntry> Entries { get; set; } = new();
+}
+
+public class OrphanRewardEntry
+{
+    public string UserId { get; set; }
+    public List<OrphanAssignmentDetail> Assignments { get; set; } = new();
+    public string Reason { get; set; }
+}
+
+public class OrphanAssignmentDetail
+{
+    public string AssignmentId { get; set; }
+    public string RewardId { get; set; }
+    public string ProviderReference { get; set; }
+    public System.DateTime AssignedAt { get; set; }
+}
+
+public class OrphanRewardRevocationResult
+{
+    public System.DateTime ExecutedAtUtc { get; set; }
+    public int UsersTouched { get; set; }
+    public int AssignmentsRevoked { get; set; }
+    public List<string> Errors { get; set; } = new();
+    public List<string> SkippedUserIdsNotInLatestDetection { get; set; } = new();
+}

--- a/W3ChampionsStatisticService/Rewards/Services/OrphanRewardService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/OrphanRewardService.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using W3C.Domain.Rewards.Abstractions;
 using W3C.Domain.Rewards.Entities;
 using W3C.Domain.Rewards.Repositories;
-using W3C.Domain.Rewards.ValueObjects;
 using W3ChampionsStatisticService.Rewards.Providers.Patreon;
 
 namespace W3ChampionsStatisticService.Rewards.Services;

--- a/W3ChampionsStatisticService/Rewards/Services/OrphanRewardService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/OrphanRewardService.cs
@@ -36,6 +36,9 @@ public class OrphanRewardService(
         if (!activePatreonRAs.Any()) return report;
 
         var activeAssociations = await _associationRepository.GetAll(AssociationStatus.Active);
+        // Use IsActive() rather than just status: a row may have Status=Active but ExpiresAt
+        // in the past if the periodic expiry sweep hasn't transitioned it yet. Such PMUAs no
+        // longer represent a live entitlement and should not gate orphan detection.
         var userIdsWithActivePmua = activeAssociations
             .Where(a => a.ProviderId == ProviderId && a.IsActive())
             .Select(a => a.UserId)

--- a/W3ChampionsStatisticService/Rewards/Services/OrphanRewardService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/OrphanRewardService.cs
@@ -97,6 +97,7 @@ public class OrphanRewardService(
             }
 
             var entry = freshReport.Entries.First(e => e.UserId == requestedUserId);
+            var revokedForUser = 0;
             foreach (var assignment in entry.Assignments)
             {
                 try
@@ -104,6 +105,7 @@ public class OrphanRewardService(
                     await _rewardService.RevokeReward(assignment.AssignmentId,
                         $"Admin orphan cleanup by {actorBattleTag}: no backing active PMUA, not active patron");
                     result.AssignmentsRevoked++;
+                    revokedForUser++;
                     _logger.LogInformation("Admin orphan cleanup revoked {AssignmentId} for {UserId} (actor: {Actor})",
                         assignment.AssignmentId, requestedUserId, actorBattleTag);
                 }
@@ -114,7 +116,7 @@ public class OrphanRewardService(
                     result.Errors.Add($"{assignment.AssignmentId}: {ex.Message}");
                 }
             }
-            result.UsersTouched++;
+            if (revokedForUser > 0) result.UsersTouched++;
         }
 
         return result;

--- a/W3ChampionsStatisticService/Rewards/Services/OrphanRewardService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/OrphanRewardService.cs
@@ -49,7 +49,7 @@ public class OrphanRewardService(
             .Where(m => m.IsActivePatron && !string.IsNullOrEmpty(m.PatreonUserId))
             .Select(m => patreonUserIdToBattleTag.GetValueOrDefault(m.PatreonUserId))
             .Where(bt => !string.IsNullOrEmpty(bt))
-            .ToHashSet();
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var grouped = activePatreonRAs.GroupBy(ra => ra.UserId);
         foreach (var group in grouped)

--- a/W3ChampionsStatisticService/Rewards/Services/OrphanRewardService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/OrphanRewardService.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using W3C.Domain.Rewards.Abstractions;
+using W3C.Domain.Rewards.Entities;
+using W3C.Domain.Rewards.Repositories;
+using W3C.Domain.Rewards.ValueObjects;
+using W3ChampionsStatisticService.Rewards.Providers.Patreon;
+
+namespace W3ChampionsStatisticService.Rewards.Services;
+
+public class OrphanRewardService(
+    IRewardAssignmentRepository assignmentRepository,
+    IProductMappingUserAssociationRepository associationRepository,
+    IPatreonAccountLinkRepository linkRepository,
+    PatreonApiClient patreonApiClient,
+    IRewardService rewardService,
+    ILogger<OrphanRewardService> logger) : IOrphanRewardService
+{
+    private const string ProviderId = "patreon";
+
+    private readonly IRewardAssignmentRepository _assignmentRepository = assignmentRepository;
+    private readonly IProductMappingUserAssociationRepository _associationRepository = associationRepository;
+    private readonly IPatreonAccountLinkRepository _linkRepository = linkRepository;
+    private readonly PatreonApiClient _patreonApiClient = patreonApiClient;
+    private readonly IRewardService _rewardService = rewardService;
+    private readonly ILogger<OrphanRewardService> _logger = logger;
+
+    public async Task<OrphanRewardReport> DetectOrphans()
+    {
+        var report = new OrphanRewardReport { DetectedAtUtc = DateTime.UtcNow };
+
+        var activePatreonRAs = await _assignmentRepository.GetActiveAssignmentsByProvider(ProviderId);
+        if (!activePatreonRAs.Any()) return report;
+
+        var activeAssociations = await _associationRepository.GetAll(AssociationStatus.Active);
+        var userIdsWithActivePmua = activeAssociations
+            .Where(a => a.ProviderId == ProviderId && a.IsActive())
+            .Select(a => a.UserId)
+            .ToHashSet();
+
+        var allLinks = await _linkRepository.GetAll();
+        var patreonUserIdToBattleTag = allLinks.ToDictionary(l => l.PatreonUserId, l => l.BattleTag);
+
+        var allMembers = await _patreonApiClient.GetAllCampaignMembers();
+        var activePatronBattleTags = allMembers
+            .Where(m => m.IsActivePatron && !string.IsNullOrEmpty(m.PatreonUserId))
+            .Select(m => patreonUserIdToBattleTag.GetValueOrDefault(m.PatreonUserId))
+            .Where(bt => !string.IsNullOrEmpty(bt))
+            .ToHashSet();
+
+        var grouped = activePatreonRAs.GroupBy(ra => ra.UserId);
+        foreach (var group in grouped)
+        {
+            var userId = group.Key;
+            if (string.IsNullOrEmpty(userId)) continue;
+
+            if (userIdsWithActivePmua.Contains(userId)) continue;       // healthy
+            if (activePatronBattleTags.Contains(userId)) continue;      // missing-but-reactivating; will heal via drift
+
+            report.Entries.Add(new OrphanRewardEntry
+            {
+                UserId = userId,
+                Reason = "Active patreon RewardAssignment with no backing active PMUA and not an active patron",
+                Assignments = group.Select(ra => new OrphanAssignmentDetail
+                {
+                    AssignmentId = ra.Id,
+                    RewardId = ra.RewardId,
+                    ProviderReference = ra.ProviderReference,
+                    AssignedAt = ra.AssignedAt
+                }).ToList()
+            });
+        }
+
+        _logger.LogInformation("Orphan detection: {Count} users with orphan rewards", report.Entries.Count);
+        return report;
+    }
+
+    public async Task<OrphanRewardRevocationResult> RevokeOrphans(IReadOnlySet<string> approvedUserIds, string actorBattleTag)
+    {
+        var result = new OrphanRewardRevocationResult { ExecutedAtUtc = DateTime.UtcNow };
+
+        // Re-detect to make the decision against fresh data — never revoke based on a stale report.
+        var freshReport = await DetectOrphans();
+        var freshUserIds = freshReport.Entries.Select(e => e.UserId).ToHashSet();
+
+        foreach (var requestedUserId in approvedUserIds)
+        {
+            if (!freshUserIds.Contains(requestedUserId))
+            {
+                result.SkippedUserIdsNotInLatestDetection.Add(requestedUserId);
+                _logger.LogWarning("Skipping orphan revocation for {UserId} — no longer in fresh orphan detection (actor: {Actor})",
+                    requestedUserId, actorBattleTag);
+                continue;
+            }
+
+            var entry = freshReport.Entries.First(e => e.UserId == requestedUserId);
+            foreach (var assignment in entry.Assignments)
+            {
+                try
+                {
+                    await _rewardService.RevokeReward(assignment.AssignmentId,
+                        $"Admin orphan cleanup by {actorBattleTag}: no backing active PMUA, not active patron");
+                    result.AssignmentsRevoked++;
+                    _logger.LogInformation("Admin orphan cleanup revoked {AssignmentId} for {UserId} (actor: {Actor})",
+                        assignment.AssignmentId, requestedUserId, actorBattleTag);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Admin orphan cleanup failed for {AssignmentId} ({UserId})",
+                        assignment.AssignmentId, requestedUserId);
+                    result.Errors.Add($"{assignment.AssignmentId}: {ex.Message}");
+                }
+            }
+            result.UsersTouched++;
+        }
+
+        return result;
+    }
+}

--- a/W3ChampionsStatisticService/Rewards/Services/OrphanRewardService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/OrphanRewardService.cs
@@ -42,7 +42,7 @@ public class OrphanRewardService(
         var userIdsWithActivePmua = activeAssociations
             .Where(a => a.ProviderId == ProviderId && a.IsActive())
             .Select(a => a.UserId)
-            .ToHashSet();
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var allLinks = await _linkRepository.GetAll();
         var patreonUserIdToBattleTag = allLinks.ToDictionary(l => l.PatreonUserId, l => l.BattleTag);

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -714,6 +714,22 @@ public class PatreonDriftDetectionService(
         var associations = userAssociationsLookup.GetValueOrDefault(extraAssignment.UserId) ?? new List<ProductMappingUserAssociation>();
         var activePatreonAssociations = associations.Where(a => a.ProviderId == ProviderId && a.IsActive()).ToList();
 
+        if (!dryRun)
+        {
+            // Revoke RewardAssignments FIRST. If this throws, PMUAs stay active and
+            // the next drift cycle retries the whole user cleanly. Revoking PMUAs first
+            // would leave active RAs with no PMUA — recreating the orphan-RA bug.
+            var activeRAs = await _rewardAssignmentRepository.GetByUserIdAndStatus(extraAssignment.UserId, RewardStatus.Active);
+            var patreonRAs = activeRAs.Where(a => a.ProviderId == ProviderId).ToList();
+
+            foreach (var ra in patreonRAs)
+            {
+                await _rewardService.RevokeReward(ra.Id, $"Drift sync: {extraAssignment.Reason}");
+                Log.Information("Drift sync revoked RewardAssignment {AssignmentId} for {UserId} (reward {RewardId})",
+                    ra.Id, extraAssignment.UserId, ra.RewardId);
+            }
+        }
+
         foreach (var association in activePatreonAssociations)
         {
             association.Revoke($"Drift sync: {extraAssignment.Reason}");
@@ -723,20 +739,6 @@ public class PatreonDriftDetectionService(
         if (dryRun)
         {
             return;
-        }
-
-        // Directly revoke active patreon RewardAssignment rows for this user.
-        // The reconciler can NOT do this on its own because it iterates active PMUAs;
-        // by this point the user has zero active PMUAs and the reconciler would no-op.
-        // Mirror the proven path from PatreonAccountLinkRepository.HandleLinkRemoval.
-        var activeRAs = await _rewardAssignmentRepository.GetByUserIdAndStatus(extraAssignment.UserId, RewardStatus.Active);
-        var patreonRAs = activeRAs.Where(a => a.ProviderId == ProviderId).ToList();
-
-        foreach (var ra in patreonRAs)
-        {
-            await _rewardService.RevokeReward(ra.Id, $"Drift sync: {extraAssignment.Reason}");
-            Log.Information("Drift sync revoked RewardAssignment {AssignmentId} for {UserId} (reward {RewardId})",
-                ra.Id, extraAssignment.UserId, ra.RewardId);
         }
 
         // Reconciliation pass — covers any RA the direct revoke didn't catch
@@ -848,15 +850,9 @@ public class PatreonDriftDetectionService(
     /// </summary>
     private async Task DeactivateAllUserAssociations(string battleTag, List<ProductMappingUserAssociation> currentAssociations)
     {
-        foreach (var association in currentAssociations)
-        {
-            association.Revoke("Patron no longer active");
-            await _associationRepository.Update(association);
-        }
-
-        // Directly revoke active patreon RewardAssignment rows for this user.
-        // Mirror DeactivateUserAssociation; the reconciler alone cannot do this
-        // because it iterates active PMUAs and would see an empty set.
+        // Revoke RewardAssignments FIRST. If this throws, PMUAs stay active and
+        // the next sync cycle retries cleanly. Revoking PMUAs first would leave active
+        // RAs with no PMUA — recreating the orphan-RA bug.
         var activeRAs = await _rewardAssignmentRepository.GetByUserIdAndStatus(battleTag, RewardStatus.Active);
         var patreonRAs = activeRAs.Where(a => a.ProviderId == ProviderId).ToList();
 
@@ -865,6 +861,12 @@ public class PatreonDriftDetectionService(
             await _rewardService.RevokeReward(ra.Id, "Patron no longer active");
             Log.Information("SyncSingleUser revoked RewardAssignment {AssignmentId} for {UserId} (reward {RewardId})",
                 ra.Id, battleTag, ra.RewardId);
+        }
+
+        foreach (var association in currentAssociations)
+        {
+            association.Revoke("Patron no longer active");
+            await _associationRepository.Update(association);
         }
 
         // Reconciliation pass for completeness

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -854,7 +854,20 @@ public class PatreonDriftDetectionService(
             await _associationRepository.Update(association);
         }
 
-        // Immediately reconcile rewards to revoke all assignments
+        // Directly revoke active patreon RewardAssignment rows for this user.
+        // Mirror DeactivateUserAssociation; the reconciler alone cannot do this
+        // because it iterates active PMUAs and would see an empty set.
+        var activeRAs = await _rewardAssignmentRepository.GetByUserIdAndStatus(battleTag, RewardStatus.Active);
+        var patreonRAs = activeRAs.Where(a => a.ProviderId == ProviderId).ToList();
+
+        foreach (var ra in patreonRAs)
+        {
+            await _rewardService.RevokeReward(ra.Id, "Patron no longer active");
+            Log.Information("SyncSingleUser revoked RewardAssignment {AssignmentId} for {UserId} (reward {RewardId})",
+                ra.Id, battleTag, ra.RewardId);
+        }
+
+        // Reconciliation pass for completeness
         var eventIdPrefix = $"deactivate_{DateTime.UtcNow:yyyyMMddHHmmss}_{battleTag}";
         var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(battleTag, eventIdPrefix, dryRun: false);
         Log.Information("Reconciled rewards for deactivated patron {UserId}: Added={Added}, Revoked={Revoked}",

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -7,6 +7,7 @@ using W3C.Domain.Rewards.Abstractions;
 using W3C.Domain.Rewards.Constants;
 using W3C.Domain.Rewards.Entities;
 using W3C.Domain.Rewards.Repositories;
+using W3C.Domain.Rewards.ValueObjects;
 using W3ChampionsStatisticService.Rewards.Providers.Patreon;
 
 namespace W3ChampionsStatisticService.Rewards.Services;
@@ -719,14 +720,31 @@ public class PatreonDriftDetectionService(
             await _associationRepository.Update(association);
         }
 
-        // Immediately reconcile rewards for this user to revoke assignments (unless dry run)
-        if (!dryRun)
+        if (dryRun)
         {
-            var eventIdPrefix = $"extra_assignment_removal_{DateTime.UtcNow:yyyyMMddHHmmss}_{extraAssignment.UserId}";
-            var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(extraAssignment.UserId, eventIdPrefix, dryRun: false);
-            Log.Information("Reconciled rewards for extra assignment user {UserId}: Added={Added}, Revoked={Revoked}",
-                extraAssignment.UserId, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
+            return;
         }
+
+        // Directly revoke active patreon RewardAssignment rows for this user.
+        // The reconciler can NOT do this on its own because it iterates active PMUAs;
+        // by this point the user has zero active PMUAs and the reconciler would no-op.
+        // Mirror the proven path from PatreonAccountLinkRepository.HandleLinkRemoval.
+        var activeRAs = await _rewardAssignmentRepository.GetByUserIdAndStatus(extraAssignment.UserId, RewardStatus.Active);
+        var patreonRAs = activeRAs.Where(a => a.ProviderId == ProviderId).ToList();
+
+        foreach (var ra in patreonRAs)
+        {
+            await _rewardService.RevokeReward(ra.Id, $"Drift sync: {extraAssignment.Reason}");
+            Log.Information("Drift sync revoked RewardAssignment {AssignmentId} for {UserId} (reward {RewardId})",
+                ra.Id, extraAssignment.UserId, ra.RewardId);
+        }
+
+        // Reconciliation pass — covers any RA the direct revoke didn't catch
+        // (e.g., legacy webhook-created RAs with a different match key).
+        var eventIdPrefix = $"extra_assignment_removal_{DateTime.UtcNow:yyyyMMddHHmmss}_{extraAssignment.UserId}";
+        var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(extraAssignment.UserId, eventIdPrefix, dryRun: false);
+        Log.Information("Reconciled rewards for extra assignment user {UserId}: Added={Added}, Revoked={Revoked}",
+            extraAssignment.UserId, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
     }
 
     /// <summary>

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -724,9 +724,17 @@ public class PatreonDriftDetectionService(
 
             foreach (var ra in patreonRAs)
             {
-                await _rewardService.RevokeReward(ra.Id, $"Drift sync: {extraAssignment.Reason}");
-                Log.Information("Drift sync revoked RewardAssignment {AssignmentId} for {UserId} (reward {RewardId})",
-                    ra.Id, extraAssignment.UserId, ra.RewardId);
+                try
+                {
+                    await _rewardService.RevokeReward(ra.Id, $"Drift sync: {extraAssignment.Reason}");
+                    Log.Information("Drift sync revoked RewardAssignment {AssignmentId} for {UserId} (reward {RewardId})",
+                        ra.Id, extraAssignment.UserId, ra.RewardId);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Drift sync failed to revoke RewardAssignment {AssignmentId} for {UserId} — continuing with remaining RAs",
+                        ra.Id, extraAssignment.UserId);
+                }
             }
         }
 
@@ -888,9 +896,17 @@ public class PatreonDriftDetectionService(
 
         foreach (var ra in patreonRAs)
         {
-            await _rewardService.RevokeReward(ra.Id, "Patron no longer active");
-            Log.Information("SyncSingleUser revoked RewardAssignment {AssignmentId} for {UserId} (reward {RewardId})",
-                ra.Id, battleTag, ra.RewardId);
+            try
+            {
+                await _rewardService.RevokeReward(ra.Id, "Patron no longer active");
+                Log.Information("SyncSingleUser revoked RewardAssignment {AssignmentId} for {UserId} (reward {RewardId})",
+                    ra.Id, battleTag, ra.RewardId);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "SyncSingleUser failed to revoke RewardAssignment {AssignmentId} for {UserId} — continuing with remaining RAs",
+                    ra.Id, battleTag);
+            }
         }
 
         foreach (var association in currentAssociations)

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -700,6 +700,8 @@ public class PatreonDriftDetectionService(
             var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(battleTag, eventIdPrefix, dryRun: false);
             Log.Information("Reconciled rewards for missing member {PatreonUserId} -> {UserId}: Added={Added}, Revoked={Revoked}",
                 missingMember.PatreonUserId, battleTag, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
+
+            await TouchLastSync(battleTag);
         }
     }
 
@@ -745,6 +747,8 @@ public class PatreonDriftDetectionService(
         var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(extraAssignment.UserId, eventIdPrefix, dryRun: false);
         Log.Information("Reconciled rewards for extra assignment user {UserId}: Added={Added}, Revoked={Revoked}",
             extraAssignment.UserId, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
+
+        await TouchLastSync(extraAssignment.UserId);
     }
 
     /// <summary>
@@ -803,6 +807,8 @@ public class PatreonDriftDetectionService(
         var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(tierMismatch.UserId, eventIdPrefix, dryRun: false);
         Log.Information("Reconciled rewards for tier mismatch user {UserId}: Added={Added}, Revoked={Revoked}",
             tierMismatch.UserId, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
+
+        await TouchLastSync(tierMismatch.UserId);
 
         return true;
     }

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -726,15 +726,15 @@ public class PatreonDriftDetectionService(
             }
         }
 
+        if (dryRun)
+        {
+            return;
+        }
+
         foreach (var association in activePatreonAssociations)
         {
             association.Revoke($"Drift sync: {extraAssignment.Reason}");
             await _associationRepository.Update(association);
-        }
-
-        if (dryRun)
-        {
-            return;
         }
 
         // Reconciliation pass — covers any RA the direct revoke didn't catch

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -431,15 +431,7 @@ public class PatreonDriftDetectionService(
             {
                 try
                 {
-                    // We no longer create events - we work directly with associations
-                    // var syncEvent = CreateTierMismatchEvent(tierMismatch);
-                    // syncResult.GeneratedEvents.Add(syncEvent);
-
-                    bool didWork = true;
-                    if (!dryRun)
-                    {
-                        didWork = await UpdateUserAssociationTiers(tierMismatch, dryRun);
-                    }
+                    var didWork = await UpdateUserAssociationTiers(tierMismatch, dryRun);
 
                     if (didWork)
                     {
@@ -754,12 +746,14 @@ public class PatreonDriftDetectionService(
     }
 
     /// <summary>
-    /// Updates associations for tier mismatch
+    /// Updates associations for tier mismatch.
+    /// Consults the no-op guard FIRST (before checking dryRun) so that dry-run callers
+    /// receive an accurate preview of what a live sync would do.
     /// </summary>
-    /// <returns>true when tiers were actually updated; false when the actionable set already matches and no work was done.</returns>
+    /// <returns>true when tiers would be (or were) updated; false when the actionable set already
+    /// matches the existing active set and no work is needed.</returns>
     private async Task<bool> UpdateUserAssociationTiers(TierMismatch tierMismatch, bool dryRun = false)
     {
-        // Deactivate current associations
         var currentAssociations = await _associationRepository.GetProductMappingsByUserId(tierMismatch.UserId);
         var activePatreonAssociations = currentAssociations.Where(a => a.ProviderId == ProviderId && a.IsActive()).ToList();
 
@@ -780,8 +774,14 @@ public class PatreonDriftDetectionService(
         if (existingActive.SetEquals(actionableTiers))
         {
             Log.Debug("Drift no-op for {UserId}: actionable tier set {Tiers} matches existing active.",
-                tierMismatch.UserId, string.Join(",", actionableTiers));
+                tierMismatch.UserId, string.Join(",", actionableTiers.OrderBy(t => t, System.StringComparer.Ordinal)));
             return false;
+        }
+
+        if (dryRun)
+        {
+            // Real change would occur but we are in preview mode — report it without mutating.
+            return true;
         }
 
         foreach (var association in activePatreonAssociations)
@@ -790,20 +790,17 @@ public class PatreonDriftDetectionService(
             await _associationRepository.Update(association);
         }
 
-        // Create new associations for current tiers
+        // filteredTierIds may include unmapped tiers (e.g., the campaign's free-follower tier).
+        // CreateOrUpdateAssociation skips those silently when no mapping exists.
         foreach (var tierId in filteredTierIds)
         {
-            await CreateOrUpdateAssociation(tierMismatch.UserId, tierId, "drift_sync_tier_update", skipReconciliation: dryRun);
+            await CreateOrUpdateAssociation(tierMismatch.UserId, tierId, "drift_sync_tier_update", skipReconciliation: false);
         }
 
-        // Immediately reconcile rewards for this user (unless dry run)
-        if (!dryRun)
-        {
-            var eventIdPrefix = $"tier_mismatch_fix_{DateTime.UtcNow:yyyyMMddHHmmss}_{tierMismatch.UserId}";
-            var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(tierMismatch.UserId, eventIdPrefix, dryRun: false);
-            Log.Information("Reconciled rewards for tier mismatch user {UserId}: Added={Added}, Revoked={Revoked}",
-                tierMismatch.UserId, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
-        }
+        var eventIdPrefix = $"tier_mismatch_fix_{DateTime.UtcNow:yyyyMMddHHmmss}_{tierMismatch.UserId}";
+        var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(tierMismatch.UserId, eventIdPrefix, dryRun: false);
+        Log.Information("Reconciled rewards for tier mismatch user {UserId}: Added={Added}, Revoked={Revoked}",
+            tierMismatch.UserId, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
 
         return true;
     }

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -602,7 +602,7 @@ public class PatreonDriftDetectionService(
                 Log.Information("[USER-SYNC] Successfully processed {SyncAction} for BattleTag {BattleTag} (PatreonUserId: {PatreonUserId})",
                     syncAction, battleTag, patreonUserId);
 
-                await TouchLastSync(battleTag);
+                await _patreonLinkRepository.RefreshLastSyncAt(battleTag);
             }
 
             return result;
@@ -701,7 +701,7 @@ public class PatreonDriftDetectionService(
             Log.Information("Reconciled rewards for missing member {PatreonUserId} -> {UserId}: Added={Added}, Revoked={Revoked}",
                 missingMember.PatreonUserId, battleTag, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
 
-            await TouchLastSync(battleTag);
+            await _patreonLinkRepository.RefreshLastSyncAt(battleTag);
         }
     }
 
@@ -748,7 +748,7 @@ public class PatreonDriftDetectionService(
         Log.Information("Reconciled rewards for extra assignment user {UserId}: Added={Added}, Revoked={Revoked}",
             extraAssignment.UserId, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
 
-        await TouchLastSync(extraAssignment.UserId);
+        await _patreonLinkRepository.RefreshLastSyncAt(extraAssignment.UserId);
     }
 
     /// <summary>
@@ -808,7 +808,7 @@ public class PatreonDriftDetectionService(
         Log.Information("Reconciled rewards for tier mismatch user {UserId}: Added={Added}, Revoked={Revoked}",
             tierMismatch.UserId, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
 
-        await TouchLastSync(tierMismatch.UserId);
+        await _patreonLinkRepository.RefreshLastSyncAt(tierMismatch.UserId);
 
         return true;
     }
@@ -1023,26 +1023,6 @@ public class PatreonDriftDetectionService(
         }
     }
 
-    /// <summary>
-    /// Refresh the PatreonAccountLink.LastSyncAt timestamp after a successful sync action for this user.
-    /// Non-fatal on failure — the main sync already succeeded; this is just bookkeeping.
-    /// </summary>
-    private async Task TouchLastSync(string battleTag)
-    {
-        try
-        {
-            var link = await _patreonLinkRepository.GetByBattleTag(battleTag);
-            if (link != null)
-            {
-                link.UpdateLastSync();
-                await _patreonLinkRepository.Update(link);
-            }
-        }
-        catch (Exception ex)
-        {
-            Log.Warning(ex, "Failed to update LastSyncAt for {BattleTag}", battleTag);
-        }
-    }
 }
 
 public class DriftDetectionResult

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -16,13 +16,17 @@ public class PatreonDriftDetectionService(
     IProductMappingUserAssociationRepository associationRepository,
     IProductMappingRepository productMappingRepository,
     IPatreonAccountLinkRepository patreonLinkRepository,
-    IProductMappingReconciliationService reconciliationService)
+    IProductMappingReconciliationService reconciliationService,
+    IRewardAssignmentRepository rewardAssignmentRepository,
+    IRewardService rewardService)
 {
     private readonly PatreonApiClient _patreonApiClient = patreonApiClient;
     private readonly IProductMappingUserAssociationRepository _associationRepository = associationRepository;
     private readonly IProductMappingRepository _productMappingRepository = productMappingRepository;
     private readonly IPatreonAccountLinkRepository _patreonLinkRepository = patreonLinkRepository;
     private readonly IProductMappingReconciliationService _reconciliationService = reconciliationService;
+    private readonly IRewardAssignmentRepository _rewardAssignmentRepository = rewardAssignmentRepository;
+    private readonly IRewardService _rewardService = rewardService;
     private const string ProviderId = "patreon";
 
     public async Task<DriftDetectionResult> DetectDrift()

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -435,17 +435,21 @@ public class PatreonDriftDetectionService(
                     // var syncEvent = CreateTierMismatchEvent(tierMismatch);
                     // syncResult.GeneratedEvents.Add(syncEvent);
 
+                    bool didWork = true;
                     if (!dryRun)
                     {
-                        await UpdateUserAssociationTiers(tierMismatch, dryRun);
+                        didWork = await UpdateUserAssociationTiers(tierMismatch, dryRun);
                     }
 
-                    syncResult.TiersUpdated++;
-                    Log.Information("[DRIFT-SYNC] {Action} tiers for user: {UserId} " +
-                        "(Patreon Filtered: [{PatreonFiltered}], Internal Filtered: [{InternalFiltered}])",
-                        dryRun ? "Would update" : "Updated", tierMismatch.UserId,
-                        string.Join(",", tierMismatch.PatreonTiersFiltered ?? tierMismatch.PatreonTiers ?? new List<string>()),
-                        string.Join(",", tierMismatch.InternalTiersFiltered ?? tierMismatch.InternalTiers ?? new List<string>()));
+                    if (didWork)
+                    {
+                        syncResult.TiersUpdated++;
+                        Log.Information("[DRIFT-SYNC] {Action} tiers for user: {UserId} " +
+                            "(Patreon Filtered: [{PatreonFiltered}], Internal Filtered: [{InternalFiltered}])",
+                            dryRun ? "Would update" : "Updated", tierMismatch.UserId,
+                            string.Join(",", tierMismatch.PatreonTiersFiltered ?? tierMismatch.PatreonTiers ?? new List<string>()),
+                            string.Join(",", tierMismatch.InternalTiersFiltered ?? tierMismatch.InternalTiers ?? new List<string>()));
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -752,20 +756,39 @@ public class PatreonDriftDetectionService(
     /// <summary>
     /// Updates associations for tier mismatch
     /// </summary>
-    private async Task UpdateUserAssociationTiers(TierMismatch tierMismatch, bool dryRun = false)
+    /// <returns>true when tiers were actually updated; false when the actionable set already matches and no work was done.</returns>
+    private async Task<bool> UpdateUserAssociationTiers(TierMismatch tierMismatch, bool dryRun = false)
     {
         // Deactivate current associations
         var currentAssociations = await _associationRepository.GetProductMappingsByUserId(tierMismatch.UserId);
         var activePatreonAssociations = currentAssociations.Where(a => a.ProviderId == ProviderId && a.IsActive()).ToList();
+
+        var existingActive = activePatreonAssociations.Select(a => a.ProviderProductId).ToHashSet();
+
+        var allProductMappings = await _productMappingRepository.GetByProviderId(ProviderId);
+
+        // Compute the actionable tier set: filtered Patreon tiers that have a corresponding ProductMapping.
+        // Tiers without a mapping (e.g., the campaign's free-follower tier) cannot be stored as PMUAs and
+        // would be skipped during create — so they should also be excluded from the comparison to avoid
+        // an infinite revoke+recreate churn loop.
+        var filteredTierIds = tierMismatch.PatreonTiersFiltered ?? new List<string>();
+        var actionableTiers = filteredTierIds
+            .Where(tid => allProductMappings.Any(pm =>
+                pm.ProductProviders.Any(pp => pp.ProviderId == ProviderId && pp.ProductId == tid)))
+            .ToHashSet();
+
+        if (existingActive.SetEquals(actionableTiers))
+        {
+            Log.Debug("Drift no-op for {UserId}: actionable tier set {Tiers} matches existing active.",
+                tierMismatch.UserId, string.Join(",", actionableTiers));
+            return false;
+        }
 
         foreach (var association in activePatreonAssociations)
         {
             association.Revoke("Tier mismatch - updating to match Patreon");
             await _associationRepository.Update(association);
         }
-
-        // Use the pre-filtered tiers from the TierMismatch that were already processed during detection
-        var filteredTierIds = tierMismatch.PatreonTiersFiltered ?? new List<string>();
 
         // Create new associations for current tiers
         foreach (var tierId in filteredTierIds)
@@ -781,6 +804,8 @@ public class PatreonDriftDetectionService(
             Log.Information("Reconciled rewards for tier mismatch user {UserId}: Added={Added}, Revoked={Revoked}",
                 tierMismatch.UserId, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
         }
+
+        return true;
     }
 
     /// <summary>

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonDriftDetectionService.cs
@@ -601,6 +601,8 @@ public class PatreonDriftDetectionService(
 
                 Log.Information("[USER-SYNC] Successfully processed {SyncAction} for BattleTag {BattleTag} (PatreonUserId: {PatreonUserId})",
                     syncAction, battleTag, patreonUserId);
+
+                await TouchLastSync(battleTag);
             }
 
             return result;
@@ -1012,6 +1014,27 @@ public class PatreonDriftDetectionService(
             var reconciliationResult = await _reconciliationService.ReconcileUserAssociations(battleTag, eventIdPrefix, dryRun: false);
             Log.Information("Reconciled rewards for user {UserId}: Added={Added}, Revoked={Revoked}",
                 battleTag, reconciliationResult.RewardsAdded, reconciliationResult.RewardsRevoked);
+        }
+    }
+
+    /// <summary>
+    /// Refresh the PatreonAccountLink.LastSyncAt timestamp after a successful sync action for this user.
+    /// Non-fatal on failure — the main sync already succeeded; this is just bookkeeping.
+    /// </summary>
+    private async Task TouchLastSync(string battleTag)
+    {
+        try
+        {
+            var link = await _patreonLinkRepository.GetByBattleTag(battleTag);
+            if (link != null)
+            {
+                link.UpdateLastSync();
+                await _patreonLinkRepository.Update(link);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to update LastSyncAt for {BattleTag}", battleTag);
         }
     }
 }

--- a/W3ChampionsStatisticService/Rewards/Services/PatreonTierFilter.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/PatreonTierFilter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Serilog;
@@ -9,12 +10,34 @@ internal static class PatreonTierFilter
 {
     private const string ProviderId = "patreon";
 
+    /// <summary>
+    /// Reads REWARDS_PATREON_IGNORED_TIER_IDS env var (comma-separated tier IDs) and uses it
+    /// as the ignore list. Empty/missing → no tiers ignored. The ignore list lets us drop
+    /// non-monetized "follower" tiers (e.g., Patreon's free-tier feature) that have no
+    /// corresponding ProductMapping, preventing infinite drift mismatch loops.
+    /// </summary>
     public static List<string> Filter(List<EntitledTier> tiers, List<ProductMapping> productMappings)
     {
+        return Filter(tiers, productMappings, GetIgnoredTierIdsFromEnv());
+    }
+
+    /// <summary>
+    /// Test-friendly overload: ignored tier IDs supplied explicitly.
+    /// Tiers in the ignore list are dropped before the passthrough/Tiered split.
+    /// </summary>
+    public static List<string> Filter(
+        List<EntitledTier> tiers,
+        List<ProductMapping> productMappings,
+        IReadOnlySet<string> ignoredTierIds)
+    {
+        var input = (ignoredTierIds == null || ignoredTierIds.Count == 0)
+            ? tiers
+            : tiers.Where(t => !ignoredTierIds.Contains(t.TierId)).ToList();
+
         var tieredCandidates = new List<EntitledTier>();
         var passthrough = new List<string>();
 
-        foreach (var t in tiers)
+        foreach (var t in input)
         {
             var mapping = productMappings.FirstOrDefault(pm =>
                 pm.ProductProviders.Any(pp => pp.ProviderId == ProviderId && pp.ProductId == t.TierId));
@@ -29,7 +52,7 @@ internal static class PatreonTierFilter
         {
             var winner = tieredCandidates
                 .OrderByDescending(c => c.AmountCents.HasValue && c.AmountCents.Value >= 0 ? c.AmountCents.Value : long.MinValue)
-                .ThenBy(c => c.TierId, System.StringComparer.Ordinal)
+                .ThenBy(c => c.TierId, StringComparer.Ordinal)
                 .First();
             result.Add(winner.TierId);
             if (tieredCandidates.Count > 1)
@@ -39,5 +62,14 @@ internal static class PatreonTierFilter
                         .Select(c => $"{c.TierId}({c.AmountCents}c)")));
         }
         return result;
+    }
+
+    private static IReadOnlySet<string> GetIgnoredTierIdsFromEnv()
+    {
+        var raw = Environment.GetEnvironmentVariable("REWARDS_PATREON_IGNORED_TIER_IDS");
+        if (string.IsNullOrWhiteSpace(raw)) return new HashSet<string>();
+        return raw
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToHashSet(StringComparer.Ordinal);
     }
 }

--- a/W3ChampionsStatisticService/Rewards/Services/ProductMappingReconciliationService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/ProductMappingReconciliationService.cs
@@ -75,6 +75,25 @@ public class ProductMappingReconciliationService(
     }
 
     /// <summary>
+    /// Extracts the ProductMapping ID an active RA was created for, using the same three-way matching
+    /// logic as GetUserAssignmentsForMapping but in reverse. Returns null if the RA can't be matched
+    /// to any mapping (e.g., manual grant, malformed metadata) — such RAs are left alone.
+    /// </summary>
+    private static string TryExtractMappingId(RewardAssignment ra)
+    {
+        if (!string.IsNullOrEmpty(ra.ProviderReference) && ra.ProviderReference.StartsWith("reconciliation:"))
+        {
+            return ra.ProviderReference.Substring("reconciliation:".Length);
+        }
+        if (ra.Metadata != null && ra.Metadata.TryGetValue("product_mapping_id", out var mappingIdObj) && mappingIdObj != null)
+        {
+            return mappingIdObj.ToString();
+        }
+        // Webhook-created RAs use Metadata["tier_id"] — caller must resolve via product mapping lookup.
+        return null;
+    }
+
+    /// <summary>
     /// Reconciles rewards for a specific user based on their current associations
     /// </summary>
     public async Task<ProductMappingReconciliationResult> ReconcileUserAssociations(string userId, string eventIdPrefix, bool dryRun = false)
@@ -93,9 +112,11 @@ public class ProductMappingReconciliationService(
 
             // Get all active associations for this user
             var activeAssociations = await _productMappingService.GetUserAssociationsByUserId(userId);
+            var expectedMappingIds = activeAssociations.Select(a => a.ProductMappingId).ToHashSet();
 
             _logger.LogInformation("Found {ActiveCount} active associations for user {UserId}", activeAssociations.Count, userId);
 
+            // Forward sweep: for each active PMUA, ensure RAs for its mapping match the mapping's reward list
             foreach (var association in activeAssociations)
             {
                 var mapping = await _productMappingService.GetProductMappingById(association.ProductMappingId);
@@ -120,11 +141,38 @@ public class ProductMappingReconciliationService(
                 }
             }
 
-            result.TotalUsersAffected = result.UserReconciliations.Any() ? 1 : 0;
+            // Backward sweep: revoke active patreon RAs whose mapping has no backing active PMUA.
+            // This closes the gap where a PMUA has been revoked but its RAs remain active —
+            // the structural bug that caused the orphan RA pattern in production. Manual grants
+            // (ProviderId != "patreon", or null) are NOT touched.
+            var allUserRewards = await _rewardService.GetUserRewards(userId);
+            var activePatreonOrphans = allUserRewards
+                .Where(ra => ra.Status == RewardStatus.Active && ra.ProviderId == "patreon")
+                .Where(ra =>
+                {
+                    var raMappingId = TryExtractMappingId(ra);
+                    // Only revoke if we can identify the mapping AND it's not in the active set.
+                    // RAs we can't classify are left alone (defensive: avoid revoking webhook-only or unknown rows).
+                    return raMappingId != null && !expectedMappingIds.Contains(raMappingId);
+                })
+                .ToList();
+
+            foreach (var orphan in activePatreonOrphans)
+            {
+                if (!dryRun)
+                {
+                    await _rewardService.RevokeReward(orphan.Id, "Reconciliation: no backing active PMUA");
+                    _logger.LogInformation("Reconciler revoked orphan RewardAssignment {AssignmentId} for {UserId} (reward {RewardId})",
+                        orphan.Id, userId, orphan.RewardId);
+                }
+                result.RewardsRevoked++;
+            }
+
+            result.TotalUsersAffected = (result.UserReconciliations.Any() || activePatreonOrphans.Any()) ? 1 : 0;
             result.Success = result.Errors.Count == 0;
 
-            _logger.LogInformation("User reconciliation completed for {UserId}: Success={Success}, Added={Added}, Revoked={Revoked}",
-                userId, result.Success, result.RewardsAdded, result.RewardsRevoked);
+            _logger.LogInformation("User reconciliation completed for {UserId}: Success={Success}, Added={Added}, Revoked={Revoked} (Orphans={OrphanCount})",
+                userId, result.Success, result.RewardsAdded, result.RewardsRevoked, activePatreonOrphans.Count);
 
             return result;
         }

--- a/W3ChampionsStatisticService/Rewards/Services/RewardService.cs
+++ b/W3ChampionsStatisticService/Rewards/Services/RewardService.cs
@@ -486,12 +486,20 @@ public class RewardService(
     public async Task RevokeReward(string assignmentId, string reason)
     {
         var assignment = await _assignmentRepo.GetById(assignmentId);
-        if (assignment != null)
+        if (assignment == null)
         {
-            assignment.Revoke(reason);
-            await _assignmentRepo.Update(assignment);
-            await RevokeRewardModule(assignment);
+            return;
         }
+        if (assignment.Status == RewardStatus.Revoked)
+        {
+            // Idempotent: do not re-revoke. Prevents module side-effects from firing twice
+            // when multiple call paths (direct revoke + reconciler) hit the same RA.
+            _logger.LogDebug("RevokeReward called for already-revoked assignment {AssignmentId}; skipping.", assignmentId);
+            return;
+        }
+        assignment.Revoke(reason);
+        await _assignmentRepo.Update(assignment);
+        await RevokeRewardModule(assignment);
     }
 
     public async Task ExpireReward(string assignmentId)

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/OrphanRewardServiceTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/OrphanRewardServiceTests.cs
@@ -1,0 +1,189 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using W3C.Domain.Rewards.Abstractions;
+using W3C.Domain.Rewards.Entities;
+using W3C.Domain.Rewards.Repositories;
+using W3C.Domain.Rewards.ValueObjects;
+using W3ChampionsStatisticService.Rewards.Providers.Patreon;
+using W3ChampionsStatisticService.Rewards.Services;
+
+namespace WC3ChampionsStatisticService.Tests.Rewards;
+
+[TestFixture]
+public class OrphanRewardServiceTests
+{
+    private Mock<IRewardAssignmentRepository> _mockAssignmentRepo;
+    private Mock<IProductMappingUserAssociationRepository> _mockAssociationRepo;
+    private Mock<IPatreonAccountLinkRepository> _mockLinkRepo;
+    private Mock<PatreonApiClient> _mockPatreonApi;
+    private Mock<IRewardService> _mockRewardService;
+    private Mock<ILogger<OrphanRewardService>> _mockLogger;
+    private OrphanRewardService _service;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockAssignmentRepo = new Mock<IRewardAssignmentRepository>();
+        _mockAssociationRepo = new Mock<IProductMappingUserAssociationRepository>();
+        _mockLinkRepo = new Mock<IPatreonAccountLinkRepository>();
+        _mockPatreonApi = new Mock<PatreonApiClient>(Mock.Of<HttpClient>());
+        _mockRewardService = new Mock<IRewardService>();
+        _mockLogger = new Mock<ILogger<OrphanRewardService>>();
+
+        _service = new OrphanRewardService(
+            _mockAssignmentRepo.Object,
+            _mockAssociationRepo.Object,
+            _mockLinkRepo.Object,
+            _mockPatreonApi.Object,
+            _mockRewardService.Object,
+            _mockLogger.Object);
+    }
+
+    [Test]
+    public async Task DetectOrphans_FindsUserWithActiveRAButNoActivePMUAAndNotActivePatron()
+    {
+        var userId = "Bubu#23550";
+
+        _mockAssignmentRepo.Setup(x => x.GetActiveAssignmentsByProvider("patreon"))
+            .ReturnsAsync(new List<RewardAssignment>
+            {
+                new RewardAssignment { Id = "ra-1", UserId = userId, RewardId = "reward-grandmaster", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:mapping-grandmaster", AssignedAt = System.DateTime.UtcNow.AddMonths(-3) }
+            });
+
+        _mockAssociationRepo.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>()); // no active PMUAs
+
+        _mockLinkRepo.Setup(x => x.GetAll())
+            .ReturnsAsync(new List<PatreonAccountLink>()); // no link
+
+        _mockPatreonApi.Setup(x => x.GetAllCampaignMembers())
+            .ReturnsAsync(new List<PatreonMember>()); // not an active patron
+
+        var report = await _service.DetectOrphans();
+
+        Assert.That(report.Entries, Has.Count.EqualTo(1));
+        Assert.That(report.Entries[0].UserId, Is.EqualTo(userId));
+        Assert.That(report.Entries[0].Assignments.Select(a => a.AssignmentId), Is.EquivalentTo(new[] { "ra-1" }));
+    }
+
+    [Test]
+    public async Task DetectOrphans_DoesNotIncludeUserWithActivePMUA()
+    {
+        var userId = "Healthy#1234";
+
+        _mockAssignmentRepo.Setup(x => x.GetActiveAssignmentsByProvider("patreon"))
+            .ReturnsAsync(new List<RewardAssignment>
+            {
+                new RewardAssignment { Id = "ra-1", UserId = userId, RewardId = "reward-x", ProviderId = "patreon", Status = RewardStatus.Active }
+            });
+
+        _mockAssociationRepo.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>
+            {
+                new ProductMappingUserAssociation { Id = "pmua-1", UserId = userId, ProductMappingId = "mapping-x", ProviderId = "patreon", Status = AssociationStatus.Active }
+            });
+
+        _mockLinkRepo.Setup(x => x.GetAll()).ReturnsAsync(new List<PatreonAccountLink>());
+        _mockPatreonApi.Setup(x => x.GetAllCampaignMembers()).ReturnsAsync(new List<PatreonMember>());
+
+        var report = await _service.DetectOrphans();
+
+        Assert.That(report.Entries, Is.Empty);
+    }
+
+    [Test]
+    public async Task DetectOrphans_DoesNotIncludeUserWhoIsActivePatron()
+    {
+        var userId = "Reactivating#1234";
+        var patreonUserId = "999";
+
+        _mockAssignmentRepo.Setup(x => x.GetActiveAssignmentsByProvider("patreon"))
+            .ReturnsAsync(new List<RewardAssignment>
+            {
+                new RewardAssignment { Id = "ra-1", UserId = userId, RewardId = "reward-x", ProviderId = "patreon", Status = RewardStatus.Active }
+            });
+
+        _mockAssociationRepo.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+
+        _mockLinkRepo.Setup(x => x.GetAll())
+            .ReturnsAsync(new List<PatreonAccountLink> { new PatreonAccountLink(userId, patreonUserId) });
+
+        _mockPatreonApi.Setup(x => x.GetAllCampaignMembers())
+            .ReturnsAsync(new List<PatreonMember>
+            {
+                new PatreonMember
+                {
+                    PatreonUserId = patreonUserId,
+                    PatronStatus = "active_patron",
+                    LastChargeStatus = "Paid",
+                    EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = "6482051", AmountCents = 100 } }
+                }
+            });
+
+        var report = await _service.DetectOrphans();
+
+        Assert.That(report.Entries, Is.Empty);
+    }
+
+    [Test]
+    public async Task RevokeOrphans_RevokesOnlyApprovedUsers_ThatStillAppearInFreshDetection()
+    {
+        var bubu = "Bubu#23550";
+        var stale = "StaleUser#1234"; // approved by admin but no longer in fresh detection
+        var actor = "Faro#2494";
+
+        // Detection setup — only Bubu is currently an orphan
+        _mockAssignmentRepo.Setup(x => x.GetActiveAssignmentsByProvider("patreon"))
+            .ReturnsAsync(new List<RewardAssignment>
+            {
+                new RewardAssignment { Id = "ra-bubu-1", UserId = bubu, RewardId = "r1", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:m" }
+            });
+        _mockAssociationRepo.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockLinkRepo.Setup(x => x.GetAll()).ReturnsAsync(new List<PatreonAccountLink>());
+        _mockPatreonApi.Setup(x => x.GetAllCampaignMembers()).ReturnsAsync(new List<PatreonMember>());
+
+        var approved = new HashSet<string> { bubu, stale };
+
+        var result = await _service.RevokeOrphans(approved, actor);
+
+        _mockRewardService.Verify(x => x.RevokeReward("ra-bubu-1", It.Is<string>(s => s.Contains(actor))), Times.Once);
+        Assert.That(result.UsersTouched, Is.EqualTo(1));
+        Assert.That(result.AssignmentsRevoked, Is.EqualTo(1));
+        Assert.That(result.SkippedUserIdsNotInLatestDetection, Is.EquivalentTo(new[] { stale }));
+    }
+
+    [Test]
+    public async Task RevokeOrphans_LogsAndContinues_OnRevokeFailure()
+    {
+        var bubu = "Bubu#23550";
+        var actor = "Faro#2494";
+
+        _mockAssignmentRepo.Setup(x => x.GetActiveAssignmentsByProvider("patreon"))
+            .ReturnsAsync(new List<RewardAssignment>
+            {
+                new RewardAssignment { Id = "ra-1", UserId = bubu, RewardId = "r1", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:m" },
+                new RewardAssignment { Id = "ra-2", UserId = bubu, RewardId = "r2", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:m" }
+            });
+        _mockAssociationRepo.Setup(x => x.GetAll(AssociationStatus.Active)).ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockLinkRepo.Setup(x => x.GetAll()).ReturnsAsync(new List<PatreonAccountLink>());
+        _mockPatreonApi.Setup(x => x.GetAllCampaignMembers()).ReturnsAsync(new List<PatreonMember>());
+
+        _mockRewardService.Setup(x => x.RevokeReward("ra-1", It.IsAny<string>()))
+            .ThrowsAsync(new System.InvalidOperationException("simulated"));
+        _mockRewardService.Setup(x => x.RevokeReward("ra-2", It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _service.RevokeOrphans(new HashSet<string> { bubu }, actor);
+
+        Assert.That(result.AssignmentsRevoked, Is.EqualTo(1));
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
+        Assert.That(result.Errors[0], Does.Contain("ra-1"));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/OrphanRewardServiceTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/OrphanRewardServiceTests.cs
@@ -132,6 +132,47 @@ public class OrphanRewardServiceTests
     }
 
     [Test]
+    public async Task DetectOrphans_DoesNotMisclassifyActivePatron_WhenLinkBattleTagCasingDiffersFromRA()
+    {
+        // Regression test: PatreonAccountLink.BattleTag and RewardAssignment.UserId may
+        // have differed historically (pre-canonicalization). The active-patron exclusion
+        // must be case-insensitive so we don't revoke a paying patron's rewards.
+        var raUserId = "Player#1234";
+        var linkBattleTag = "player#1234"; // lowercase variant from older data
+        var patreonUserId = "12345";
+
+        _mockAssignmentRepo.Setup(x => x.GetActiveAssignmentsByProvider("patreon"))
+            .ReturnsAsync(new List<RewardAssignment>
+            {
+                new RewardAssignment { Id = "ra-1", UserId = raUserId, RewardId = "r", ProviderId = "patreon", Status = RewardStatus.Active }
+            });
+
+        _mockAssociationRepo.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+
+        _mockLinkRepo.Setup(x => x.GetAll())
+            .ReturnsAsync(new List<PatreonAccountLink> { new PatreonAccountLink(linkBattleTag, patreonUserId) });
+
+        _mockPatreonApi.Setup(x => x.GetAllCampaignMembers())
+            .ReturnsAsync(new List<PatreonMember>
+            {
+                new PatreonMember
+                {
+                    PatreonUserId = patreonUserId,
+                    PatronStatus = "active_patron",
+                    LastChargeStatus = "Paid",
+                    EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = "t1", AmountCents = 100 } }
+                }
+            });
+
+        var report = await _service.DetectOrphans();
+
+        // Should NOT be classified as orphan — they are an active patron despite casing mismatch
+        Assert.That(report.Entries, Is.Empty,
+            "Active patron with case-different BattleTag must not be flagged as orphan.");
+    }
+
+    [Test]
     public async Task RevokeOrphans_RevokesOnlyApprovedUsers_ThatStillAppearInFreshDetection()
     {
         var bubu = "Bubu#23550";

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/OrphanRewardServiceTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/OrphanRewardServiceTests.cs
@@ -253,5 +253,7 @@ public class OrphanRewardServiceTests
         Assert.That(result.AssignmentsRevoked, Is.EqualTo(1));
         Assert.That(result.Errors, Has.Count.EqualTo(1));
         Assert.That(result.Errors[0], Does.Contain("ra-1"));
+        // ra-2 must still be attempted even though ra-1 threw (log-and-continue behavior)
+        _mockRewardService.Verify(x => x.RevokeReward("ra-2", It.IsAny<string>()), Times.Once);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/OrphanRewardServiceTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/OrphanRewardServiceTests.cs
@@ -173,6 +173,40 @@ public class OrphanRewardServiceTests
     }
 
     [Test]
+    public async Task DetectOrphans_DoesNotMisclassifyOrphan_WhenPmuaUserIdCasingDiffersFromRA()
+    {
+        // Regression test for PMUA-side casing. Pre-canonicalization, RA.UserId and
+        // PMUA.UserId could differ in casing. The case-insensitive lookup must protect
+        // healthy users from being flagged as orphan in this case.
+        var raUserId = "Player#1234";
+        var pmuaUserId = "player#1234";  // lowercase variant from legacy data
+
+        _mockAssignmentRepo.Setup(x => x.GetActiveAssignmentsByProvider("patreon"))
+            .ReturnsAsync(new List<RewardAssignment>
+            {
+                new RewardAssignment { Id = "ra-1", UserId = raUserId, RewardId = "r", ProviderId = "patreon", Status = RewardStatus.Active }
+            });
+
+        _mockAssociationRepo.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>
+            {
+                new ProductMappingUserAssociation
+                {
+                    Id = "pmua-1", UserId = pmuaUserId, ProductMappingId = "mapping-x",
+                    ProviderId = "patreon", Status = AssociationStatus.Active
+                }
+            });
+
+        _mockLinkRepo.Setup(x => x.GetAll()).ReturnsAsync(new List<PatreonAccountLink>());
+        _mockPatreonApi.Setup(x => x.GetAllCampaignMembers()).ReturnsAsync(new List<PatreonMember>());
+
+        var report = await _service.DetectOrphans();
+
+        Assert.That(report.Entries, Is.Empty,
+            "User with case-different PMUA must not be flagged as orphan.");
+    }
+
+    [Test]
     public async Task RevokeOrphans_RevokesOnlyApprovedUsers_ThatStillAppearInFreshDetection()
     {
         var bubu = "Bubu#23550";

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/OrphanRewardServiceTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/OrphanRewardServiceTests.cs
@@ -201,6 +201,33 @@ public class OrphanRewardServiceTests
     }
 
     [Test]
+    public async Task RevokeOrphans_AllAssignmentsForUserFail_DoesNotIncrementUsersTouched()
+    {
+        var bubu = "Bubu#23550";
+        var actor = "Faro#2494";
+
+        _mockAssignmentRepo.Setup(x => x.GetActiveAssignmentsByProvider("patreon"))
+            .ReturnsAsync(new List<RewardAssignment>
+            {
+                new RewardAssignment { Id = "ra-1", UserId = bubu, RewardId = "r1", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:m" },
+                new RewardAssignment { Id = "ra-2", UserId = bubu, RewardId = "r2", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:m" }
+            });
+        _mockAssociationRepo.Setup(x => x.GetAll(AssociationStatus.Active)).ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockLinkRepo.Setup(x => x.GetAll()).ReturnsAsync(new List<PatreonAccountLink>());
+        _mockPatreonApi.Setup(x => x.GetAllCampaignMembers()).ReturnsAsync(new List<PatreonMember>());
+
+        // Every revoke throws
+        _mockRewardService.Setup(x => x.RevokeReward(It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new System.InvalidOperationException("simulated"));
+
+        var result = await _service.RevokeOrphans(new HashSet<string> { bubu }, actor);
+
+        Assert.That(result.AssignmentsRevoked, Is.EqualTo(0), "No assignments succeeded.");
+        Assert.That(result.UsersTouched, Is.EqualTo(0), "User should not be counted as touched if 0 assignments succeeded.");
+        Assert.That(result.Errors, Has.Count.EqualTo(2));
+    }
+
+    [Test]
     public async Task RevokeOrphans_LogsAndContinues_OnRevokeFailure()
     {
         var bubu = "Bubu#23550";

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftRevocationIntegrationTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftRevocationIntegrationTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using W3C.Domain.Rewards.Abstractions;
+using W3C.Domain.Rewards.Entities;
+using W3C.Domain.Rewards.Repositories;
+using W3C.Domain.Rewards.ValueObjects;
+using W3ChampionsStatisticService.Rewards.Providers.Patreon;
+using W3ChampionsStatisticService.Rewards.Services;
+
+namespace WC3ChampionsStatisticService.Tests.Rewards;
+
+/// <summary>
+/// Regression test for the orphan RewardAssignment bug. Wires up a REAL
+/// ProductMappingReconciliationService (not mocked) and asserts that drift sync
+/// revokes RewardAssignment rows end-to-end via the IRewardService.RevokeReward
+/// path. This is the test that would have caught the original production bug —
+/// the prior mock-based fixture in PatreonDriftSyncTests stubbed the reconciler
+/// to always return RewardsRevoked=0, which is exactly the bug.
+/// </summary>
+[TestFixture]
+public class PatreonDriftRevocationIntegrationTests
+{
+    [Test]
+    public async Task LapsedPatron_DriftSync_RevokesRewardAssignmentEndToEnd()
+    {
+        // Arrange — Bubu#23550 has 1 active PMUA + 2 active patreon RAs, but no longer
+        // an active patron in Patreon. Drift sync must revoke the RAs end-to-end.
+        var userId = "Bubu#23550";
+
+        var mockPatreonApiClient = new Mock<PatreonApiClient>(Mock.Of<HttpClient>());
+        mockPatreonApiClient.Setup(x => x.GetAllCampaignMembers()).ReturnsAsync(new List<PatreonMember>());
+
+        var mockAssociationRepo = new Mock<IProductMappingUserAssociationRepository>();
+        var existingPmua = new ProductMappingUserAssociation
+        {
+            Id = "pmua-1",
+            UserId = userId,
+            ProductMappingId = "mapping-grandmaster",
+            ProviderId = "patreon",
+            ProviderProductId = "6482092",
+            Status = AssociationStatus.Active,
+            AssignedAt = DateTime.UtcNow.AddMonths(-3)
+        };
+        mockAssociationRepo.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation> { existingPmua });
+        mockAssociationRepo.Setup(x => x.GetProductMappingsByUserId(userId))
+            .ReturnsAsync(new List<ProductMappingUserAssociation> { existingPmua });
+        mockAssociationRepo.Setup(x => x.Update(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+
+        var grandmasterMapping = new ProductMapping
+        {
+            Id = "mapping-grandmaster",
+            ProductName = "Grand Master",
+            RewardIds = new List<string> { "reward-grandmaster-icon", "reward-grandmaster-portrait" },
+            ProductProviders = new List<ProductProviderPair>
+            {
+                new ProductProviderPair { ProviderId = "patreon", ProductId = "6482092" }
+            }
+        };
+
+        var mockProductMappingRepo = new Mock<IProductMappingRepository>();
+        mockProductMappingRepo.Setup(x => x.GetById("mapping-grandmaster"))
+            .ReturnsAsync(grandmasterMapping);
+        mockProductMappingRepo.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping> { grandmasterMapping });
+
+        var mockPatreonLinkRepo = new Mock<IPatreonAccountLinkRepository>();
+        mockPatreonLinkRepo.Setup(x => x.GetAll()).ReturnsAsync(new List<PatreonAccountLink>());
+        mockPatreonLinkRepo.Setup(x => x.RefreshLastSyncAt(It.IsAny<string>())).Returns(Task.CompletedTask);
+
+        // Track RA state — model what the real RevokeReward would do
+        var revokedAssignmentIds = new HashSet<string>();
+        var allActiveRAs = new List<RewardAssignment>
+        {
+            new RewardAssignment
+            {
+                Id = "ra-1", UserId = userId, RewardId = "reward-grandmaster-icon",
+                ProviderId = "patreon", Status = RewardStatus.Active,
+                ProviderReference = "reconciliation:mapping-grandmaster"
+            },
+            new RewardAssignment
+            {
+                Id = "ra-2", UserId = userId, RewardId = "reward-grandmaster-portrait",
+                ProviderId = "patreon", Status = RewardStatus.Active,
+                ProviderReference = "reconciliation:mapping-grandmaster"
+            }
+        };
+
+        var mockRewardAssignmentRepo = new Mock<IRewardAssignmentRepository>();
+        // Filter out revoked assignments on each query (simulates DB state)
+        mockRewardAssignmentRepo.Setup(x => x.GetByUserIdAndStatus(userId, RewardStatus.Active))
+            .ReturnsAsync(() => allActiveRAs.Where(ra => !revokedAssignmentIds.Contains(ra.Id)).ToList());
+        mockRewardAssignmentRepo.Setup(x => x.GetActiveAssignmentsByProvider("patreon"))
+            .ReturnsAsync(() => allActiveRAs.Where(ra => !revokedAssignmentIds.Contains(ra.Id)).ToList());
+
+        var mockRewardService = new Mock<IRewardService>();
+        mockRewardService.Setup(x => x.RevokeReward(It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<string, string>((id, reason) => revokedAssignmentIds.Add(id))
+            .Returns(Task.CompletedTask);
+        // GetUserRewards must reflect the same state — drives the bidirectional reconciler
+        mockRewardService.Setup(x => x.GetUserRewards(userId))
+            .ReturnsAsync(() => allActiveRAs.Where(ra => !revokedAssignmentIds.Contains(ra.Id)).ToList());
+
+        var mockProductMappingService = new Mock<IProductMappingService>();
+        // Post-PMUA-revoke: empty (PMUA was revoked by the point-fix, drift run is now in reconciler phase)
+        mockProductMappingService.Setup(x => x.GetUserAssociationsByUserId(userId))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+
+        // REAL reconciliation service — the integration boundary we care about
+        var realReconciler = new ProductMappingReconciliationService(
+            mockProductMappingService.Object,
+            mockRewardService.Object,
+            Mock.Of<ILogger<ProductMappingReconciliationService>>());
+
+        var service = new PatreonDriftDetectionService(
+            mockPatreonApiClient.Object,
+            mockAssociationRepo.Object,
+            mockProductMappingRepo.Object,
+            mockPatreonLinkRepo.Object,
+            realReconciler,
+            mockRewardAssignmentRepo.Object,
+            mockRewardService.Object);
+
+        // Act
+        var driftResult = await service.DetectDrift();
+        await service.SyncDrift(driftResult, dryRun: false);
+
+        // Assert — both RAs were revoked end-to-end via the integration boundary
+        Assert.That(revokedAssignmentIds, Is.EquivalentTo(new[] { "ra-1", "ra-2" }),
+            "Both orphan RAs must be revoked end-to-end. If this fails, the drift sync " +
+            "is silently leaving RewardAssignments active after revoking PMUAs — the exact " +
+            "production bug this test was created to prevent.");
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -25,6 +25,7 @@ public class PatreonDriftSyncTests
     private Mock<IPatreonAccountLinkRepository> _mockPatreonLinkRepository;
     private Mock<IProductMappingReconciliationService> _mockReconciliationService;
     private Mock<IRewardService> _mockRewardService;
+    private Mock<IRewardAssignmentRepository> _mockRewardAssignmentRepository;
     private PatreonDriftDetectionService _service;
     private PatreonOAuthService _oauthService;
 
@@ -80,12 +81,20 @@ public class PatreonDriftSyncTests
         _mockAssociationRepository.Setup(x => x.Create(It.IsAny<ProductMappingUserAssociation>()))
             .ReturnsAsync((ProductMappingUserAssociation a) => a);
 
+        _mockRewardAssignmentRepository = new Mock<IRewardAssignmentRepository>();
+
+        // Default behavior: empty list (most tests will not exercise it; specific tests override)
+        _mockRewardAssignmentRepository.Setup(x => x.GetByUserIdAndStatus(It.IsAny<string>(), It.IsAny<RewardStatus>()))
+            .ReturnsAsync(new List<RewardAssignment>());
+
         _service = new PatreonDriftDetectionService(
             _mockPatreonApiClient.Object,
             _mockAssociationRepository.Object,
             _mockProductMappingRepository.Object,
             _mockPatreonLinkRepository.Object,
-            _mockReconciliationService.Object);
+            _mockReconciliationService.Object,
+            _mockRewardAssignmentRepository.Object,
+            _mockRewardService.Object);
 
         // Setup OAuth service for unlinking tests
         var mockHttpClient = new Mock<HttpClient>();

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -2061,4 +2061,52 @@ public class PatreonDriftSyncTests
         _mockRewardService.Verify(x => x.RevokeReward("ra-2", It.Is<string>(s => s.Contains("Drift sync"))), Times.Once);
         Assert.That(syncResult.AssignmentsRevoked, Is.GreaterThanOrEqualTo(1));
     }
+
+    [Test]
+    public async Task DeactivateAllUserAssociations_RevokesActivePatreonRewardAssignments()
+    {
+        // Arrange — user is going from active to "no longer active patron" via SyncSingleUser
+        var userId = "TestUser#1234";
+        var patreonUserId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+        var existingPmua = new ProductMappingUserAssociation
+        {
+            Id = "pmua-1",
+            UserId = userId,
+            ProductMappingId = "mapping-silver",
+            ProviderId = "patreon",
+            ProviderProductId = "6482057",
+            Status = AssociationStatus.Active,
+            AssignedAt = DateTime.UtcNow.AddDays(-30)
+        };
+
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(userId))
+            .ReturnsAsync(new List<ProductMappingUserAssociation> { existingPmua });
+        _mockAssociationRepository.Setup(x => x.Update(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+
+        var activeRAs = new List<RewardAssignment>
+        {
+            new RewardAssignment { Id = "ra-silver-1", UserId = userId, RewardId = "reward-silver", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:mapping-silver" }
+        };
+        _mockRewardAssignmentRepository.Setup(x => x.GetByUserIdAndStatus(userId, RewardStatus.Active))
+            .ReturnsAsync(activeRAs);
+
+        // Patreon API says: not an active patron anymore (former patron)
+        _mockPatreonApiClient.Setup(x => x.GetCampaignMemberByPatreonUserId(patreonUserId))
+            .ReturnsAsync(new PatreonMember
+            {
+                PatreonUserId = patreonUserId,
+                PatronStatus = "former_patron",
+                LastChargeStatus = "Paid",
+                EntitledTiers = new List<EntitledTier>()
+            });
+
+        // Act
+        var result = await _service.SyncSingleUser(userId, patreonUserId, accessToken: "valid-token");
+
+        // Assert
+        Assert.That(result.Success, Is.True);
+        _mockRewardService.Verify(x => x.RevokeReward("ra-silver-1", It.Is<string>(s => s.Contains("Patron no longer active") || s.Contains("Drift sync"))), Times.Once);
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -2109,4 +2109,70 @@ public class PatreonDriftSyncTests
         Assert.That(result.Success, Is.True);
         _mockRewardService.Verify(x => x.RevokeReward("ra-silver-1", It.Is<string>(s => s.Contains("Patron no longer active") || s.Contains("Drift sync"))), Times.Once);
     }
+
+    [Test]
+    public async Task DeactivateUserAssociation_WhenRevokeRewardThrows_PMUAStaysActive()
+    {
+        // Regression test for order-of-operations safety.
+        // If RevokeReward throws, the PMUA must NOT have been revoked yet.
+        // Revoked PMUA + active RA recreates the orphan-RA bug; the next drift cycle
+        // would see zero active PMUAs and skip the user entirely.
+        var userId = "Bubu#23550";
+        var existingPmua = new ProductMappingUserAssociation
+        {
+            Id = "pmua-1",
+            UserId = userId,
+            ProductMappingId = "mapping-grandmaster",
+            ProviderId = "patreon",
+            ProviderProductId = "6482092",
+            Status = AssociationStatus.Active,
+            AssignedAt = DateTime.UtcNow.AddMonths(-3)
+        };
+
+        _mockAssociationRepository.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation> { existingPmua });
+        _mockAssociationRepository.Setup(x => x.Update(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping>());
+
+        var activeRA = new RewardAssignment
+        {
+            Id = "ra-1",
+            UserId = userId,
+            RewardId = "r1",
+            ProviderId = "patreon",
+            Status = RewardStatus.Active,
+            ProviderReference = "reconciliation:mapping-grandmaster"
+        };
+        _mockRewardAssignmentRepository.Setup(x => x.GetByUserIdAndStatus(userId, RewardStatus.Active))
+            .ReturnsAsync(new List<RewardAssignment> { activeRA });
+
+        // Simulate a transient failure on RA revoke
+        _mockRewardService.Setup(x => x.RevokeReward("ra-1", It.IsAny<string>()))
+            .ThrowsAsync(new InvalidOperationException("simulated RA revoke failure"));
+
+        // No matching active patron in Patreon → user shows up as ExtraAssignment
+        _mockPatreonApiClient.Setup(x => x.GetAllCampaignMembers())
+            .ReturnsAsync(new List<PatreonMember>());
+        _mockPatreonLinkRepository.Setup(x => x.GetAll())
+            .ReturnsAsync(new List<PatreonAccountLink>());
+
+        // Act — SyncDrift catches per-user errors and continues; should not throw
+        var driftResult = await _service.DetectDrift();
+        SyncResult syncResult = null;
+        Assert.DoesNotThrowAsync(async () =>
+        {
+            syncResult = await _service.SyncDrift(driftResult, dryRun: false);
+        }, "SyncDrift must swallow per-user errors and not propagate them to the caller.");
+
+        // Assert — PMUA was NOT updated. The RA revoke threw BEFORE the PMUA was touched,
+        // so the PMUA must remain Active. If the PMUA were revoked first, we'd have an
+        // orphaned active RA with no PMUA — exactly the bug we're fixing.
+        _mockAssociationRepository.Verify(x => x.Update(It.IsAny<ProductMappingUserAssociation>()), Times.Never,
+            "PMUA must not be revoked when RA revoke throws — revoking it first would orphan the RA.");
+        Assert.That(existingPmua.Status, Is.EqualTo(AssociationStatus.Active),
+            "PMUA in-memory state must remain Active after RA revoke failure (RA revoke must come first).");
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -2365,7 +2365,6 @@ public class PatreonDriftSyncTests
             LastSyncAt = null
         };
         _mockPatreonLinkRepository.Setup(x => x.GetByPatreonUserId(patreonUserId)).ReturnsAsync(existingLink);
-        _mockPatreonLinkRepository.Setup(x => x.GetByBattleTag(userId)).ReturnsAsync(existingLink);
 
         _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(userId))
             .ReturnsAsync(new List<ProductMappingUserAssociation>());
@@ -2397,9 +2396,9 @@ public class PatreonDriftSyncTests
         // Act
         var result = await _service.SyncSingleUser(userId, patreonUserId, "valid-token");
 
-        // Assert — Update was called on the link with non-null LastSyncAt
+        // Assert — RefreshLastSyncAt was delegated to the repository (bookkeeping now owned by repo layer)
         Assert.That(result.Success, Is.True, result.ErrorMessage);
-        _mockPatreonLinkRepository.Verify(x => x.Update(It.Is<PatreonAccountLink>(l => l.LastSyncAt != null && l.BattleTag == userId)), Times.AtLeastOnce);
+        _mockPatreonLinkRepository.Verify(x => x.RefreshLastSyncAt(userId), Times.AtLeastOnce);
     }
 
     [Test]
@@ -2429,7 +2428,6 @@ public class PatreonDriftSyncTests
 
         var link = new PatreonAccountLink(userId, patreonUserId) { LastSyncAt = null };
         _mockPatreonLinkRepository.Setup(x => x.GetAll()).ReturnsAsync(new List<PatreonAccountLink> { link });
-        _mockPatreonLinkRepository.Setup(x => x.GetByBattleTag(userId)).ReturnsAsync(link);
 
         _mockPatreonApiClient.Setup(x => x.GetAllCampaignMembers())
             .ReturnsAsync(new List<PatreonMember>
@@ -2446,6 +2444,7 @@ public class PatreonDriftSyncTests
         var driftResult = await _service.DetectDrift();
         var syncResult = await _service.SyncDrift(driftResult, dryRun: false);
 
-        _mockPatreonLinkRepository.Verify(x => x.Update(It.Is<PatreonAccountLink>(l => l.LastSyncAt != null && l.BattleTag == userId)), Times.AtLeastOnce);
+        // Assert — RefreshLastSyncAt was delegated to the repository (bookkeeping now owned by repo layer)
+        _mockPatreonLinkRepository.Verify(x => x.RefreshLastSyncAt(userId), Times.AtLeastOnce);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -2241,10 +2241,13 @@ public class PatreonDriftSyncTests
 
         var existingPmua = new ProductMappingUserAssociation
         {
-            Id = "pmua-1", UserId = userId,
+            Id = "pmua-1",
+            UserId = userId,
             ProductMappingId = "mapping-silver",
-            ProviderId = "patreon", ProviderProductId = "6482057",
-            Status = AssociationStatus.Active, AssignedAt = DateTime.UtcNow.AddDays(-1)
+            ProviderId = "patreon",
+            ProviderProductId = "6482057",
+            Status = AssociationStatus.Active,
+            AssignedAt = DateTime.UtcNow.AddDays(-1)
         };
         _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(userId))
             .ReturnsAsync(new List<ProductMappingUserAssociation> { existingPmua });
@@ -2274,7 +2277,8 @@ public class PatreonDriftSyncTests
 
         var driftResult = new DriftDetectionResult
         {
-            ProviderId = "patreon", Timestamp = DateTime.UtcNow,
+            ProviderId = "patreon",
+            Timestamp = DateTime.UtcNow,
             MismatchedTiers = new List<TierMismatch> { tierMismatch }
         };
 
@@ -2296,10 +2300,13 @@ public class PatreonDriftSyncTests
 
         var existingPmua = new ProductMappingUserAssociation
         {
-            Id = "pmua-1", UserId = userId,
+            Id = "pmua-1",
+            UserId = userId,
             ProductMappingId = "mapping-silver",
-            ProviderId = "patreon", ProviderProductId = "6482057",
-            Status = AssociationStatus.Active, AssignedAt = DateTime.UtcNow.AddDays(-1)
+            ProviderId = "patreon",
+            ProviderProductId = "6482057",
+            Status = AssociationStatus.Active,
+            AssignedAt = DateTime.UtcNow.AddDays(-1)
         };
         _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(userId))
             .ReturnsAsync(new List<ProductMappingUserAssociation> { existingPmua });
@@ -2329,7 +2336,8 @@ public class PatreonDriftSyncTests
 
         var driftResult = new DriftDetectionResult
         {
-            ProviderId = "patreon", Timestamp = DateTime.UtcNow,
+            ProviderId = "patreon",
+            Timestamp = DateTime.UtcNow,
             MismatchedTiers = new List<TierMismatch> { tierMismatch }
         };
 
@@ -2350,10 +2358,13 @@ public class PatreonDriftSyncTests
 
         var existingPmua = new ProductMappingUserAssociation
         {
-            Id = "pmua-silver", UserId = userId,
+            Id = "pmua-silver",
+            UserId = userId,
             ProductMappingId = "mapping-silver",
-            ProviderId = "patreon", ProviderProductId = "6482057",
-            Status = AssociationStatus.Active, AssignedAt = DateTime.UtcNow.AddDays(-1)
+            ProviderId = "patreon",
+            ProviderProductId = "6482057",
+            Status = AssociationStatus.Active,
+            AssignedAt = DateTime.UtcNow.AddDays(-1)
         };
         _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(userId))
             .ReturnsAsync(new List<ProductMappingUserAssociation> { existingPmua });
@@ -2375,7 +2386,8 @@ public class PatreonDriftSyncTests
 
         var tierMismatch = new TierMismatch
         {
-            UserId = userId, PatreonMemberId = "memberId",
+            UserId = userId,
+            PatreonMemberId = "memberId",
             PatreonTiers = new List<string> { "6482070" },
             PatreonTiersFiltered = new List<string> { "6482070" }, // Gold
             InternalTiers = new List<string> { "6482057" },        // Silver
@@ -2384,7 +2396,8 @@ public class PatreonDriftSyncTests
 
         var driftResult = new DriftDetectionResult
         {
-            ProviderId = "patreon", Timestamp = DateTime.UtcNow,
+            ProviderId = "patreon",
+            Timestamp = DateTime.UtcNow,
             MismatchedTiers = new List<TierMismatch> { tierMismatch }
         };
 

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -2353,4 +2353,69 @@ public class PatreonDriftSyncTests
         Assert.That(syncResult.TiersUpdated, Is.EqualTo(1),
             "Real tier upgrade should still be reported in dry-run.");
     }
+
+    [Test]
+    public async Task SyncSingleUser_OnSuccess_UpdatesLastSyncOnAccountLink()
+    {
+        var userId = "TestUser#1234";
+        var patreonUserId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+        var existingLink = new PatreonAccountLink(userId, patreonUserId)
+        {
+            LastSyncAt = null
+        };
+        _mockPatreonLinkRepository.Setup(x => x.GetByPatreonUserId(patreonUserId)).ReturnsAsync(existingLink);
+        _mockPatreonLinkRepository.Setup(x => x.GetByBattleTag(userId)).ReturnsAsync(existingLink);
+
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(userId))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+
+        _mockPatreonApiClient.Setup(x => x.GetCampaignMemberByPatreonUserId(patreonUserId))
+            .ReturnsAsync(new PatreonMember
+            {
+                PatreonUserId = patreonUserId,
+                PatronStatus = "active_patron",
+                LastChargeStatus = "Paid",
+                EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = "tier1", AmountCents = 100 } }
+            });
+
+        // Act
+        var result = await _service.SyncSingleUser(userId, patreonUserId, "valid-token");
+
+        // Assert — Update was called on the link with non-null LastSyncAt
+        Assert.That(result.Success, Is.True);
+        _mockPatreonLinkRepository.Verify(x => x.Update(It.Is<PatreonAccountLink>(l => l.LastSyncAt != null && l.BattleTag == userId)), Times.AtLeastOnce);
+    }
+
+    [Test]
+    public async Task SyncDrift_AfterMissingMemberSync_UpdatesLastSync()
+    {
+        // Arrange — user is missing from internal but active patron
+        var userId = "Reactivating#1234";
+        var patreonUserId = "999";
+
+        _mockAssociationRepository.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+
+        var link = new PatreonAccountLink(userId, patreonUserId) { LastSyncAt = null };
+        _mockPatreonLinkRepository.Setup(x => x.GetAll()).ReturnsAsync(new List<PatreonAccountLink> { link });
+        _mockPatreonLinkRepository.Setup(x => x.GetByBattleTag(userId)).ReturnsAsync(link);
+
+        _mockPatreonApiClient.Setup(x => x.GetAllCampaignMembers())
+            .ReturnsAsync(new List<PatreonMember>
+            {
+                new PatreonMember
+                {
+                    PatreonUserId = patreonUserId,
+                    PatronStatus = "active_patron",
+                    LastChargeStatus = "Paid",
+                    EntitledTiers = new List<EntitledTier> { new EntitledTier { TierId = "tier1", AmountCents = 100 } }
+                }
+            });
+
+        var driftResult = await _service.DetectDrift();
+        var syncResult = await _service.SyncDrift(driftResult, dryRun: false);
+
+        _mockPatreonLinkRepository.Verify(x => x.Update(It.Is<PatreonAccountLink>(l => l.LastSyncAt != null && l.BattleTag == userId)), Times.AtLeastOnce);
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -111,7 +111,15 @@ public class PatreonDriftSyncTests
     [Test]
     public async Task SyncDrift_DryRun_GeneratesEventsWithCorrectIdentification()
     {
-        // Arrange
+        // Arrange — "TestUser#789" has no PatreonTiersFiltered set (null), so the actionable
+        // tier set is empty and the no-op guard fires: TiersUpdated stays 0.
+        // This is correct: UpdateUserAssociationTiers is now always called (even in dry-run)
+        // and the no-op guard is consulted before any dryRun short-circuit.
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId("TestUser#789"))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping>());
+
         var driftResult = new DriftDetectionResult
         {
             Timestamp = DateTime.UtcNow,
@@ -146,6 +154,8 @@ public class PatreonDriftSyncTests
                     PatreonMemberId = "member789",
                     PatreonTiers = new List<string> { "tier2" },
                     InternalTiers = new List<string> { "tier1" },
+                    // PatreonTiersFiltered intentionally null — simulates a mismatch entry
+                    // where no filtered tiers are set, so the actionable set is empty → no-op.
                     Reason = "Test tier mismatch"
                 }
             }
@@ -159,7 +169,9 @@ public class PatreonDriftSyncTests
         Assert.IsTrue(syncResult.WasDryRun);
         Assert.AreEqual(1, syncResult.MembersAdded);
         Assert.AreEqual(1, syncResult.AssignmentsRevoked);
-        Assert.AreEqual(1, syncResult.TiersUpdated);
+        // TiersUpdated is 0: the no-op guard fires before the dry-run short-circuit.
+        // PatreonTiersFiltered is null → actionableTiers is empty → matches existing empty set.
+        Assert.AreEqual(0, syncResult.TiersUpdated);
         Assert.AreEqual(0, syncResult.ProcessedAssociations.Count); // No processing in dry run
 
         // Verify no actual association changes happened in dry run
@@ -2229,5 +2241,116 @@ public class PatreonDriftSyncTests
         // Assert — no revoke or update of the existing PMUA
         _mockAssociationRepository.Verify(x => x.Update(It.Is<ProductMappingUserAssociation>(a => a.Status == AssociationStatus.Revoked)), Times.Never);
         Assert.That(syncResult.TiersUpdated, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task UpdateUserAssociationTiers_DryRun_NoOp_DoesNotIncrementTiersUpdated()
+    {
+        // Regression test: dry-run mode must respect the no-op guard so operators get
+        // an accurate preview of what a live sync would do. The 6 production users in
+        // the churn loop should report TiersUpdated=0 in a dry-run.
+        var userId = "ChurnLoopUser#1234";
+
+        var existingPmua = new ProductMappingUserAssociation
+        {
+            Id = "pmua-1", UserId = userId,
+            ProductMappingId = "mapping-silver",
+            ProviderId = "patreon", ProviderProductId = "6482057",
+            Status = AssociationStatus.Active, AssignedAt = DateTime.UtcNow.AddDays(-1)
+        };
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(userId))
+            .ReturnsAsync(new List<ProductMappingUserAssociation> { existingPmua });
+
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping>
+            {
+                new ProductMapping
+                {
+                    Id = "mapping-silver",
+                    ProductName = "Silver",
+                    Type = ProductMappingType.Tiered,
+                    ProductProviders = new List<ProductProviderPair> { new ProductProviderPair { ProviderId = "patreon", ProductId = "6482057" } }
+                }
+                // 15145463 deliberately unmapped
+            });
+
+        var tierMismatch = new TierMismatch
+        {
+            UserId = userId,
+            PatreonMemberId = "memberId",
+            PatreonTiers = new List<string> { "15145463", "6482057" },
+            PatreonTiersFiltered = new List<string> { "15145463", "6482057" },
+            InternalTiers = new List<string> { "6482057" },
+            InternalTiersFiltered = new List<string> { "6482057" }
+        };
+
+        var driftResult = new DriftDetectionResult
+        {
+            ProviderId = "patreon", Timestamp = DateTime.UtcNow,
+            MismatchedTiers = new List<TierMismatch> { tierMismatch }
+        };
+
+        // Act — dry-run
+        var syncResult = await _service.SyncDrift(driftResult, dryRun: true);
+
+        // Assert — no DB writes, TiersUpdated == 0 (matches the live sync behavior, not the pre-fix overstatement)
+        _mockAssociationRepository.Verify(x => x.Update(It.IsAny<ProductMappingUserAssociation>()), Times.Never);
+        Assert.That(syncResult.TiersUpdated, Is.EqualTo(0),
+            "Dry-run must respect the no-op guard — otherwise operators get a misleading preview.");
+    }
+
+    [Test]
+    public async Task UpdateUserAssociationTiers_DryRun_RealTierUpgrade_DoesNotMutateDbButReportsCount()
+    {
+        // For a real tier change (Silver→Gold), dry-run should NOT mutate but SHOULD report TiersUpdated=1.
+        var userId = "Upgrader#1234";
+
+        var existingPmua = new ProductMappingUserAssociation
+        {
+            Id = "pmua-silver", UserId = userId,
+            ProductMappingId = "mapping-silver",
+            ProviderId = "patreon", ProviderProductId = "6482057",
+            Status = AssociationStatus.Active, AssignedAt = DateTime.UtcNow.AddDays(-1)
+        };
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(userId))
+            .ReturnsAsync(new List<ProductMappingUserAssociation> { existingPmua });
+
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping>
+            {
+                new ProductMapping
+                {
+                    Id = "mapping-silver", ProductName = "Silver", Type = ProductMappingType.Tiered,
+                    ProductProviders = new List<ProductProviderPair> { new ProductProviderPair { ProviderId = "patreon", ProductId = "6482057" } }
+                },
+                new ProductMapping
+                {
+                    Id = "mapping-gold", ProductName = "Gold", Type = ProductMappingType.Tiered,
+                    ProductProviders = new List<ProductProviderPair> { new ProductProviderPair { ProviderId = "patreon", ProductId = "6482070" } }
+                }
+            });
+
+        var tierMismatch = new TierMismatch
+        {
+            UserId = userId, PatreonMemberId = "memberId",
+            PatreonTiers = new List<string> { "6482070" },
+            PatreonTiersFiltered = new List<string> { "6482070" }, // Gold
+            InternalTiers = new List<string> { "6482057" },        // Silver
+            InternalTiersFiltered = new List<string> { "6482057" }
+        };
+
+        var driftResult = new DriftDetectionResult
+        {
+            ProviderId = "patreon", Timestamp = DateTime.UtcNow,
+            MismatchedTiers = new List<TierMismatch> { tierMismatch }
+        };
+
+        var syncResult = await _service.SyncDrift(driftResult, dryRun: true);
+
+        // Assert: NO DB writes (dry-run is honest), but TiersUpdated reports 1 (real change would happen)
+        _mockAssociationRepository.Verify(x => x.Update(It.IsAny<ProductMappingUserAssociation>()), Times.Never,
+            "Dry-run must not mutate DB even for real tier upgrades.");
+        Assert.That(syncResult.TiersUpdated, Is.EqualTo(1),
+            "Real tier upgrade should still be reported in dry-run.");
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -2012,4 +2012,53 @@ public class PatreonDriftSyncTests
         Assert.AreEqual(canonicalBattleTag, mismatch.UserId,
             "TierMismatch.UserId must be the canonical-cased BattleTag (TORREN#11438), not lowercased");
     }
+
+    [Test]
+    public async Task SyncDrift_ExtraAssignment_RevokesActivePatreonRewardAssignments()
+    {
+        // Arrange — user has 1 active patreon PMUA and 2 active patreon RAs
+        var userId = "Bubu#23550";
+        var existingPmua = new ProductMappingUserAssociation
+        {
+            Id = "pmua-1",
+            UserId = userId,
+            ProductMappingId = "mapping-grandmaster",
+            ProviderId = "patreon",
+            ProviderProductId = "6482092",
+            Status = AssociationStatus.Active,
+            AssignedAt = DateTime.UtcNow.AddMonths(-3)
+        };
+
+        _mockAssociationRepository.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation> { existingPmua });
+        _mockAssociationRepository.Setup(x => x.Update(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping>());
+
+        var activeRAs = new List<RewardAssignment>
+        {
+            new RewardAssignment { Id = "ra-1", UserId = userId, RewardId = "reward-grandmaster-icon", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:mapping-grandmaster" },
+            new RewardAssignment { Id = "ra-2", UserId = userId, RewardId = "reward-grandmaster-portrait", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:mapping-grandmaster" }
+        };
+        _mockRewardAssignmentRepository.Setup(x => x.GetByUserIdAndStatus(userId, RewardStatus.Active))
+            .ReturnsAsync(activeRAs);
+
+        // No matching active patron in Patreon → user shows up as ExtraAssignment
+        _mockPatreonApiClient.Setup(x => x.GetAllCampaignMembers())
+            .ReturnsAsync(new List<PatreonMember>());
+
+        _mockPatreonLinkRepository.Setup(x => x.GetAll())
+            .ReturnsAsync(new List<PatreonAccountLink>());
+
+        // Act
+        var driftResult = await _service.DetectDrift();
+        var syncResult = await _service.SyncDrift(driftResult, dryRun: false);
+
+        // Assert — both RA revocations actually happened
+        _mockRewardService.Verify(x => x.RevokeReward("ra-1", It.Is<string>(s => s.Contains("Drift sync"))), Times.Once);
+        _mockRewardService.Verify(x => x.RevokeReward("ra-2", It.Is<string>(s => s.Contains("Drift sync"))), Times.Once);
+        Assert.That(syncResult.AssignmentsRevoked, Is.GreaterThanOrEqualTo(1));
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -2123,12 +2123,13 @@ public class PatreonDriftSyncTests
     }
 
     [Test]
-    public async Task DeactivateUserAssociation_WhenRevokeRewardThrows_PMUAStaysActive()
+    public async Task DeactivateUserAssociation_WhenAllRevokesFail_SyncDoesNotThrow()
     {
-        // Regression test for order-of-operations safety.
-        // If RevokeReward throws, the PMUA must NOT have been revoked yet.
-        // Revoked PMUA + active RA recreates the orphan-RA bug; the next drift cycle
-        // would see zero active PMUAs and skip the user entirely.
+        // When every RA revoke throws (all failing, none succeeding), SyncDrift must still
+        // not propagate the exception to the caller — per-RA failures are logged and swallowed.
+        // The PMUA revocation proceeds regardless, because we cannot leave PMUAs active if
+        // the user is no longer a patron. The orphan-RA risk from a partial failure is handled
+        // by the bidirectional reconciler on the next cycle.
         var userId = "Bubu#23550";
         var existingPmua = new ProductMappingUserAssociation
         {
@@ -2171,21 +2172,63 @@ public class PatreonDriftSyncTests
         _mockPatreonLinkRepository.Setup(x => x.GetAll())
             .ReturnsAsync(new List<PatreonAccountLink>());
 
-        // Act — SyncDrift catches per-user errors and continues; should not throw
+        // Act — SyncDrift catches per-RA errors and continues; must not throw
         var driftResult = await _service.DetectDrift();
-        SyncResult syncResult = null;
         Assert.DoesNotThrowAsync(async () =>
-        {
-            syncResult = await _service.SyncDrift(driftResult, dryRun: false);
-        }, "SyncDrift must swallow per-user errors and not propagate them to the caller.");
+            await _service.SyncDrift(driftResult, dryRun: false),
+            "SyncDrift must swallow per-RA errors and not propagate them to the caller.");
+    }
 
-        // Assert — PMUA was NOT updated. The RA revoke threw BEFORE the PMUA was touched,
-        // so the PMUA must remain Active. If the PMUA were revoked first, we'd have an
-        // orphaned active RA with no PMUA — exactly the bug we're fixing.
-        _mockAssociationRepository.Verify(x => x.Update(It.IsAny<ProductMappingUserAssociation>()), Times.Never,
-            "PMUA must not be revoked when RA revoke throws — revoking it first would orphan the RA.");
-        Assert.That(existingPmua.Status, Is.EqualTo(AssociationStatus.Active),
-            "PMUA in-memory state must remain Active after RA revoke failure (RA revoke must come first).");
+    [Test]
+    public async Task DeactivateUserAssociation_OneRevokeThrows_RemainingRAsStillRevoked()
+    {
+        // Regression: a single failing RA must not halt the entire user's sync.
+        // Otherwise we leak partial state (some RAs revoked, others active, PMUAs untouched).
+        var userId = "PartialFailUser#1234";
+
+        var existingPmua = new ProductMappingUserAssociation
+        {
+            Id = "pmua-1",
+            UserId = userId,
+            ProductMappingId = "mapping-grandmaster",
+            ProviderId = "patreon",
+            ProviderProductId = "6482092",
+            Status = AssociationStatus.Active,
+            AssignedAt = DateTime.UtcNow.AddMonths(-3)
+        };
+        _mockAssociationRepository.Setup(x => x.GetAll(AssociationStatus.Active))
+            .ReturnsAsync(new List<ProductMappingUserAssociation> { existingPmua });
+        _mockAssociationRepository.Setup(x => x.Update(It.IsAny<ProductMappingUserAssociation>()))
+            .ReturnsAsync((ProductMappingUserAssociation a) => a);
+
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping>());
+
+        var activeRAs = new List<RewardAssignment>
+        {
+            new RewardAssignment { Id = "ra-1", UserId = userId, RewardId = "r1", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:mapping-grandmaster" },
+            new RewardAssignment { Id = "ra-2", UserId = userId, RewardId = "r2", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:mapping-grandmaster" },
+            new RewardAssignment { Id = "ra-3", UserId = userId, RewardId = "r3", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:mapping-grandmaster" }
+        };
+        _mockRewardAssignmentRepository.Setup(x => x.GetByUserIdAndStatus(userId, RewardStatus.Active))
+            .ReturnsAsync(activeRAs);
+
+        // Middle RA throws; first and last should still be revoked
+        _mockRewardService.Setup(x => x.RevokeReward("ra-2", It.IsAny<string>()))
+            .ThrowsAsync(new InvalidOperationException("simulated transient failure"));
+
+        // No matching active patron in Patreon → user shows up as ExtraAssignment
+        _mockPatreonApiClient.Setup(x => x.GetAllCampaignMembers()).ReturnsAsync(new List<PatreonMember>());
+        _mockPatreonLinkRepository.Setup(x => x.GetAll()).ReturnsAsync(new List<PatreonAccountLink>());
+
+        // Act
+        var driftResult = await _service.DetectDrift();
+        Assert.DoesNotThrowAsync(async () => await _service.SyncDrift(driftResult, dryRun: false),
+            "SyncDrift must not throw when one RA revoke fails — remaining RAs must still be processed.");
+
+        // Assert — ra-1 and ra-3 were revoked despite ra-2 throwing
+        _mockRewardService.Verify(x => x.RevokeReward("ra-1", It.IsAny<string>()), Times.Once);
+        _mockRewardService.Verify(x => x.RevokeReward("ra-3", It.IsAny<string>()), Times.Once);
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -24,8 +24,8 @@ public class PatreonDriftSyncTests
     private Mock<IProductMappingRepository> _mockProductMappingRepository;
     private Mock<IPatreonAccountLinkRepository> _mockPatreonLinkRepository;
     private Mock<IProductMappingReconciliationService> _mockReconciliationService;
-    private Mock<IRewardService> _mockRewardService;
     private Mock<IRewardAssignmentRepository> _mockRewardAssignmentRepository;
+    private Mock<IRewardService> _mockRewardService;
     private PatreonDriftDetectionService _service;
     private PatreonOAuthService _oauthService;
 

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -2175,4 +2175,59 @@ public class PatreonDriftSyncTests
         Assert.That(existingPmua.Status, Is.EqualTo(AssociationStatus.Active),
             "PMUA in-memory state must remain Active after RA revoke failure (RA revoke must come first).");
     }
+
+    [Test]
+    public async Task UpdateUserAssociationTiers_SkipsRevokeRecreate_WhenActionableTierSetEqualsExistingActive()
+    {
+        // Arrange — user has 1 active PMUA for tier 6482057. Patreon says they have tiers
+        // [15145463 (unmapped), 6482057 (mapped)]. Filter would produce [15145463, 6482057].
+        // Internal mapped set = {6482057}. Without the guard, the drift loops every cycle.
+        var userId = "ChurnLoopUser#1234";
+
+        var existingPmua = new ProductMappingUserAssociation
+        {
+            Id = "pmua-1", UserId = userId,
+            ProductMappingId = "mapping-silver",
+            ProviderId = "patreon", ProviderProductId = "6482057",
+            Status = AssociationStatus.Active, AssignedAt = DateTime.UtcNow.AddDays(-1)
+        };
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(userId))
+            .ReturnsAsync(new List<ProductMappingUserAssociation> { existingPmua });
+
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping>
+            {
+                new ProductMapping
+                {
+                    Id = "mapping-silver",
+                    ProductName = "Silver",
+                    Type = ProductMappingType.Tiered,
+                    ProductProviders = new List<ProductProviderPair> { new ProductProviderPair { ProviderId = "patreon", ProductId = "6482057" } }
+                }
+                // mapping for 15145463 deliberately absent — unmapped/free tier
+            });
+
+        var tierMismatch = new TierMismatch
+        {
+            UserId = userId,
+            PatreonMemberId = "memberId",
+            PatreonTiers = new List<string> { "15145463", "6482057" },
+            PatreonTiersFiltered = new List<string> { "15145463", "6482057" },
+            InternalTiers = new List<string> { "6482057" },
+            InternalTiersFiltered = new List<string> { "6482057" }
+        };
+
+        var driftResult = new DriftDetectionResult
+        {
+            ProviderId = "patreon", Timestamp = DateTime.UtcNow,
+            MismatchedTiers = new List<TierMismatch> { tierMismatch }
+        };
+
+        // Act
+        var syncResult = await _service.SyncDrift(driftResult, dryRun: false);
+
+        // Assert — no revoke or update of the existing PMUA
+        _mockAssociationRepository.Verify(x => x.Update(It.Is<ProductMappingUserAssociation>(a => a.Status == AssociationStatus.Revoked)), Times.Never);
+        Assert.That(syncResult.TiersUpdated, Is.EqualTo(0));
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -2411,6 +2411,21 @@ public class PatreonDriftSyncTests
 
         _mockAssociationRepository.Setup(x => x.GetAll(AssociationStatus.Active))
             .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(userId))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+
+        var productMapping = new ProductMapping
+        {
+            Id = "mapping-drift-123",
+            ProductName = "Tier 1",
+            RewardIds = new List<string> { "reward-1" },
+            ProductProviders = new List<ProductProviderPair>
+            {
+                new ProductProviderPair { ProviderId = "patreon", ProductId = "tier1" }
+            }
+        };
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping> { productMapping });
 
         var link = new PatreonAccountLink(userId, patreonUserId) { LastSyncAt = null };
         _mockPatreonLinkRepository.Setup(x => x.GetAll()).ReturnsAsync(new List<PatreonAccountLink> { link });

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonDriftSyncTests.cs
@@ -2370,6 +2370,21 @@ public class PatreonDriftSyncTests
         _mockAssociationRepository.Setup(x => x.GetProductMappingsByUserId(userId))
             .ReturnsAsync(new List<ProductMappingUserAssociation>());
 
+        var productMapping = new ProductMapping
+        {
+            Id = "mapping-sync-123",
+            ProductName = "Tier 1",
+            RewardIds = new List<string> { "reward-1" },
+            ProductProviders = new List<ProductProviderPair>
+            {
+                new ProductProviderPair { ProviderId = "patreon", ProductId = "tier1" }
+            }
+        };
+        _mockProductMappingRepository.Setup(x => x.GetByProviderId("patreon"))
+            .ReturnsAsync(new List<ProductMapping> { productMapping });
+        _mockProductMappingRepository.Setup(x => x.GetByProviderAndProductId("patreon", "tier1"))
+            .ReturnsAsync(new List<ProductMapping> { productMapping });
+
         _mockPatreonApiClient.Setup(x => x.GetCampaignMemberByPatreonUserId(patreonUserId))
             .ReturnsAsync(new PatreonMember
             {
@@ -2383,7 +2398,7 @@ public class PatreonDriftSyncTests
         var result = await _service.SyncSingleUser(userId, patreonUserId, "valid-token");
 
         // Assert — Update was called on the link with non-null LastSyncAt
-        Assert.That(result.Success, Is.True);
+        Assert.That(result.Success, Is.True, result.ErrorMessage);
         _mockPatreonLinkRepository.Verify(x => x.Update(It.Is<PatreonAccountLink>(l => l.LastSyncAt != null && l.BattleTag == userId)), Times.AtLeastOnce);
     }
 

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonTierFilterTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/PatreonTierFilterTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using W3C.Domain.Rewards.Entities;
+using W3ChampionsStatisticService.Rewards.Services;
+
+namespace WC3ChampionsStatisticService.Tests.Rewards;
+
+[TestFixture]
+public class PatreonTierFilterTests
+{
+    [Test]
+    public void Filter_WithIgnoredTier_DropsBeforeProcessing()
+    {
+        var tiers = new List<EntitledTier>
+        {
+            new() { TierId = "15145463", AmountCents = 0 },
+            new() { TierId = "6482092", AmountCents = 10000 } // Grand Master tiered
+        };
+        var mappings = new List<ProductMapping>
+        {
+            new() {
+                Id = "m-grandmaster",
+                Type = ProductMappingType.Tiered,
+                ProductProviders = new List<ProductProviderPair> {
+                    new() { ProviderId = "patreon", ProductId = "6482092" }
+                }
+            }
+        };
+
+        var ignored = new HashSet<string> { "15145463" };
+        var result = PatreonTierFilter.Filter(tiers, mappings, ignored);
+
+        Assert.That(result, Is.EquivalentTo(new[] { "6482092" }));
+    }
+
+    [Test]
+    public void Filter_WithoutIgnoreList_PassesUnmappedTierThrough()
+    {
+        var tiers = new List<EntitledTier>
+        {
+            new() { TierId = "15145463", AmountCents = 0 },
+            new() { TierId = "6482092", AmountCents = 10000 }
+        };
+        var mappings = new List<ProductMapping>
+        {
+            new() {
+                Id = "m-grandmaster",
+                Type = ProductMappingType.Tiered,
+                ProductProviders = new List<ProductProviderPair> { new() { ProviderId = "patreon", ProductId = "6482092" } }
+            }
+        };
+
+        var result = PatreonTierFilter.Filter(tiers, mappings, ignoredTierIds: null);
+
+        Assert.That(result, Is.EquivalentTo(new[] { "15145463", "6482092" }));
+    }
+
+    [Test]
+    public void Filter_WithEmptyIgnoreList_DoesNotDropTiers()
+    {
+        var tiers = new List<EntitledTier>
+        {
+            new() { TierId = "15145463", AmountCents = 0 }
+        };
+        var mappings = new List<ProductMapping>();
+        var empty = new HashSet<string>();
+
+        var result = PatreonTierFilter.Filter(tiers, mappings, empty);
+
+        Assert.That(result, Is.EquivalentTo(new[] { "15145463" }));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/ProductMappingReconciliationTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/ProductMappingReconciliationTests.cs
@@ -474,4 +474,158 @@ public class ProductMappingReconciliationTests
             Throws.TypeOf<InvalidOperationException>()
                 .With.Message.Contain("Product mapping non-existent not found"));
     }
+
+    [Test]
+    public async Task ReconcileUserAssociations_WithNoActivePMUAs_RevokesActivePatreonOrphanRAs()
+    {
+        // Arrange — user has zero active PMUAs but two active patreon RAs (orphans)
+        var userId = "Bubu#23550";
+
+        _mockProductMappingService.Setup(x => x.GetUserAssociationsByUserId(userId))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>()); // no active PMUAs
+
+        var orphanRAs = new List<RewardAssignment>
+        {
+            new RewardAssignment { Id = "ra-1", UserId = userId, RewardId = "reward-grandmaster-icon", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:mapping-grandmaster" },
+            new RewardAssignment { Id = "ra-2", UserId = userId, RewardId = "reward-grandmaster-portrait", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:mapping-grandmaster" }
+        };
+        _mockRewardService.Setup(x => x.GetUserRewards(userId)).ReturnsAsync(orphanRAs);
+
+        // Act
+        var result = await _service.ReconcileUserAssociations(userId, "test_prefix", dryRun: false);
+
+        // Assert
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.RewardsRevoked, Is.EqualTo(2));
+        _mockRewardService.Verify(x => x.RevokeReward("ra-1", It.IsAny<string>()), Times.Once);
+        _mockRewardService.Verify(x => x.RevokeReward("ra-2", It.IsAny<string>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ReconcileUserAssociations_WithActivePMUA_LeavesMatchingPatreonRAsAlone()
+    {
+        // Arrange — user has active PMUA for mapping-grandmaster and matching RAs (healthy state)
+        var userId = "Healthy#1234";
+
+        _mockProductMappingService.Setup(x => x.GetUserAssociationsByUserId(userId))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>
+            {
+                new ProductMappingUserAssociation
+                {
+                    Id = "pmua-1", UserId = userId, ProductMappingId = "mapping-grandmaster",
+                    ProviderId = "patreon", ProviderProductId = "6482092",
+                    Status = AssociationStatus.Active, AssignedAt = DateTime.UtcNow.AddDays(-1)
+                }
+            });
+
+        _mockProductMappingService.Setup(x => x.GetProductMappingById("mapping-grandmaster"))
+            .ReturnsAsync(new ProductMapping
+            {
+                Id = "mapping-grandmaster",
+                ProductName = "Grand Master",
+                RewardIds = new List<string> { "reward-grandmaster-icon" },
+                ProductProviders = new List<ProductProviderPair>
+                {
+                    new ProductProviderPair { ProviderId = "patreon", ProductId = "6482092" }
+                }
+            });
+
+        var existingRAs = new List<RewardAssignment>
+        {
+            new RewardAssignment { Id = "ra-1", UserId = userId, RewardId = "reward-grandmaster-icon", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:mapping-grandmaster" }
+        };
+        _mockRewardService.Setup(x => x.GetUserRewards(userId)).ReturnsAsync(existingRAs);
+
+        // Act
+        var result = await _service.ReconcileUserAssociations(userId, "test_prefix", dryRun: false);
+
+        // Assert — no revocations
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.RewardsRevoked, Is.EqualTo(0));
+        _mockRewardService.Verify(x => x.RevokeReward(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ReconcileUserAssociations_WithActivePMUAForBronze_RevokesGoldOrphanRA()
+    {
+        // Arrange — user downgraded from gold to bronze; one bronze PMUA active, but a stale gold RA still active
+        var userId = "Downgraded#1234";
+
+        _mockProductMappingService.Setup(x => x.GetUserAssociationsByUserId(userId))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>
+            {
+                new ProductMappingUserAssociation
+                {
+                    Id = "pmua-bronze", UserId = userId, ProductMappingId = "mapping-bronze",
+                    ProviderId = "patreon", ProviderProductId = "6482051",
+                    Status = AssociationStatus.Active, AssignedAt = DateTime.UtcNow.AddDays(-1)
+                }
+            });
+
+        _mockProductMappingService.Setup(x => x.GetProductMappingById("mapping-bronze"))
+            .ReturnsAsync(new ProductMapping
+            {
+                Id = "mapping-bronze", ProductName = "Bronze",
+                RewardIds = new List<string> { "reward-bronze" },
+                ProductProviders = new List<ProductProviderPair> { new ProductProviderPair { ProviderId = "patreon", ProductId = "6482051" } }
+            });
+
+        var ras = new List<RewardAssignment>
+        {
+            new RewardAssignment { Id = "ra-bronze", UserId = userId, RewardId = "reward-bronze", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:mapping-bronze" },
+            new RewardAssignment { Id = "ra-gold-orphan", UserId = userId, RewardId = "reward-gold", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:mapping-gold" }
+        };
+        _mockRewardService.Setup(x => x.GetUserRewards(userId)).ReturnsAsync(ras);
+
+        // Act
+        var result = await _service.ReconcileUserAssociations(userId, "test_prefix", dryRun: false);
+
+        // Assert
+        Assert.That(result.RewardsRevoked, Is.EqualTo(1));
+        _mockRewardService.Verify(x => x.RevokeReward("ra-gold-orphan", It.IsAny<string>()), Times.Once);
+        _mockRewardService.Verify(x => x.RevokeReward("ra-bronze", It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ReconcileUserAssociations_DryRun_DoesNotRevokeOrphans()
+    {
+        // Arrange — orphan RAs but dryRun=true
+        var userId = "DryRunTest#1234";
+        _mockProductMappingService.Setup(x => x.GetUserAssociationsByUserId(userId))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockRewardService.Setup(x => x.GetUserRewards(userId))
+            .ReturnsAsync(new List<RewardAssignment>
+            {
+                new RewardAssignment { Id = "ra-orphan", UserId = userId, RewardId = "reward-x", ProviderId = "patreon", Status = RewardStatus.Active, ProviderReference = "reconciliation:mapping-x" }
+            });
+
+        // Act
+        var result = await _service.ReconcileUserAssociations(userId, "test_prefix", dryRun: true);
+
+        // Assert — no revocation actually fired, but report says it would
+        _mockRewardService.Verify(x => x.RevokeReward(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        Assert.That(result.RewardsRevoked, Is.EqualTo(1)); // counted but not executed
+    }
+
+    [Test]
+    public async Task ReconcileUserAssociations_LeavesNonPatreonRAsAlone()
+    {
+        // Arrange — orphan-shaped RA but ProviderId != "patreon" (e.g., kofi, manual)
+        var userId = "Mixed#1234";
+        _mockProductMappingService.Setup(x => x.GetUserAssociationsByUserId(userId))
+            .ReturnsAsync(new List<ProductMappingUserAssociation>());
+        _mockRewardService.Setup(x => x.GetUserRewards(userId))
+            .ReturnsAsync(new List<RewardAssignment>
+            {
+                new RewardAssignment { Id = "ra-kofi", UserId = userId, RewardId = "reward-x", ProviderId = "kofi", Status = RewardStatus.Active },
+                new RewardAssignment { Id = "ra-manual", UserId = userId, RewardId = "reward-y", ProviderId = null, Status = RewardStatus.Active }
+            });
+
+        // Act
+        var result = await _service.ReconcileUserAssociations(userId, "test_prefix", dryRun: false);
+
+        // Assert — neither touched
+        _mockRewardService.Verify(x => x.RevokeReward(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        Assert.That(result.RewardsRevoked, Is.EqualTo(0));
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/ProductMappingReconciliationTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/ProductMappingReconciliationTests.cs
@@ -565,7 +565,8 @@ public class ProductMappingReconciliationTests
         _mockProductMappingService.Setup(x => x.GetProductMappingById("mapping-bronze"))
             .ReturnsAsync(new ProductMapping
             {
-                Id = "mapping-bronze", ProductName = "Bronze",
+                Id = "mapping-bronze",
+                ProductName = "Bronze",
                 RewardIds = new List<string> { "reward-bronze" },
                 ProductProviders = new List<ProductProviderPair> { new ProductProviderPair { ProviderId = "patreon", ProductId = "6482051" } }
             });

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/RewardDriftDetectionControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/RewardDriftDetectionControllerTests.cs
@@ -16,11 +16,13 @@ using W3ChampionsStatisticService.Rewards.Services;
 namespace WC3ChampionsStatisticService.Tests.Rewards;
 
 /// <summary>
-/// A testable subclass that exposes a helper to preset the last-run state
-/// without needing to run the actual background cycle.
+/// A testable subclass that overrides LastRun so tests can inject an arbitrary
+/// snapshot without running the actual background cycle.
 /// </summary>
 internal sealed class StubDriftBackgroundService : RewardDriftDetectionBackgroundService
 {
+    private DriftRunSnapshot _stub;
+
     public StubDriftBackgroundService()
         : base(
             new ServiceCollection().BuildServiceProvider(),
@@ -28,25 +30,11 @@ internal sealed class StubDriftBackgroundService : RewardDriftDetectionBackgroun
     {
     }
 
-    public void SetLastRunState(
-        DateTime? startedAtUtc,
-        DateTime? completedAtUtc,
-        bool succeeded,
-        string errorMessage,
-        int membersAdded,
-        int assignmentsRevoked,
-        int tiersUpdated)
+    public override DriftRunSnapshot LastRun => _stub;
+
+    public void SetLastRun(DriftRunSnapshot snapshot)
     {
-        // Use reflection to set the private setters (they are auto-properties
-        // with private set — the simplest approach that avoids changing production code).
-        var t = typeof(RewardDriftDetectionBackgroundService);
-        t.GetProperty(nameof(LastRunStartedAtUtc))!.SetValue(this, startedAtUtc);
-        t.GetProperty(nameof(LastRunCompletedAtUtc))!.SetValue(this, completedAtUtc);
-        t.GetProperty(nameof(LastRunSucceeded))!.SetValue(this, succeeded);
-        t.GetProperty(nameof(LastRunErrorMessage))!.SetValue(this, errorMessage);
-        t.GetProperty(nameof(LastRunMembersAdded))!.SetValue(this, membersAdded);
-        t.GetProperty(nameof(LastRunAssignmentsRevoked))!.SetValue(this, assignmentsRevoked);
-        t.GetProperty(nameof(LastRunTiersUpdated))!.SetValue(this, tiersUpdated);
+        _stub = snapshot;
     }
 }
 
@@ -90,14 +78,14 @@ public class RewardDriftDetectionControllerTests
             var completed = new DateTime(2026, 1, 15, 10, 0, 5, DateTimeKind.Utc);
 
             var bgService = new StubDriftBackgroundService();
-            bgService.SetLastRunState(
-                startedAtUtc: started,
-                completedAtUtc: completed,
-                succeeded: true,
-                errorMessage: null,
-                membersAdded: 3,
-                assignmentsRevoked: 1,
-                tiersUpdated: 2);
+            bgService.SetLastRun(new DriftRunSnapshot(
+                StartedAtUtc: started,
+                CompletedAtUtc: completed,
+                Succeeded: true,
+                ErrorMessage: null,
+                MembersAdded: 3,
+                AssignmentsRevoked: 1,
+                TiersUpdated: 2));
 
             var controller = BuildController(bgService);
 
@@ -138,7 +126,7 @@ public class RewardDriftDetectionControllerTests
         Environment.SetEnvironmentVariable("REWARDS_PATREON_IGNORED_TIER_IDS", null);
 
         var bgService = new StubDriftBackgroundService();
-        // No last-run state set — all properties at defaults (null / false / 0)
+        // No last-run snapshot set — LastRun returns null
 
         var controller = BuildController(bgService);
 
@@ -154,7 +142,40 @@ public class RewardDriftDetectionControllerTests
         Assert.That(json, Does.Contain("\"autoSyncEnabled\":false"), "Default: auto-sync disabled");
         Assert.That(json, Does.Contain("\"dryRun\":true"), "Default: dry-run on for safety");
         Assert.That(json, Does.Contain("\"ignoredTierIds\":\"\""), "Default: empty ignored-tier list");
-        Assert.That(json, Does.Contain("\"startedAtUtc\":null"), "No cycle run yet — startedAtUtc null");
-        Assert.That(json, Does.Contain("\"completedAtUtc\":null"), "No cycle run yet — completedAtUtc null");
+        Assert.That(json, Does.Contain("\"lastRun\":null"), "No cycle run yet — lastRun should be null");
+    }
+
+    [Test]
+    public void GetDriftDetectionStatus_FailedCycle_ExposesErrorMessageAndZeroCounts()
+    {
+        // Arrange
+        var started = DateTime.UtcNow.AddMinutes(-5);
+        var completed = DateTime.UtcNow.AddMinutes(-4);
+
+        var bgService = new StubDriftBackgroundService();
+        bgService.SetLastRun(new DriftRunSnapshot(
+            StartedAtUtc: started,
+            CompletedAtUtc: completed,
+            Succeeded: false,
+            ErrorMessage: "Patreon API timeout",
+            MembersAdded: 0,
+            AssignmentsRevoked: 0,
+            TiersUpdated: 0));
+
+        var controller = BuildController(bgService);
+
+        // Act
+        var actionResult = controller.GetDriftDetectionStatus() as OkObjectResult;
+
+        // Assert
+        Assert.That(actionResult, Is.Not.Null, "Expected OkObjectResult");
+
+        var json = JsonSerializer.Serialize(actionResult!.Value);
+
+        Assert.That(json, Does.Contain("\"succeeded\":false"), "lastRun.succeeded should be false");
+        Assert.That(json, Does.Contain("\"errorMessage\":\"Patreon API timeout\""), "lastRun.errorMessage should carry exception message");
+        Assert.That(json, Does.Contain("\"membersAdded\":0"), "lastRun.membersAdded must be 0 on failure — no stale counts");
+        Assert.That(json, Does.Contain("\"assignmentsRevoked\":0"), "lastRun.assignmentsRevoked must be 0 on failure");
+        Assert.That(json, Does.Contain("\"tiersUpdated\":0"), "lastRun.tiersUpdated must be 0 on failure");
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/RewardDriftDetectionControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/RewardDriftDetectionControllerTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using W3C.Domain.Common.Services;
+using W3C.Domain.Rewards.Abstractions;
+using W3C.Domain.Rewards.Repositories;
+using W3ChampionsStatisticService.Rewards.BackgroundServices;
+using W3ChampionsStatisticService.Rewards.Controllers;
+using W3ChampionsStatisticService.Rewards.Providers.Patreon;
+using W3ChampionsStatisticService.Rewards.Services;
+
+namespace WC3ChampionsStatisticService.Tests.Rewards;
+
+/// <summary>
+/// A testable subclass that exposes a helper to preset the last-run state
+/// without needing to run the actual background cycle.
+/// </summary>
+internal sealed class StubDriftBackgroundService : RewardDriftDetectionBackgroundService
+{
+    public StubDriftBackgroundService()
+        : base(
+            new ServiceCollection().BuildServiceProvider(),
+            Mock.Of<ILogger<RewardDriftDetectionBackgroundService>>())
+    {
+    }
+
+    public void SetLastRunState(
+        DateTime? startedAtUtc,
+        DateTime? completedAtUtc,
+        bool succeeded,
+        string errorMessage,
+        int membersAdded,
+        int assignmentsRevoked,
+        int tiersUpdated)
+    {
+        // Use reflection to set the private setters (they are auto-properties
+        // with private set — the simplest approach that avoids changing production code).
+        var t = typeof(RewardDriftDetectionBackgroundService);
+        t.GetProperty(nameof(LastRunStartedAtUtc))!.SetValue(this, startedAtUtc);
+        t.GetProperty(nameof(LastRunCompletedAtUtc))!.SetValue(this, completedAtUtc);
+        t.GetProperty(nameof(LastRunSucceeded))!.SetValue(this, succeeded);
+        t.GetProperty(nameof(LastRunErrorMessage))!.SetValue(this, errorMessage);
+        t.GetProperty(nameof(LastRunMembersAdded))!.SetValue(this, membersAdded);
+        t.GetProperty(nameof(LastRunAssignmentsRevoked))!.SetValue(this, assignmentsRevoked);
+        t.GetProperty(nameof(LastRunTiersUpdated))!.SetValue(this, tiersUpdated);
+    }
+}
+
+[TestFixture]
+public class RewardDriftDetectionControllerTests
+{
+    private static RewardDriftDetectionController BuildController(
+        StubDriftBackgroundService bgService)
+    {
+        // PatreonApiClient requires an HttpClient in its constructor — pass a real (unused) one.
+        var patreonApiClient = new Mock<PatreonApiClient>(new System.Net.Http.HttpClient());
+
+        var patreonService = new PatreonDriftDetectionService(
+            patreonApiClient.Object,
+            Mock.Of<IProductMappingUserAssociationRepository>(),
+            Mock.Of<IProductMappingRepository>(),
+            Mock.Of<IPatreonAccountLinkRepository>(),
+            Mock.Of<IProductMappingReconciliationService>(),
+            Mock.Of<IRewardAssignmentRepository>(),
+            Mock.Of<IRewardService>());
+
+        return new RewardDriftDetectionController(
+            patreonService,
+            Mock.Of<IAuditLogService>(),
+            Mock.Of<ILogger<RewardDriftDetectionController>>(),
+            bgService);
+    }
+
+    [Test]
+    public void GetDriftDetectionStatus_ReturnsEnvVarStateAndLastRunSummary()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("REWARDS_DRIFT_DETECTION_ENABLED", "true");
+        Environment.SetEnvironmentVariable("REWARDS_DRIFT_AUTO_SYNC_ENABLED", "true");
+        Environment.SetEnvironmentVariable("REWARDS_DRIFT_SYNC_DRY_RUN", "false");
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_IGNORED_TIER_IDS", "15145463");
+
+        try
+        {
+            var started = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc);
+            var completed = new DateTime(2026, 1, 15, 10, 0, 5, DateTimeKind.Utc);
+
+            var bgService = new StubDriftBackgroundService();
+            bgService.SetLastRunState(
+                startedAtUtc: started,
+                completedAtUtc: completed,
+                succeeded: true,
+                errorMessage: null,
+                membersAdded: 3,
+                assignmentsRevoked: 1,
+                tiersUpdated: 2);
+
+            var controller = BuildController(bgService);
+
+            // Act
+            var actionResult = controller.GetDriftDetectionStatus() as OkObjectResult;
+
+            // Assert
+            Assert.That(actionResult, Is.Not.Null, "Expected OkObjectResult");
+
+            var json = JsonSerializer.Serialize(actionResult!.Value);
+
+            Assert.That(json, Does.Contain("\"detectionEnabled\":true"), "detectionEnabled should be true from env var");
+            Assert.That(json, Does.Contain("\"autoSyncEnabled\":true"), "autoSyncEnabled should be true from env var");
+            Assert.That(json, Does.Contain("\"dryRun\":false"), "dryRun should be false from env var");
+            Assert.That(json, Does.Contain("\"ignoredTierIds\":\"15145463\""), "ignoredTierIds should reflect env var");
+            Assert.That(json, Does.Contain("\"succeeded\":true"), "lastRun.succeeded should be true");
+            Assert.That(json, Does.Contain("\"membersAdded\":3"), "lastRun.membersAdded should be 3");
+            Assert.That(json, Does.Contain("\"assignmentsRevoked\":1"), "lastRun.assignmentsRevoked should be 1");
+            Assert.That(json, Does.Contain("\"tiersUpdated\":2"), "lastRun.tiersUpdated should be 2");
+            Assert.That(json, Does.Contain("\"patreon\""), "providers should include patreon");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("REWARDS_DRIFT_DETECTION_ENABLED", null);
+            Environment.SetEnvironmentVariable("REWARDS_DRIFT_AUTO_SYNC_ENABLED", null);
+            Environment.SetEnvironmentVariable("REWARDS_DRIFT_SYNC_DRY_RUN", null);
+            Environment.SetEnvironmentVariable("REWARDS_PATREON_IGNORED_TIER_IDS", null);
+        }
+    }
+
+    [Test]
+    public void GetDriftDetectionStatus_WhenNoEnvVars_ReturnsConservativeDefaults()
+    {
+        // Arrange — ensure env vars are absent
+        Environment.SetEnvironmentVariable("REWARDS_DRIFT_DETECTION_ENABLED", null);
+        Environment.SetEnvironmentVariable("REWARDS_DRIFT_AUTO_SYNC_ENABLED", null);
+        Environment.SetEnvironmentVariable("REWARDS_DRIFT_SYNC_DRY_RUN", null);
+        Environment.SetEnvironmentVariable("REWARDS_PATREON_IGNORED_TIER_IDS", null);
+
+        var bgService = new StubDriftBackgroundService();
+        // No last-run state set — all properties at defaults (null / false / 0)
+
+        var controller = BuildController(bgService);
+
+        // Act
+        var actionResult = controller.GetDriftDetectionStatus() as OkObjectResult;
+
+        // Assert
+        Assert.That(actionResult, Is.Not.Null, "Expected OkObjectResult");
+
+        var json = JsonSerializer.Serialize(actionResult!.Value);
+
+        Assert.That(json, Does.Contain("\"detectionEnabled\":false"), "Default: detection disabled");
+        Assert.That(json, Does.Contain("\"autoSyncEnabled\":false"), "Default: auto-sync disabled");
+        Assert.That(json, Does.Contain("\"dryRun\":true"), "Default: dry-run on for safety");
+        Assert.That(json, Does.Contain("\"ignoredTierIds\":\"\""), "Default: empty ignored-tier list");
+        Assert.That(json, Does.Contain("\"startedAtUtc\":null"), "No cycle run yet — startedAtUtc null");
+        Assert.That(json, Does.Contain("\"completedAtUtc\":null"), "No cycle run yet — completedAtUtc null");
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Rewards/RewardServiceTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Rewards/RewardServiceTests.cs
@@ -309,6 +309,42 @@ public class RewardServiceTests
     }
 
     [Test]
+    public async Task RevokeReward_WhenAssignmentAlreadyRevoked_IsIdempotent()
+    {
+        // Regression test for double-revoke safety.
+        // Several call paths in the drift sync PR can hit the same RA twice:
+        // the direct revoke loop + the bidirectional reconciler. If RevokeReward
+        // is not idempotent, the module side-effect (e.g. portrait removal) fires twice,
+        // which may corrupt state or cause double-revocation errors.
+        var assignmentId = "ra-already-revoked";
+        var revokedAssignment = new RewardAssignment
+        {
+            Id = assignmentId,
+            UserId = "User#1234",
+            RewardId = "reward-x",
+            ProviderId = "patreon",
+            Status = RewardStatus.Revoked,
+            RevokedAt = DateTime.UtcNow.AddDays(-1)
+        };
+        _mockAssignmentRepo.Setup(x => x.GetById(assignmentId)).ReturnsAsync(revokedAssignment);
+
+        // Act — call RevokeReward on an assignment that is already Revoked
+        await _rewardService.RevokeReward(assignmentId, "second call");
+
+        // Assert — Update NOT called (no DB churn), no module side-effect fired again.
+        // The RewardService constructor injects IServiceScopeFactory for module resolution;
+        // modules are looked up from the scope. An Update call is the observable evidence
+        // that the method did not return early.
+        _mockAssignmentRepo.Verify(x => x.Update(It.IsAny<RewardAssignment>()), Times.Never,
+            "RevokeReward must not call Update for an already-revoked assignment (idempotent early return).");
+
+        // Also assert the no-reason overload is equally idempotent
+        await _rewardService.RevokeReward(assignmentId);
+        _mockAssignmentRepo.Verify(x => x.Update(It.IsAny<RewardAssignment>()), Times.Never,
+            "The no-reason overload must also be idempotent for an already-revoked assignment.");
+    }
+
+    [Test]
     public async Task ProcessRewardEvent_MultipleTiersWithPartialRewards_OnlyAssignsMissingOnes()
     {
         // Arrange - User has tier1 completely, tier2 partially (missing one reward)


### PR DESCRIPTION
## Summary

- Closes the financial-correctness bug where 33% (54/162) of Patreon-rewarded users in production have active `RewardAssignment` rows but no active `ProductMappingUserAssociation`. Drift sync now revokes RAs end-to-end via three layers of defense: point-fix at PMUA-revoke moments, bidirectional `ReconcileUserAssociations`, and an admin-gated cleanup endpoint for the existing 54 orphans.
- Stops the hourly `drift_sync_tier_update` churn loop affecting 6+ active users (`Slygo#21784`, `Ameth#21227`, `effkay#11518`, `Coherent#2542`, `JieYanLing#1387`, `Zebrahead#2684`) by adding `REWARDS_PATREON_IGNORED_TIER_IDS` (set to `15145463` — the campaign's free-follower tier, confirmed via Patreon API) plus a no-op guard in `UpdateUserAssociationTiers` that defends in depth against any future unmapped tier.
- Wires `PatreonAccountLink.LastSyncAt` into all sync-success paths, replaces the stub `GetDriftDetectionStatus` endpoint with real env-var state + last-run summary, and makes `RewardService.RevokeReward` idempotent.

## Investigation provenance

Investigated `Bubu#23550` who appeared with active Grand Master rewards despite no active Patreon. Production DB queries confirmed Bubu's PMUAs were correctly revoked on 2026-02-01 (`drift_sync_missing` saw `former_patron`) but the 18 backing RAs remained active. Git archaeology pinned the regression to commit `5e88f12` (2025-08-23) which deleted the working `ProcessRewardEvent`-based revocation path and replaced it with `ReconcileUserAssociations` — but only the forward half ("for each active PMUA, ensure RAs exist") was implemented; the reverse half was never written. Tests didn't catch it because `PatreonDriftSyncTests` mocks `IProductMappingReconciliationService` and unconditionally stubs `RewardsRevoked = 0`.

## What changed

**Bug 1 — orphan RA revocation (CRITICAL, financial)**
- `DeactivateUserAssociation` and `DeactivateAllUserAssociations` now revoke patreon RAs directly at the moment of PMUA revocation, mirroring the proven `HandleLinkRemoval` pattern. RAs revoked **before** PMUAs to avoid worsening failure shape; per-RA revoke wrapped in try/catch-and-continue so a single transient failure doesn't halt the rest of the user's sync.
- `ReconcileUserAssociations` now performs a backward sweep: for each user reconciled, find active patreon RAs whose mapping has no backing active PMUA and revoke them. Closes the same bug class for any future caller.
- New admin endpoints (`AdminRewardController`):
  - `GET /api/rewards/admin/orphan-rewards` — preview report (read-only)
  - `POST /api/rewards/admin/orphan-rewards/revoke` — revoke approved subset, with re-detection-against-fresh-data safety
- `IOrphanRewardService` + `OrphanRewardService` encapsulate the detection and revocation logic. Casing-safe HashSet comparisons (handles legacy pre-canonicalization data).

**Bug 2 — free-tier churn loop**
- `PatreonTierFilter` reads `REWARDS_PATREON_IGNORED_TIER_IDS` (comma-separated tier IDs) and drops matching tiers before the passthrough/Tiered split.
- `UpdateUserAssociationTiers` adds a no-op guard: when the actionable tier set already equals the existing active set, return without writes. Computed before the dryRun check so dry-run preview is accurate. Defense-in-depth against any future unmapped tier.

**Observability + safety**
- `IPatreonAccountLinkRepository.RefreshLastSyncAt(battleTag)` — single source of truth for refreshing `LastSyncAt`. Wired into SyncSingleUser, drift-sync per-user mutations (`!dryRun` only), and the Patreon webhook handler.
- `GetDriftDetectionStatus` returns real env-var state (`detectionEnabled`, `autoSyncEnabled`, `dryRun`, `ignoredTierIds`) + last-run summary (`startedAtUtc`, `completedAtUtc`, `succeeded`, `errorMessage`, `membersAdded`, `assignmentsRevoked`, `tiersUpdated`). `RewardDriftDetectionBackgroundService` exposes its run state via an immutable `DriftRunSnapshot` record with `Volatile.Read/Write` for thread-safe publication. DI registration changed to `AddSingleton<T> + AddHostedService(sp => sp.GetRequiredService<T>())` so the controller receives the same instance running cycles.
- `RewardService.RevokeReward` is now idempotent — guards against re-firing module side-effects on already-revoked assignments.

**Tests**
- `PatreonDriftRevocationIntegrationTests.LapsedPatron_DriftSync_RevokesRewardAssignmentEndToEnd` — keystone regression test that wires up the real `ProductMappingReconciliationService` (not mocked) and asserts RA revocation end-to-end. This is the test that would have caught the original bug.
- 12+ new unit tests covering: drift extra-assignment RA revocation, SyncSingleUser RA revocation, bidirectional reconciler (5 scenarios incl. dry-run + non-patreon protection), orphan service detection + revocation truth tables, idempotent RevokeReward, no-op tier guard (live + dry-run), tier-update real upgrade, casing safety in orphan detection (RA + PMUA sides), order-of-ops failure tolerance, partial-revoke continuation, status endpoint env-var/last-run shape including failed-cycle case.
- 540 unit tests passing, 0 failed, 9 pre-existing skips.

---

## Deploy runbook

### Pre-deploy

1. In `docker-compose-files/website-backend/` (separate repo), add to **both** `Prod.yml` and `Test.yml`:
   ```yaml
   - REWARDS_PATREON_IGNORED_TIER_IDS=15145463
   ```
2. Confirm existing env vars are still set:
   ```yaml
   - REWARDS_DRIFT_DETECTION_ENABLED=true
   - REWARDS_DRIFT_AUTO_SYNC_ENABLED=true
   - REWARDS_DRIFT_SYNC_DRY_RUN=false
   ```

### Deploy

Standard image rollout. **No DB migration required** — only behavioral code changes.

### Post-deploy verification

1. Hit the status endpoint:
   ```bash
   curl -H "Authorization: Bearer $ADMIN_TOKEN" \
     https://website-backend.w3champions.com/api/rewards/drift-detection/status
   ```
   Expect:
   - `detectionEnabled: true`
   - `autoSyncEnabled: true`
   - `dryRun: false`
   - `ignoredTierIds: "15145463"`
   - `lastRun.completedAtUtc` updates within ~60 minutes of deploy
   - `lastRun.succeeded: true`

2. After the next 60-min drift cycle, confirm the tier-update churn loop has stopped. Query `db.ProductMappingUserAssociation` for the previously-affected users (`Slygo#21784`, `Ameth#21227`, `effkay#11518`, `Coherent#2542`, `JieYanLing#1387`, `Zebrahead#2684`) — `metadata.source: "drift_sync_tier_update"` writes should stop appearing.

### Existing-orphan cleanup (one-off, manual review)

The 54 users with active patreon RAs but no active PMUA need their RAs revoked. Use the new admin endpoints. **Deliberate human-in-the-loop step — do not script the revoke without reviewing the preview output.**

1. **Preview**:
   ```bash
   curl -H "Authorization: Bearer $ADMIN_TOKEN" \
     https://website-backend.w3champions.com/api/rewards/admin/orphan-rewards
   ```
   Save the response JSON to a file — you'll cross-check it.

2. **Cross-check**: For each entry, verify:
   - The `userId` is the canonical BattleTag form.
   - There is no internal record of this user being "comped" rewards manually outside the rewards system (e.g., Discord pings to the team). Manual portrait grants via `PUT /api/rewards/portraits` write to `PersonalSetting.SpecialPictures` and would NOT show up in this report — but if you have any other reward-granting workflow off-platform, double-check.
   - The reason matches: `"Active patreon RewardAssignment with no backing active PMUA and not an active patron"`.

3. **Revoke** the approved list:
   ```bash
   curl -X POST \
     -H "Authorization: Bearer $ADMIN_TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"userIds":["Bubu#23550","kleiZter#21520","..."]}' \
     "https://website-backend.w3champions.com/api/rewards/admin/orphan-rewards/revoke?actingPlayer=$YOUR_BATTLETAG"
   ```
   > **Note:** The `actingPlayer` query parameter is overridden by the `[InjectActingPlayerAuthCode]` filter — it is rewritten to the BattleTag extracted from your JWT. The value in the URL doesn't affect the audit log; the JWT BattleTag does. This is expected behavior.

   Inspect the response:
   - `usersTouched` should match the size of the approved list (or fewer, if some users became active patrons between preview and revoke — those will show in `skippedUserIdsNotInLatestDetection`).
   - `assignmentsRevoked` should match the total RA count in the preview for those users.
   - `errors` should be empty.

4. **Re-preview** to confirm cleanup:
   ```bash
   curl -H "Authorization: Bearer $ADMIN_TOKEN" \
     https://website-backend.w3champions.com/api/rewards/admin/orphan-rewards
   ```
   Should return `{"detectedAtUtc":"...","entries":[]}` (empty).

### Rollback

If the orphan revocation result looks wrong post-cleanup:
1. Reward modules (e.g., `PortraitRewardModule`) handle their own state reversal on revoke. Reverting requires re-granting via `PUT /api/rewards/portraits` for portrait rewards, or by creating new `RewardAssignment` rows manually for chat-icon / discord-role rewards.
2. Investigate root cause: query MongoDB for the affected user's `RewardAssignment` and `ProductMappingUserAssociation` history.

If a regression in the auto-revoke logic is suspected post-deploy:
1. Set `REWARDS_DRIFT_AUTO_SYNC_ENABLED=false` to halt all auto-syncing immediately.
2. Existing PMUAs are not affected by this env var change — they continue to grant rewards via the reconciler. Only the drift sync's mutation behavior is gated.
3. Revert the deploy if needed.

### Monitoring

- **Audit log entries:**
  - `ORPHAN_REWARDS_REVOKE` captures each admin invocation of the orphan cleanup endpoint with the actor BattleTag and counts.
  - `DRIFT_SYNC / EXECUTE` (category `DRIFT_SYNC`, action `EXECUTE`) is written by `POST /api/rewards/drift-detection/patreon/sync` for admin-triggered syncs. The background service uses Serilog only (no audit log entry); monitor those runs via structured Serilog output.
- **Per-RA revocation Serilog entries:**
  - `"Drift sync revoked RewardAssignment {AssignmentId} for {UserId} (reward {RewardId})"` — point-fix path
  - `"SyncSingleUser revoked RewardAssignment {AssignmentId} for {UserId} (reward {RewardId})"` — SyncSingleUser path
  - `"Reconciler revoked orphan RewardAssignment {AssignmentId} for {UserId} (reward {RewardId})"` — bidirectional reconciler
  - `"Admin orphan cleanup revoked {AssignmentId} for {UserId} (actor: {Actor})"` — admin endpoint
- **`GET /api/rewards/drift-detection/status`** — surfaces the most recent cycle's success/error and counts at a glance.

---

## Test plan checklist

- [ ] Pre-deploy: `Prod.yml` and `Test.yml` (in `docker-compose-files`) have `REWARDS_PATREON_IGNORED_TIER_IDS=15145463` added
- [ ] Deploy + verify `GET /api/rewards/drift-detection/status` returns expected env-var state + a recent successful `lastRun`
- [ ] Confirm `drift_sync_tier_update` PMUA writes for the 6 churn-loop users have stopped (query MongoDB ~60 minutes after deploy)
- [ ] Run the orphan cleanup procedure above (preview → cross-check → revoke → re-preview)
- [ ] Verify `Bubu#23550` no longer appears with Grand Master in `/api/rewards/admin/rewards/68baf57ec346a5ab8364413b/assignments`
- [ ] Spot-check audit log: `ORPHAN_REWARDS_REVOKE` entries with the actor BattleTag and counts

## Out of scope

- Frontend admin search 404 fix (`AdminService.ts:284` missing `/admin/`) ships as separate PR: w3champions/website#1061.
- `PatreonDriftDetectionService.cs` (1128 lines) extraction into smaller services — flagged for follow-up.
- `SyncSingleUser` access-token gate is dead code (the call uses the campaign creator token); deliberately left as-is.