### PR TITLE
feat: trust Russia gateway IP in ForwardedHeaders for flo-TLS-443 Phase B

### DIFF
--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -292,7 +292,8 @@ var app = builder.Build();
 app.UseForwardedHeaders(new ForwardedHeadersOptions
 {
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
-    KnownNetworks = { new IPNetwork(IPAddress.Parse("172.18.0.0"), 16) } // Docker network
+    KnownNetworks = { new IPNetwork(IPAddress.Parse("172.18.0.0"), 16) }, // Docker network
+    KnownProxies = { IPAddress.Parse("212.60.5.180") } // Russia gateway
 });
 app.Use(
     (context, next) =>


### PR DESCRIPTION
## Summary

One-line addition to Program.cs adding 212.60.5.180 (Russia gateway) to ForwardedHeaders.KnownProxies.

## Why

Phase B of the flo-TLS-on-443 design will put a Traefik container in front of nginx-proxy on big-elephant with TLS passthrough + PROXY-protocol v2 outbound to nginx-proxy. For Russia-routed HTTPS requests, the PROXY header at nginx-proxy contains Russia's IP (its TCP peer), which leaks into the outbound X-Forwarded-For chain to this service as `<real-client>, 212.60.5.180`. Without this fix, .NET's middleware walks right-to-left, stops at 212.60.5.180 (not in any trust list), and reports it as the client IP — breaking rate limiting and Turnstile verification keying.

## Phase

Lands as part of Phase A of the rollout. **Inert today** (no behavior change); becomes load-bearing once Phase B's catch-all ingress flip happens.

## Test plan

- [x] `dotnet build` succeeds (0 errors, 1 pre-existing warning)
- [x] Existing tests pass (540 passed, 0 failed, 9 skipped)
- [ ] Post-Phase-B verification: rate limit / Turnstile correctly keys on real client IP for both direct and Russia-routed traffic