### PR TITLE
fix(read-model): strip AI players from MatchFinishedEvent before delegating to inner handlers

### DIFF
--- a/W3ChampionsStatisticService/ReadModelBase/MatchFinishedReadModelHandler.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/MatchFinishedReadModelHandler.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using W3C.Contracts.Matchmaking;
 using W3C.Domain.MatchmakingService;
 using W3C.Domain.Repositories;
 using W3C.Domain.Tracing;

--- a/W3ChampionsStatisticService/ReadModelBase/MatchFinishedReadModelHandler.cs
+++ b/W3ChampionsStatisticService/ReadModelBase/MatchFinishedReadModelHandler.cs
@@ -1,10 +1,12 @@
-﻿using System;
+using System;
+using System.Linq;
 using System.Threading.Tasks;
+using W3C.Contracts.Matchmaking;
 using W3C.Domain.MatchmakingService;
 using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.Services;
-using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.ReadModelBase;
 
@@ -33,6 +35,26 @@ public class MatchFinishedReadModelHandler<T>(
 
     protected override async Task UpdateInnerHandler(MatchFinishedEvent matchEvent)
     {
+        StripComputerPlayers(matchEvent);
         await _innerHandler.Update(matchEvent);
     }
+
+    private static void StripComputerPlayers(MatchFinishedEvent matchEvent)
+    {
+        if (matchEvent.match?.players != null)
+        {
+            matchEvent.match.players = matchEvent.match.players
+                .Where(p => !IsComputer(p))
+                .ToList();
+        }
+        if (matchEvent.result?.players != null)
+        {
+            matchEvent.result.players = matchEvent.result.players
+                .Where(p => !IsComputer(p))
+                .ToList();
+        }
+    }
+
+    private static bool IsComputer(PlayerMMrChange p) => string.IsNullOrEmpty(p?.battleTag);
+    private static bool IsComputer(PlayerBlizzard p) => p == null || p.isAi || string.IsNullOrEmpty(p.battleTag);
 }

--- a/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
@@ -162,6 +162,13 @@ public static class TestDtoHelper
         fakeEvent.match.gameMode = GameMode.GM_LTW_FFA;
         fakeEvent.match.map = "Maps/frozenthrone/community/(4)LegionTD.w3x";
 
+        // AutoFixture marks generated PlayerBlizzard entries as AI; force them human
+        // so the added map-forced AI below is the only computer in the fixture.
+        foreach (var p in fakeEvent.result.players)
+        {
+            p.isAi = false;
+        }
+
         // Add a map-forced computer to result.players (mirrors flo's LegionTD creep slot).
         fakeEvent.result.players.Add(new PlayerBlizzard
         {

--- a/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
@@ -156,6 +156,39 @@ public static class TestDtoHelper
         return fakeEvent;
     }
 
+    public static MatchFinishedEvent CreateFakeLegionTdEvent()
+    {
+        var fakeEvent = CreateFakeEvent();
+        fakeEvent.match.gameMode = GameMode.GM_LTW_FFA;
+        fakeEvent.match.map = "Maps/frozenthrone/community/(4)LegionTD.w3x";
+
+        // Add a map-forced computer to result.players (mirrors flo's LegionTD creep slot).
+        fakeEvent.result.players.Add(new PlayerBlizzard
+        {
+            battleTag = "",
+            isAi = true,
+            teamIndex = 2,
+            playerColor = 11,
+            toonName = "Computer (Insane)",
+            won = false,
+            heroes = new List<Hero>(),
+            overallScore = new OverallScore(),
+            unitScore = new UnitScore(),
+            heroScore = new HeroScore(),
+            resourceScore = new ResourceScore(),
+        });
+
+        // Also add a phantom PlayerMMrChange with no battleTag to exercise match.players filtering.
+        fakeEvent.match.players.Add(new PlayerMMrChange
+        {
+            battleTag = "",
+            team = 2,
+            won = false,
+        });
+
+        return fakeEvent;
+    }
+
     private static void CreateMatchTeam(MatchFinishedEvent fakeEvent, bool won, int team, int playersPerTeam)
     {
         CreateMatchTeamWithRanking(fakeEvent, won, team, playersPerTeam);

--- a/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchFinishedReadModelHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchFinishedReadModelHandlerTests.cs
@@ -176,5 +176,9 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
             "Inner handler must not see players with empty battleTag in result.players");
         Assert.That(receivedEvent.match.players.Any(p => string.IsNullOrEmpty(p.battleTag)), Is.False,
             "Inner handler must not see players with empty battleTag in match.players");
+        Assert.That(receivedEvent.result.players.Count, Is.EqualTo(2),
+            "Human players must be preserved in result.players after stripping");
+        Assert.That(receivedEvent.match.players.Count, Is.EqualTo(2),
+            "Human players must be preserved in match.players after stripping");
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchFinishedReadModelHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/ReadModel/MatchFinishedReadModelHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using Moq;
@@ -136,5 +137,44 @@ public class ReadModelHandlerBaseTests : IntegrationTestBase
         Assert.AreEqual(fakeEvent3.match.id, matches[0].MatchId);
         Assert.AreEqual(fakeEvent3.Id, matches[0].Id);
         mockTrackingService.Verify(m => m.TrackException(It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task InnerHandlerReceivesNoAiPlayers()
+    {
+        var fakeEvent = TestDtoHelper.CreateFakeLegionTdEvent();
+        fakeEvent.match.state = EMatchState.FINISHED;
+        fakeEvent.WasFakeEvent = false;
+
+        var mockEvents = new Mock<IMatchEventRepository>();
+        mockEvents.SetupSequence(m => m.Load<MatchFinishedEvent>(It.IsAny<string>(), It.IsAny<int>()))
+            .ReturnsAsync([fakeEvent])
+            .ReturnsAsync([]);
+
+        var mockTrackingService = TestDtoHelper.CreateMockTrackingService();
+        var versionRepository = new VersionRepository(MongoClient);
+
+        MatchFinishedEvent receivedEvent = null;
+        var innerHandlerMock = new Mock<IMatchFinishedReadModelHandler>();
+        innerHandlerMock
+            .Setup(h => h.Update(It.IsAny<MatchFinishedEvent>()))
+            .Callback<MatchFinishedEvent>(e => receivedEvent = e)
+            .Returns(Task.CompletedTask);
+
+        var handler = new MatchFinishedReadModelHandler<IMatchFinishedReadModelHandler>(
+            mockEvents.Object,
+            versionRepository,
+            innerHandlerMock.Object,
+            mockTrackingService.Object);
+
+        await handler.Update();
+
+        Assert.That(receivedEvent, Is.Not.Null);
+        Assert.That(receivedEvent.result.players.Any(p => p.isAi), Is.False,
+            "Inner handler must not see AI players in result.players");
+        Assert.That(receivedEvent.result.players.Any(p => string.IsNullOrEmpty(p.battleTag)), Is.False,
+            "Inner handler must not see players with empty battleTag in result.players");
+        Assert.That(receivedEvent.match.players.Any(p => string.IsNullOrEmpty(p.battleTag)), Is.False,
+            "Inner handler must not see players with empty battleTag in match.players");
     }
 }


### PR DESCRIPTION
## Summary

- Filters AI/computer entries out of `MatchFinishedEvent.match.players` and `MatchFinishedEvent.result.players` at the `MatchFinishedReadModelHandler<T>` base, before delegating to the 20+ `IMatchFinishedReadModelHandler` implementations. None of those handlers know about `PlayerBlizzard.isAi` or empty-`battleTag` `PlayerMMrChange` entries — they'd otherwise create phantom `PlayerOverallStats`, `PlayerWinLoss`, `PlayerMmrRpTimeline`, and `Matchup` rows keyed on empty battleTags, and `PlayerHeroStatsHandler` (which indexes `result.players[0]/[1]` assuming a 2-player 1v1) could crash or write garbage when computers inflate the count.
- Adds `CreateFakeLegionTdEvent()` fixture + `InnerHandlerReceivesNoAiPlayers` test asserting filtered counts (both `Any(isAi) == false` and `Count == expected` to catch over-filtering).
- Fixes a latent bug the count-assertion exposed in `CreateFakeEvent()` — `AutoFixture` defaults `PlayerBlizzard.isAi` to `true`, so previous tests passed accidentally because every fixture player was being stripped.

## Why this is defense-in-depth

Ladder maps like LegionTD have map-hardcoded AI slots (creeps) that today flow through:
```
flo → matchmaking-service (isLadderMatch=true) → statsHook.pushMatchResult → MatchFinishedEvent → website-backend
```

The matchmaking-service PR adds its own AI-stripping at `statsHook.pushMatchResult`, but this read-model filter protects every current and future inner handler regardless of upstream behavior.

## Paired changes

- **matchmaking-service**: separate PR strips AI from `MatchFinishedEvent` payload upstream and ships `userAddedComputerColors` to the launcher.
- **launcher-e**: https://github.com/w3champions/launcher-e/pull/758 hides map-baked AI on the score screen.

## Test plan

- [x] `dotnet test WC3ChampionsStatisticService.UnitTests` → 541 passing, 9 skipped, 0 failing
- [x] `dotnet format --verify-no-changes` clean
- [x] New test `InnerHandlerReceivesNoAiPlayers` validates both negative (no AI / no empty-battleTag survives) and positive (count == 2) assertions
- [ ] Smoke a LegionTD ladder match end-to-end — verify no new DB rows are keyed on empty battleTag in `PlayerOverallStats`, `PersonalSetting`, `PlayerWinLoss`, `Matchup`