### PR TITLE
feat: PlayerMatchTelemetry endpoint + LagReport transport field

### DIFF
--- a/W3ChampionsStatisticService/LagReports/LagReport.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReport.cs
@@ -61,10 +61,10 @@ public class LagReportPlayer
     public EConnectionType ConnectionType { get; set; }
 
     /// <summary>
-    /// Transport protocol used for the game stream ("TCP" or "QUIC").
-    /// Defaults to "TCP" so existing documents that lack the field deserialize cleanly.
+    /// Transport protocol used for the game stream (TCP or QUIC).
+    /// Defaults to TCP so existing documents that lack the field deserialize cleanly.
     /// </summary>
-    public string Transport { get; set; } = "TCP";
+    public Transport Transport { get; set; } = Transport.TCP;
 
     /// <summary>Name of the proxy node (null if direct).</summary>
     public string ProxyName { get; set; }

--- a/W3ChampionsStatisticService/LagReports/LagReport.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReport.cs
@@ -60,6 +60,12 @@ public class LagReportPlayer
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public EConnectionType ConnectionType { get; set; }
 
+    /// <summary>
+    /// Transport protocol used for the game stream ("TCP" or "QUIC").
+    /// Defaults to "TCP" so existing documents that lack the field deserialize cleanly.
+    /// </summary>
+    public string Transport { get; set; } = "TCP";
+
     /// <summary>Name of the proxy node (null if direct).</summary>
     public string ProxyName { get; set; }
 

--- a/W3ChampionsStatisticService/LagReports/LagReportController.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportController.cs
@@ -184,6 +184,7 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
             BattleTag = battleTag,
             ClientIp = topo.ClientIp,
             ConnectionType = topo.ConnectionType,
+            Transport = topo.Transport,
             ProxyName = topo.ProxyName,
             ProxyIp = proxyIp,
             ProxyPort = proxyPort,

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -69,12 +69,12 @@ public class ConnectionTopologyDto
     public string ClientIp { get; set; }
 
     /// <summary>
-    /// Transport protocol used for the game stream ("TCP" or "QUIC").
-    /// Defaults to "TCP" so older launchers that don't send this field stay valid.
+    /// Transport protocol used for the game stream (TCP or QUIC).
+    /// Defaults to TCP so older launchers that don't send this field stay valid.
     /// </summary>
     [JsonPropertyName("transport")]
-    [RegularExpression("^(TCP|QUIC)$", ErrorMessage = "Transport must be TCP or QUIC.")]
-    public string Transport { get; set; } = "TCP";
+    [EnumDataType(typeof(Transport), ErrorMessage = "Transport must be TCP or QUIC.")]
+    public Transport Transport { get; set; } = Transport.TCP;
 }
 
 public class DiagnosticsDataDto

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace W3ChampionsStatisticService.LagReports;
@@ -66,6 +67,14 @@ public class ConnectionTopologyDto
 
     [JsonPropertyName("client_ip")]
     public string ClientIp { get; set; }
+
+    /// <summary>
+    /// Transport protocol used for the game stream ("TCP" or "QUIC").
+    /// Defaults to "TCP" so older launchers that don't send this field stay valid.
+    /// </summary>
+    [JsonPropertyName("transport")]
+    [RegularExpression("^(TCP|QUIC)$", ErrorMessage = "Transport must be TCP or QUIC.")]
+    public string Transport { get; set; } = "TCP";
 }
 
 public class DiagnosticsDataDto

--- a/W3ChampionsStatisticService/LagReports/LagReportEnums.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportEnums.cs
@@ -1,4 +1,17 @@
+using System.Text.Json.Serialization;
+
 namespace W3ChampionsStatisticService.LagReports;
+
+/// <summary>
+/// Transport protocol used for the game stream. Serialized as the literal
+/// "TCP" / "QUIC" string on the wire via <see cref="JsonStringEnumConverter"/>.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum Transport
+{
+    TCP,
+    QUIC,
+}
 
 public enum EIssueCategory
 {

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/IPlayerMatchTelemetryRepository.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/IPlayerMatchTelemetryRepository.cs
@@ -1,0 +1,19 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+
+namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
+
+public interface IPlayerMatchTelemetryRepository
+{
+    Task UpsertPlayerEntryAsync(
+        long gameId,
+        DateTime matchWallStart,
+        int bucketMs,
+        PlayerMatchTelemetryEntry entry,
+        TimeSpan ttl);
+
+    Task<PlayerMatchTelemetry?> GetByGameIdAsync(long gameId);
+
+    Task EnsureIndexesAsync();
+}

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/IPlayerMatchTelemetryRepository.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/IPlayerMatchTelemetryRepository.cs
@@ -9,7 +9,6 @@ public interface IPlayerMatchTelemetryRepository
     Task UpsertPlayerEntryAsync(
         long gameId,
         DateTime matchWallStart,
-        int bucketMs,
         PlayerMatchTelemetryEntry entry,
         TimeSpan ttl);
 

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetry.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetry.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using MongoDB.Bson;

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetry.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetry.cs
@@ -4,11 +4,12 @@ using System;
 using System.Collections.Generic;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using W3ChampionsStatisticService.LagReports;
 
 namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
 
-// Spec: docs/superpowers/specs/2026-05-21-flo-action-latency-design.md §4.8.2.
-// _id == GameId. Players merged by BattleTag via upsert.
+// Per-game telemetry document. _id == GameId. Each player's submission is
+// merged into Players[] via an idempotent upsert (one entry per BattleTag).
 [BsonIgnoreExtraElements]
 public class PlayerMatchTelemetry
 {
@@ -16,8 +17,6 @@ public class PlayerMatchTelemetry
     public long GameId { get; set; }
 
     public DateTime MatchWallStart { get; set; }
-
-    public int BucketMs { get; set; }
 
     public List<PlayerMatchTelemetryEntry> Players { get; set; } = new();
 
@@ -31,20 +30,14 @@ public class PlayerMatchTelemetryEntry
 {
     public string BattleTag { get; set; } = string.Empty;
 
-    // Resolved server-side from the matchmaking-service game record. Nullable until joined.
-    public int? FloPlayerId { get; set; }
-
-    public string ConnectionType { get; set; } = string.Empty;   // "TCP" | "QUIC"
-
-    // Resolved server-side from flo-controller. Nullable until joined.
-    public int? ServerNodeId { get; set; }
-    public string? ServerNodeName { get; set; }
+    public Transport ConnectionType { get; set; } = Transport.TCP;
 
     public uint GameLengthMs { get; set; }
 
-    public bool Crashed { get; set; }
+    /// <summary>UTC timestamp when the launcher detected a crash; null when the game ended cleanly.</summary>
+    public DateTime? CrashedAt { get; set; }
 
-    public DisconnectStats Disconnects { get; set; } = new();
+    public List<DisconnectEvent> DisconnectEvents { get; set; } = new();
 
     public ActionLatencyAggregate ActionLatencyAggregate { get; set; } = new();
 
@@ -64,11 +57,14 @@ public class PlayerMatchTelemetryEntry
     public DateTime SubmittedAt { get; set; }
 }
 
-public class DisconnectStats
+/// <summary>
+/// A single disconnect that occurred during the match. The launcher emits one
+/// entry per disconnection with the wall-clock start time and total duration.
+/// </summary>
+public class DisconnectEvent
 {
-    public uint Count { get; set; }
-    public uint TotalDurationMs { get; set; }
-    public uint MeanDurationMs { get; set; }
+    public DateTime StartedAt { get; set; }
+    public uint DurationMs { get; set; }
 }
 
 public class ActionLatencyAggregate

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetry.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetry.cs
@@ -7,6 +7,7 @@ namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
 
 // Spec: docs/superpowers/specs/2026-05-21-flo-action-latency-design.md §4.8.2.
 // _id == GameId. Players merged by BattleTag via upsert.
+[BsonIgnoreExtraElements]
 public class PlayerMatchTelemetry
 {
     [BsonId]

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetry.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetry.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
+
+// Spec: docs/superpowers/specs/2026-05-21-flo-action-latency-design.md §4.8.2.
+// _id == GameId. Players merged by BattleTag via upsert.
+public class PlayerMatchTelemetry
+{
+    [BsonId]
+    public long GameId { get; set; }
+
+    public DateTime MatchWallStart { get; set; }
+
+    public int BucketMs { get; set; }
+
+    public List<PlayerMatchTelemetryEntry> Players { get; set; } = new();
+
+    public DateTime CreatedAt { get; set; }
+
+    // TTL anchor — index expires this document `expireAfterSeconds: 0` after this value.
+    public DateTime ExpiresAt { get; set; }
+}
+
+public class PlayerMatchTelemetryEntry
+{
+    public string BattleTag { get; set; } = string.Empty;
+
+    // Resolved server-side from the matchmaking-service game record. Nullable until joined.
+    public int? FloPlayerId { get; set; }
+
+    public string ConnectionType { get; set; } = string.Empty;   // "TCP" | "QUIC"
+
+    // Resolved server-side from flo-controller. Nullable until joined.
+    public int? ServerNodeId { get; set; }
+    public string? ServerNodeName { get; set; }
+
+    public uint GameLengthMs { get; set; }
+
+    public bool Crashed { get; set; }
+
+    public DisconnectStats Disconnects { get; set; } = new();
+
+    public ActionLatencyAggregate ActionLatencyAggregate { get; set; } = new();
+
+    public int BucketCount { get; set; }
+
+    // BinData subtype 0; uint32 little-endian
+    public BsonBinaryData GameTimeOffsetsMs { get; set; } = new(Array.Empty<byte>());
+
+    // BinData subtype 0; uint16 little-endian
+    public BsonBinaryData MeansMs { get; set; } = new(Array.Empty<byte>());
+
+    // BinData subtype 0; uint8
+    public BsonBinaryData SampleCounts { get; set; } = new(Array.Empty<byte>());
+
+    public uint DroppedUnmatchedCount { get; set; }
+
+    public DateTime SubmittedAt { get; set; }
+}
+
+public class DisconnectStats
+{
+    public uint Count { get; set; }
+    public uint TotalDurationMs { get; set; }
+    public uint MeanDurationMs { get; set; }
+}
+
+public class ActionLatencyAggregate
+{
+    public uint SampleCount { get; set; }
+    public ushort P10Ms { get; set; }
+    public ushort P50Ms { get; set; }
+    public ushort P99Ms { get; set; }
+    public ushort P999Ms { get; set; }
+    public ushort MeanMs { get; set; }
+    public ushort StddevMs { get; set; }
+}

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryController.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryController.cs
@@ -2,12 +2,14 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using MongoDB.Bson;
+using W3C.Contracts.Admin.Permission;
 using W3C.Domain.Tracing;
 using W3ChampionsStatisticService.WebApi.ActionFilters;
 
 namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
 
-// Spec: docs/superpowers/specs/2026-05-21-flo-action-latency-design.md §4.8.
+// Per-player per-match telemetry API: receives PlayerMatchTelemetryReport
+// from launcher-e after each game and exposes an admin GET for inspection.
 [ApiController]
 [Route("api/player-match-telemetry")]
 [Trace]
@@ -37,18 +39,15 @@ public class PlayerMatchTelemetryController(IPlayerMatchTelemetryRepository repo
         var entry = new PlayerMatchTelemetryEntry
         {
             BattleTag = actingPlayer,
-            FloPlayerId = null,
-            ConnectionType = submission.ConnectionType.ToUpperInvariant(),
-            ServerNodeId = null,
-            ServerNodeName = null,
+            ConnectionType = submission.ConnectionType,
             GameLengthMs = submission.GameLengthMs,
-            Crashed = submission.Crashed,
-            Disconnects = new DisconnectStats
-            {
-                Count = submission.Disconnects.Count,
-                TotalDurationMs = submission.Disconnects.TotalDurationMs,
-                MeanDurationMs = submission.Disconnects.MeanDurationMs,
-            },
+            CrashedAt = submission.CrashedAt,
+            DisconnectEvents = (submission.DisconnectEvents ?? new())
+                .ConvertAll(d => new DisconnectEvent
+                {
+                    StartedAt = d.StartedAt,
+                    DurationMs = d.DurationMs,
+                }),
             ActionLatencyAggregate = new ActionLatencyAggregate
             {
                 SampleCount = submission.ActionLatencyAggregate.SampleCount,
@@ -70,20 +69,21 @@ public class PlayerMatchTelemetryController(IPlayerMatchTelemetryRepository repo
         await _repo.UpsertPlayerEntryAsync(
             submission.GameId,
             submission.MatchWallStart,
-            submission.BucketMs,
             entry,
             DefaultTtl);
 
         return Ok();
     }
 
-    /// <summary>Fetch a telemetry document by game id. Returns 404 if not present.</summary>
+    /// <summary>Admin: fetch a telemetry document by game id. Returns 404 if not present.</summary>
     /// <remarks>
     /// The raw domain model contains <see cref="BsonBinaryData"/> fields that System.Text.Json
-    /// cannot serialize (would crash with HTTP 500). We project to a response DTO that emits
-    /// MongoDB Extended JSON v2 BinData envelopes the website's IBinData decoder understands.
+    /// cannot serialize. We project to a response DTO that decodes them into plain
+    /// <c>uint[]</c>/<c>ushort[]</c>/<c>byte[]</c> arrays so the website receives ordinary
+    /// JSON number arrays.
     /// </remarks>
     [HttpGet("by-game/{gameId:long}")]
+    [BearerHasPermissionFilter(Permission = EPermission.Proxies)]
     public async Task<IActionResult> GetByGame(long gameId)
     {
         var doc = await _repo.GetByGameIdAsync(gameId);

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryController.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryController.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using MongoDB.Bson;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.WebApi.ActionFilters;
+
+namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
+
+// Spec: docs/superpowers/specs/2026-05-21-flo-action-latency-design.md §4.8.
+[ApiController]
+[Route("api/player-match-telemetry")]
+[Trace]
+public class PlayerMatchTelemetryController(IPlayerMatchTelemetryRepository repo) : ControllerBase
+{
+    private static readonly TimeSpan DefaultTtl = TimeSpan.FromDays(90);
+
+    private readonly IPlayerMatchTelemetryRepository _repo = repo;
+
+    /// <summary>
+    /// Submit a player's match telemetry — called by the launcher per player after match end.
+    /// Authenticated users only (any player, not admin-only).
+    /// </summary>
+    [HttpPost]
+    [InjectActingPlayerAuthCode]
+    public async Task<IActionResult> Submit(
+        [FromBody] PlayerMatchTelemetrySubmissionDto submission,
+        string actingPlayer)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        var ts = submission.ActionLatencyTimeseries;
+
+        var entry = new PlayerMatchTelemetryEntry
+        {
+            BattleTag = actingPlayer,
+            FloPlayerId = null,
+            ConnectionType = submission.ConnectionType.ToUpperInvariant(),
+            ServerNodeId = null,
+            ServerNodeName = null,
+            GameLengthMs = submission.GameLengthMs,
+            Crashed = submission.Crashed,
+            Disconnects = new DisconnectStats
+            {
+                Count = submission.Disconnects.Count,
+                TotalDurationMs = submission.Disconnects.TotalDurationMs,
+                MeanDurationMs = submission.Disconnects.MeanDurationMs,
+            },
+            ActionLatencyAggregate = new ActionLatencyAggregate
+            {
+                SampleCount = submission.ActionLatencyAggregate.SampleCount,
+                P10Ms = submission.ActionLatencyAggregate.P10Ms,
+                P50Ms = submission.ActionLatencyAggregate.P50Ms,
+                P99Ms = submission.ActionLatencyAggregate.P99Ms,
+                P999Ms = submission.ActionLatencyAggregate.P999Ms,
+                MeanMs = submission.ActionLatencyAggregate.MeanMs,
+                StddevMs = submission.ActionLatencyAggregate.StddevMs,
+            },
+            BucketCount = ts.MeansMs.Length,
+            GameTimeOffsetsMs = new BsonBinaryData(EncodeU32Le(ts.GameTimeOffsetsMs)),
+            MeansMs = new BsonBinaryData(EncodeU16Le(ts.MeansMs)),
+            SampleCounts = new BsonBinaryData(ts.SampleCounts),
+            DroppedUnmatchedCount = submission.DroppedUnmatchedCount,
+            SubmittedAt = DateTime.UtcNow,
+        };
+
+        await _repo.UpsertPlayerEntryAsync(
+            submission.GameId,
+            submission.MatchWallStart,
+            submission.BucketMs,
+            entry,
+            DefaultTtl);
+
+        return Ok();
+    }
+
+    /// <summary>Fetch a telemetry document by game id. Returns 404 if not present.</summary>
+    [HttpGet("by-game/{gameId:long}")]
+    public async Task<IActionResult> GetByGame(long gameId)
+    {
+        var doc = await _repo.GetByGameIdAsync(gameId);
+        if (doc is null) return NotFound();
+        return Ok(doc);
+    }
+
+    private static byte[] EncodeU32Le(uint[] values)
+    {
+        var bytes = new byte[values.Length * 4];
+        Buffer.BlockCopy(values, 0, bytes, 0, bytes.Length);
+        return bytes;
+    }
+
+    private static byte[] EncodeU16Le(ushort[] values)
+    {
+        var bytes = new byte[values.Length * 2];
+        Buffer.BlockCopy(values, 0, bytes, 0, bytes.Length);
+        return bytes;
+    }
+}

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryController.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryController.cs
@@ -78,12 +78,17 @@ public class PlayerMatchTelemetryController(IPlayerMatchTelemetryRepository repo
     }
 
     /// <summary>Fetch a telemetry document by game id. Returns 404 if not present.</summary>
+    /// <remarks>
+    /// The raw domain model contains <see cref="BsonBinaryData"/> fields that System.Text.Json
+    /// cannot serialize (would crash with HTTP 500). We project to a response DTO that emits
+    /// MongoDB Extended JSON v2 BinData envelopes the website's IBinData decoder understands.
+    /// </remarks>
     [HttpGet("by-game/{gameId:long}")]
     public async Task<IActionResult> GetByGame(long gameId)
     {
         var doc = await _repo.GetByGameIdAsync(gameId);
         if (doc is null) return NotFound();
-        return Ok(doc);
+        return Ok(PlayerMatchTelemetryMapper.ToResponseDto(doc));
     }
 
     /// <summary>

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryController.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryController.cs
@@ -86,6 +86,14 @@ public class PlayerMatchTelemetryController(IPlayerMatchTelemetryRepository repo
         return Ok(doc);
     }
 
+    /// <summary>
+    /// Encodes a <see cref="uint"/>[] as little-endian bytes via <see cref="Buffer.BlockCopy"/>.
+    /// </summary>
+    /// <remarks>
+    /// On x86_64 and arm64 Linux (the deployment platforms) this produces little-endian output
+    /// directly. If the service is ever ported to a big-endian host, swap to
+    /// <c>System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian</c> per element.
+    /// </remarks>
     private static byte[] EncodeU32Le(uint[] values)
     {
         var bytes = new byte[values.Length * 4];
@@ -93,6 +101,14 @@ public class PlayerMatchTelemetryController(IPlayerMatchTelemetryRepository repo
         return bytes;
     }
 
+    /// <summary>
+    /// Encodes a <see cref="ushort"/>[] as little-endian bytes via <see cref="Buffer.BlockCopy"/>.
+    /// </summary>
+    /// <remarks>
+    /// On x86_64 and arm64 Linux (the deployment platforms) this produces little-endian output
+    /// directly. If the service is ever ported to a big-endian host, swap to
+    /// <c>System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian</c> per element.
+    /// </remarks>
     private static byte[] EncodeU16Le(ushort[] values)
     {
         var bytes = new byte[values.Length * 2];

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
+
+// Spec: docs/superpowers/specs/2026-05-21-flo-action-latency-design.md §4.8.1.
+public record PlayerMatchTelemetrySubmissionDto(
+    [property: Range(0L, long.MaxValue)] long GameId,
+    [property: Range(100, 10_000)] int BucketMs,
+    DateTime MatchWallStart,
+    [property: Range(typeof(uint), "0", "4294967295")] uint GameLengthMs,
+    bool Crashed,
+    [property: RegularExpression("^(TCP|QUIC|Tcp|Quic)$",
+        ErrorMessage = "ConnectionType must be 'TCP' or 'QUIC'.")]
+    string ConnectionType,
+    [property: Required] DisconnectsDto Disconnects,
+    [property: Required] ActionLatencyAggregateDto ActionLatencyAggregate,
+    [property: Required] ActionLatencyTimeseriesDto ActionLatencyTimeseries,
+    uint DroppedUnmatchedCount
+) : IValidatableObject
+{
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        var ts = ActionLatencyTimeseries;
+        if (ts is null) yield break;
+        if (ts.GameTimeOffsetsMs.Length != ts.MeansMs.Length ||
+            ts.MeansMs.Length != ts.SampleCounts.Length)
+        {
+            yield return new ValidationResult(
+                $"Timeseries parallel arrays must be the same length: " +
+                $"GameTimeOffsetsMs={ts.GameTimeOffsetsMs.Length}, " +
+                $"MeansMs={ts.MeansMs.Length}, " +
+                $"SampleCounts={ts.SampleCounts.Length}",
+                new[] { nameof(ActionLatencyTimeseries) });
+        }
+        if (ts.MeansMs.Length > 28_800)
+        {
+            yield return new ValidationResult(
+                $"Timeseries length {ts.MeansMs.Length} exceeds max 28800 buckets.",
+                new[] { nameof(ActionLatencyTimeseries) });
+        }
+    }
+}
+
+public record DisconnectsDto(uint Count, uint TotalDurationMs, uint MeanDurationMs);
+
+public record ActionLatencyAggregateDto(
+    uint SampleCount,
+    ushort P10Ms,
+    ushort P50Ms,
+    ushort P99Ms,
+    ushort P999Ms,
+    ushort MeanMs,
+    ushort StddevMs
+);
+
+public record ActionLatencyTimeseriesDto(
+    uint[] GameTimeOffsetsMs,
+    ushort[] MeansMs,
+    byte[] SampleCounts
+);

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
@@ -1,42 +1,30 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using MongoDB.Bson;
+using W3ChampionsStatisticService.LagReports;
 
 namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
 
-// Spec: docs/superpowers/specs/2026-05-21-flo-action-latency-design.md §4.8.1.
-//
-// Launcher-e serializes via Rust serde with snake_case field names, so every
-// property needs an explicit [JsonPropertyName] to bind correctly under
-// ASP.NET Core's System.Text.Json defaults (which only case-fold PascalCase
-// ↔ camelCase, never snake_case). Mirrors the convention used by
-// LagReports/LagReportDtos.cs.
+// Submission DTO for POST /api/player-match-telemetry. Mirrors the wire
+// shape emitted by launcher-e: camelCase property names, "TCP" / "QUIC"
+// transport literals, ISO-8601 timestamps. ASP.NET Core's [FromBody]
+// binding uses JsonSerializerDefaults.Web (PropertyNamingPolicy =
+// CamelCase, PropertyNameCaseInsensitive = true), so PascalCase C#
+// properties map automatically without [JsonPropertyName] attributes.
 public record PlayerMatchTelemetrySubmissionDto(
-    [property: JsonPropertyName("game_id")]
     [property: Range(1L, long.MaxValue)] long GameId,
-    [property: JsonPropertyName("bucket_ms")]
-    [property: Range(100, 10_000)] int BucketMs,
-    [property: JsonPropertyName("match_wall_start")]
     DateTime MatchWallStart,
-    [property: JsonPropertyName("game_length_ms")]
-    uint GameLengthMs,
-    [property: JsonPropertyName("crashed")]
-    bool Crashed,
-    [property: JsonPropertyName("connection_type")]
-    [property: RegularExpression("^(TCP|QUIC)$",
-        ErrorMessage = "ConnectionType must be 'TCP' or 'QUIC'.")]
-    string ConnectionType,
-    [property: JsonPropertyName("disconnects")]
-    [property: Required] DisconnectsDto Disconnects,
-    [property: JsonPropertyName("action_latency_aggregate")]
+    [property: Range(0u, uint.MaxValue)] uint GameLengthMs,
+    DateTime? CrashedAt,
+    [property: Required, EnumDataType(typeof(Transport))] Transport ConnectionType,
+    [property: Required] List<DisconnectEventDto> DisconnectEvents,
     [property: Required] ActionLatencyAggregateDto ActionLatencyAggregate,
-    [property: JsonPropertyName("action_latency_timeseries")]
     [property: Required] ActionLatencyTimeseriesDto ActionLatencyTimeseries,
-    [property: JsonPropertyName("dropped_unmatched_count")]
     uint DroppedUnmatchedCount
 ) : IValidatableObject
 {
@@ -50,10 +38,10 @@ public record PlayerMatchTelemetrySubmissionDto(
             ts.MeansMs.Length != ts.SampleCounts.Length)
         {
             yield return new ValidationResult(
-                $"Timeseries parallel arrays must be the same length: " +
-                $"GameTimeOffsetsMs={ts.GameTimeOffsetsMs.Length}, " +
-                $"MeansMs={ts.MeansMs.Length}, " +
-                $"SampleCounts={ts.SampleCounts.Length}",
+                $"Timeseries parallel arrays must have the same length: " +
+                $"gameTimeOffsetsMs={ts.GameTimeOffsetsMs.Length}, " +
+                $"meansMs={ts.MeansMs.Length}, " +
+                $"sampleCounts={ts.SampleCounts.Length}",
                 new[] { nameof(ActionLatencyTimeseries) });
         }
         if (ts.MeansMs.Length > MaxTimeseriesBuckets)
@@ -65,25 +53,21 @@ public record PlayerMatchTelemetrySubmissionDto(
     }
 }
 
-public record DisconnectsDto(
-    [property: JsonPropertyName("count")] uint Count,
-    [property: JsonPropertyName("total_duration_ms")] uint TotalDurationMs,
-    [property: JsonPropertyName("mean_duration_ms")] uint MeanDurationMs);
+public record DisconnectEventDto(DateTime StartedAt, uint DurationMs);
 
 public record ActionLatencyAggregateDto(
-    [property: JsonPropertyName("sample_count")] uint SampleCount,
-    [property: JsonPropertyName("p10_ms")] ushort P10Ms,
-    [property: JsonPropertyName("p50_ms")] ushort P50Ms,
-    [property: JsonPropertyName("p99_ms")] ushort P99Ms,
-    [property: JsonPropertyName("p999_ms")] ushort P999Ms,
-    [property: JsonPropertyName("mean_ms")] ushort MeanMs,
-    [property: JsonPropertyName("stddev_ms")] ushort StddevMs
+    uint SampleCount,
+    ushort P10Ms,
+    ushort P50Ms,
+    ushort P99Ms,
+    ushort P999Ms,
+    ushort MeanMs,
+    ushort StddevMs
 );
 
 public record ActionLatencyTimeseriesDto(
-    [property: JsonPropertyName("game_time_offsets_ms")] uint[] GameTimeOffsetsMs,
-    [property: JsonPropertyName("means_ms")] ushort[] MeansMs,
-    [property: JsonPropertyName("sample_counts")]
+    uint[] GameTimeOffsetsMs,
+    ushort[] MeansMs,
     [property: JsonConverter(typeof(ByteArrayAsJsonNumberArrayConverter))]
     byte[] SampleCounts
 );
@@ -102,7 +86,7 @@ public sealed class ByteArrayAsJsonNumberArrayConverter : JsonConverter<byte[]>
         if (reader.TokenType != JsonTokenType.StartArray)
         {
             throw new JsonException(
-                $"Expected start of array for byte[] (sample_counts), got {reader.TokenType}.");
+                $"Expected start of array for byte[] (sampleCounts), got {reader.TokenType}.");
         }
         var buffer = new List<byte>(capacity: 256);
         while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
@@ -110,7 +94,7 @@ public sealed class ByteArrayAsJsonNumberArrayConverter : JsonConverter<byte[]>
             if (reader.TokenType != JsonTokenType.Number)
             {
                 throw new JsonException(
-                    $"Expected number element in byte[] (sample_counts), got {reader.TokenType}.");
+                    $"Expected number element in byte[] (sampleCounts), got {reader.TokenType}.");
             }
             buffer.Add(reader.GetByte()); // Throws OverflowException-derived JsonException if out of 0..255.
         }
@@ -130,70 +114,30 @@ public sealed class ByteArrayAsJsonNumberArrayConverter : JsonConverter<byte[]>
 
 // ─────────────────────────────────────────────────────────
 // Response DTOs for GET /api/player-match-telemetry/by-game/{gameId}
-// Projection of the domain model with BsonBinaryData fields
-// exposed as MongoDB Extended JSON v2 envelope shapes
-// ({ "$binary": { "base64": "...", "subType": "00" } }) so the
-// website's IBinData decoder can parse them. Returning the raw
-// domain model crashes System.Text.Json because BsonBinaryData has
-// no serializer registered — that bug is what this DTO layer fixes.
+// Projection of the domain model. BsonBinaryData fields are decoded
+// server-side into plain uint[] / ushort[] / byte[] so the frontend
+// receives ordinary JSON number arrays with no MongoDB Extended JSON
+// envelopes to unwrap.
 //
-// Wire shape convention: response DTOs emit camelCase to match the
-// website's TypeScript IPlayerMatchTelemetry types (battleTag,
-// gameId, sampleCounts, etc.). ASP.NET Core's default
+// Wire shape: camelCase property names (matches website's TypeScript
+// IPlayerMatchTelemetry types). ASP.NET Core's default
 // JsonSerializerOptions.PropertyNamingPolicy = CamelCase auto-converts
-// PascalCase C# names — no [JsonPropertyName] needed on these records.
-//
-// Exception: BinDataEnvelopeDto/BinDataPayloadDto keep explicit
-// [JsonPropertyName] attrs because their wire keys ($binary, base64,
-// subType) are literal MongoDB Extended JSON v2 strings, not
-// naming-policy-derived.
+// PascalCase C# names — no [JsonPropertyName] attrs needed.
 // ─────────────────────────────────────────────────────────
-
-public record BinDataEnvelopeDto(
-    [property: JsonPropertyName("$binary")] BinDataPayloadDto Binary
-);
-
-public record BinDataPayloadDto(
-    [property: JsonPropertyName("base64")] string Base64,
-    [property: JsonPropertyName("subType")] string SubType
-);
-
-// Response-side aggregates. Distinct from the submission-side
-// DisconnectsDto/ActionLatencyAggregateDto so the GET response can emit
-// camelCase keys (e.g. totalDurationMs) without the snake_case
-// [JsonPropertyName] attrs that the submission DTOs need for Rust serde
-// compatibility on the POST side.
-public record DisconnectsResponseDto(
-    uint Count,
-    uint TotalDurationMs,
-    uint MeanDurationMs
-);
-
-public record ActionLatencyAggregateResponseDto(
-    uint SampleCount,
-    ushort P10Ms,
-    ushort P50Ms,
-    ushort P99Ms,
-    ushort P999Ms,
-    ushort MeanMs,
-    ushort StddevMs
-);
 
 #nullable enable
 public record PlayerMatchTelemetryEntryResponseDto(
     string BattleTag,
-    int? FloPlayerId,
-    string ConnectionType,
-    int? ServerNodeId,
-    string? ServerNodeName,
+    Transport ConnectionType,
     uint GameLengthMs,
-    bool Crashed,
-    DisconnectsResponseDto Disconnects,
-    ActionLatencyAggregateResponseDto ActionLatencyAggregate,
+    DateTime? CrashedAt,
+    List<DisconnectEvent> DisconnectEvents,
+    ActionLatencyAggregate ActionLatencyAggregate,
     int BucketCount,
-    BinDataEnvelopeDto GameTimeOffsetsMs,
-    BinDataEnvelopeDto MeansMs,
-    BinDataEnvelopeDto SampleCounts,
+    uint[] GameTimeOffsetsMs,
+    ushort[] MeansMs,
+    [property: JsonConverter(typeof(ByteArrayAsJsonNumberArrayConverter))]
+    byte[] SampleCounts,
     uint DroppedUnmatchedCount,
     DateTime SubmittedAt
 );
@@ -201,7 +145,6 @@ public record PlayerMatchTelemetryEntryResponseDto(
 public record PlayerMatchTelemetryResponseDto(
     long GameId,
     DateTime MatchWallStart,
-    int BucketMs,
     List<PlayerMatchTelemetryEntryResponseDto> Players,
     DateTime CreatedAt,
     DateTime ExpiresAt
@@ -214,7 +157,6 @@ public static class PlayerMatchTelemetryMapper
         return new PlayerMatchTelemetryResponseDto(
             GameId: doc.GameId,
             MatchWallStart: doc.MatchWallStart,
-            BucketMs: doc.BucketMs,
             Players: doc.Players.Select(ToEntryResponseDto).ToList(),
             CreatedAt: doc.CreatedAt,
             ExpiresAt: doc.ExpiresAt
@@ -225,43 +167,63 @@ public static class PlayerMatchTelemetryMapper
     {
         return new PlayerMatchTelemetryEntryResponseDto(
             BattleTag: e.BattleTag,
-            FloPlayerId: e.FloPlayerId,
             ConnectionType: e.ConnectionType,
-            ServerNodeId: e.ServerNodeId,
-            ServerNodeName: e.ServerNodeName,
             GameLengthMs: e.GameLengthMs,
-            Crashed: e.Crashed,
-            Disconnects: new DisconnectsResponseDto(
-                e.Disconnects.Count,
-                e.Disconnects.TotalDurationMs,
-                e.Disconnects.MeanDurationMs),
-            ActionLatencyAggregate: new ActionLatencyAggregateResponseDto(
-                e.ActionLatencyAggregate.SampleCount,
-                e.ActionLatencyAggregate.P10Ms,
-                e.ActionLatencyAggregate.P50Ms,
-                e.ActionLatencyAggregate.P99Ms,
-                e.ActionLatencyAggregate.P999Ms,
-                e.ActionLatencyAggregate.MeanMs,
-                e.ActionLatencyAggregate.StddevMs
-            ),
+            CrashedAt: e.CrashedAt,
+            DisconnectEvents: e.DisconnectEvents,
+            ActionLatencyAggregate: e.ActionLatencyAggregate,
             BucketCount: e.BucketCount,
-            GameTimeOffsetsMs: ToEnvelope(e.GameTimeOffsetsMs),
-            MeansMs: ToEnvelope(e.MeansMs),
-            SampleCounts: ToEnvelope(e.SampleCounts),
+            GameTimeOffsetsMs: DecodeU32Le(e.GameTimeOffsetsMs),
+            MeansMs: DecodeU16Le(e.MeansMs),
+            SampleCounts: DecodeU8(e.SampleCounts),
             DroppedUnmatchedCount: e.DroppedUnmatchedCount,
             SubmittedAt: e.SubmittedAt
         );
     }
 
-    // Encodes a BsonBinaryData as a MongoDB Extended JSON v2 envelope:
-    //   { "$binary": { "base64": "...", "subType": "00" } }
-    // The website's IBinData decoder reads $binary.base64 (ignores subType),
-    // but we emit subType anyway to stay spec-compliant.
-    private static BinDataEnvelopeDto ToEnvelope(BsonBinaryData bin)
+    /// <summary>
+    /// Decodes a <see cref="BsonBinaryData"/> blob of little-endian uint32 values
+    /// into a <c>uint[]</c>. Portable across host endianness — does not rely on
+    /// <see cref="Buffer.BlockCopy"/>.
+    /// </summary>
+    private static uint[] DecodeU32Le(BsonBinaryData? bin)
     {
-        var base64 = Convert.ToBase64String(bin?.Bytes ?? Array.Empty<byte>());
-        var subType = ((byte)(bin?.SubType ?? BsonBinarySubType.Binary)).ToString("X2");
-        return new BinDataEnvelopeDto(new BinDataPayloadDto(base64, subType));
+        var bytes = bin?.Bytes ?? Array.Empty<byte>();
+        if (bytes.Length % 4 != 0)
+        {
+            throw new InvalidDataException(
+                $"DecodeU32Le: byte length {bytes.Length} is not divisible by 4");
+        }
+        var span = bytes.AsSpan();
+        var result = new uint[bytes.Length / 4];
+        for (int i = 0; i < result.Length; i++)
+        {
+            result[i] = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(i * 4, 4));
+        }
+        return result;
     }
+
+    /// <summary>
+    /// Decodes a <see cref="BsonBinaryData"/> blob of little-endian uint16 values
+    /// into a <c>ushort[]</c>. Portable across host endianness.
+    /// </summary>
+    private static ushort[] DecodeU16Le(BsonBinaryData? bin)
+    {
+        var bytes = bin?.Bytes ?? Array.Empty<byte>();
+        if (bytes.Length % 2 != 0)
+        {
+            throw new InvalidDataException(
+                $"DecodeU16Le: byte length {bytes.Length} is not divisible by 2");
+        }
+        var span = bytes.AsSpan();
+        var result = new ushort[bytes.Length / 2];
+        for (int i = 0; i < result.Length; i++)
+        {
+            result[i] = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(i * 2, 2));
+        }
+        return result;
+    }
+
+    private static byte[] DecodeU8(BsonBinaryData? bin) => bin?.Bytes ?? Array.Empty<byte>();
 }
 #nullable disable

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
@@ -6,12 +6,12 @@ namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
 
 // Spec: docs/superpowers/specs/2026-05-21-flo-action-latency-design.md §4.8.1.
 public record PlayerMatchTelemetrySubmissionDto(
-    [property: Range(0L, long.MaxValue)] long GameId,
+    [property: Range(1L, long.MaxValue)] long GameId,
     [property: Range(100, 10_000)] int BucketMs,
     DateTime MatchWallStart,
-    [property: Range(typeof(uint), "0", "4294967295")] uint GameLengthMs,
+    uint GameLengthMs,
     bool Crashed,
-    [property: RegularExpression("^(TCP|QUIC|Tcp|Quic)$",
+    [property: RegularExpression("^(TCP|QUIC)$",
         ErrorMessage = "ConnectionType must be 'TCP' or 'QUIC'.")]
     string ConnectionType,
     [property: Required] DisconnectsDto Disconnects,
@@ -20,6 +20,8 @@ public record PlayerMatchTelemetrySubmissionDto(
     uint DroppedUnmatchedCount
 ) : IValidatableObject
 {
+    private const int MaxTimeseriesBuckets = 28_800;
+
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         var ts = ActionLatencyTimeseries;
@@ -34,10 +36,10 @@ public record PlayerMatchTelemetrySubmissionDto(
                 $"SampleCounts={ts.SampleCounts.Length}",
                 new[] { nameof(ActionLatencyTimeseries) });
         }
-        if (ts.MeansMs.Length > 28_800)
+        if (ts.MeansMs.Length > MaxTimeseriesBuckets)
         {
             yield return new ValidationResult(
-                $"Timeseries length {ts.MeansMs.Length} exceeds max 28800 buckets.",
+                $"Timeseries length {ts.MeansMs.Length} exceeds max {MaxTimeseriesBuckets} buckets.",
                 new[] { nameof(ActionLatencyTimeseries) });
         }
     }

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
@@ -136,6 +136,17 @@ public sealed class ByteArrayAsJsonNumberArrayConverter : JsonConverter<byte[]>
 // website's IBinData decoder can parse them. Returning the raw
 // domain model crashes System.Text.Json because BsonBinaryData has
 // no serializer registered — that bug is what this DTO layer fixes.
+//
+// Wire shape convention: response DTOs emit camelCase to match the
+// website's TypeScript IPlayerMatchTelemetry types (battleTag,
+// gameId, sampleCounts, etc.). ASP.NET Core's default
+// JsonSerializerOptions.PropertyNamingPolicy = CamelCase auto-converts
+// PascalCase C# names — no [JsonPropertyName] needed on these records.
+//
+// Exception: BinDataEnvelopeDto/BinDataPayloadDto keep explicit
+// [JsonPropertyName] attrs because their wire keys ($binary, base64,
+// subType) are literal MongoDB Extended JSON v2 strings, not
+// naming-policy-derived.
 // ─────────────────────────────────────────────────────────
 
 public record BinDataEnvelopeDto(
@@ -147,32 +158,53 @@ public record BinDataPayloadDto(
     [property: JsonPropertyName("subType")] string SubType
 );
 
+// Response-side aggregates. Distinct from the submission-side
+// DisconnectsDto/ActionLatencyAggregateDto so the GET response can emit
+// camelCase keys (e.g. totalDurationMs) without the snake_case
+// [JsonPropertyName] attrs that the submission DTOs need for Rust serde
+// compatibility on the POST side.
+public record DisconnectsResponseDto(
+    uint Count,
+    uint TotalDurationMs,
+    uint MeanDurationMs
+);
+
+public record ActionLatencyAggregateResponseDto(
+    uint SampleCount,
+    ushort P10Ms,
+    ushort P50Ms,
+    ushort P99Ms,
+    ushort P999Ms,
+    ushort MeanMs,
+    ushort StddevMs
+);
+
 #nullable enable
 public record PlayerMatchTelemetryEntryResponseDto(
-    [property: JsonPropertyName("battle_tag")] string BattleTag,
-    [property: JsonPropertyName("flo_player_id")] int? FloPlayerId,
-    [property: JsonPropertyName("connection_type")] string ConnectionType,
-    [property: JsonPropertyName("server_node_id")] int? ServerNodeId,
-    [property: JsonPropertyName("server_node_name")] string? ServerNodeName,
-    [property: JsonPropertyName("game_length_ms")] uint GameLengthMs,
-    [property: JsonPropertyName("crashed")] bool Crashed,
-    [property: JsonPropertyName("disconnects")] DisconnectsDto Disconnects,
-    [property: JsonPropertyName("action_latency_aggregate")] ActionLatencyAggregateDto ActionLatencyAggregate,
-    [property: JsonPropertyName("bucket_count")] int BucketCount,
-    [property: JsonPropertyName("game_time_offsets_ms")] BinDataEnvelopeDto GameTimeOffsetsMs,
-    [property: JsonPropertyName("means_ms")] BinDataEnvelopeDto MeansMs,
-    [property: JsonPropertyName("sample_counts")] BinDataEnvelopeDto SampleCounts,
-    [property: JsonPropertyName("dropped_unmatched_count")] uint DroppedUnmatchedCount,
-    [property: JsonPropertyName("submitted_at")] DateTime SubmittedAt
+    string BattleTag,
+    int? FloPlayerId,
+    string ConnectionType,
+    int? ServerNodeId,
+    string? ServerNodeName,
+    uint GameLengthMs,
+    bool Crashed,
+    DisconnectsResponseDto Disconnects,
+    ActionLatencyAggregateResponseDto ActionLatencyAggregate,
+    int BucketCount,
+    BinDataEnvelopeDto GameTimeOffsetsMs,
+    BinDataEnvelopeDto MeansMs,
+    BinDataEnvelopeDto SampleCounts,
+    uint DroppedUnmatchedCount,
+    DateTime SubmittedAt
 );
 
 public record PlayerMatchTelemetryResponseDto(
-    [property: JsonPropertyName("game_id")] long GameId,
-    [property: JsonPropertyName("match_wall_start")] DateTime MatchWallStart,
-    [property: JsonPropertyName("bucket_ms")] int BucketMs,
-    [property: JsonPropertyName("players")] List<PlayerMatchTelemetryEntryResponseDto> Players,
-    [property: JsonPropertyName("created_at")] DateTime CreatedAt,
-    [property: JsonPropertyName("expires_at")] DateTime ExpiresAt
+    long GameId,
+    DateTime MatchWallStart,
+    int BucketMs,
+    List<PlayerMatchTelemetryEntryResponseDto> Players,
+    DateTime CreatedAt,
+    DateTime ExpiresAt
 );
 
 public static class PlayerMatchTelemetryMapper
@@ -199,8 +231,11 @@ public static class PlayerMatchTelemetryMapper
             ServerNodeName: e.ServerNodeName,
             GameLengthMs: e.GameLengthMs,
             Crashed: e.Crashed,
-            Disconnects: new DisconnectsDto(e.Disconnects.Count, e.Disconnects.TotalDurationMs, e.Disconnects.MeanDurationMs),
-            ActionLatencyAggregate: new ActionLatencyAggregateDto(
+            Disconnects: new DisconnectsResponseDto(
+                e.Disconnects.Count,
+                e.Disconnects.TotalDurationMs,
+                e.Disconnects.MeanDurationMs),
+            ActionLatencyAggregate: new ActionLatencyAggregateResponseDto(
                 e.ActionLatencyAggregate.SampleCount,
                 e.ActionLatencyAggregate.P10Ms,
                 e.ActionLatencyAggregate.P50Ms,

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using MongoDB.Bson;
 
 namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
 
@@ -125,3 +127,106 @@ public sealed class ByteArrayAsJsonNumberArrayConverter : JsonConverter<byte[]>
         writer.WriteEndArray();
     }
 }
+
+// ─────────────────────────────────────────────────────────
+// Response DTOs for GET /api/player-match-telemetry/by-game/{gameId}
+// Projection of the domain model with BsonBinaryData fields
+// exposed as MongoDB Extended JSON v2 envelope shapes
+// ({ "$binary": { "base64": "...", "subType": "00" } }) so the
+// website's IBinData decoder can parse them. Returning the raw
+// domain model crashes System.Text.Json because BsonBinaryData has
+// no serializer registered — that bug is what this DTO layer fixes.
+// ─────────────────────────────────────────────────────────
+
+public record BinDataEnvelopeDto(
+    [property: JsonPropertyName("$binary")] BinDataPayloadDto Binary
+);
+
+public record BinDataPayloadDto(
+    [property: JsonPropertyName("base64")] string Base64,
+    [property: JsonPropertyName("subType")] string SubType
+);
+
+#nullable enable
+public record PlayerMatchTelemetryEntryResponseDto(
+    [property: JsonPropertyName("battle_tag")] string BattleTag,
+    [property: JsonPropertyName("flo_player_id")] int? FloPlayerId,
+    [property: JsonPropertyName("connection_type")] string ConnectionType,
+    [property: JsonPropertyName("server_node_id")] int? ServerNodeId,
+    [property: JsonPropertyName("server_node_name")] string? ServerNodeName,
+    [property: JsonPropertyName("game_length_ms")] uint GameLengthMs,
+    [property: JsonPropertyName("crashed")] bool Crashed,
+    [property: JsonPropertyName("disconnects")] DisconnectsDto Disconnects,
+    [property: JsonPropertyName("action_latency_aggregate")] ActionLatencyAggregateDto ActionLatencyAggregate,
+    [property: JsonPropertyName("bucket_count")] int BucketCount,
+    [property: JsonPropertyName("game_time_offsets_ms")] BinDataEnvelopeDto GameTimeOffsetsMs,
+    [property: JsonPropertyName("means_ms")] BinDataEnvelopeDto MeansMs,
+    [property: JsonPropertyName("sample_counts")] BinDataEnvelopeDto SampleCounts,
+    [property: JsonPropertyName("dropped_unmatched_count")] uint DroppedUnmatchedCount,
+    [property: JsonPropertyName("submitted_at")] DateTime SubmittedAt
+);
+
+public record PlayerMatchTelemetryResponseDto(
+    [property: JsonPropertyName("game_id")] long GameId,
+    [property: JsonPropertyName("match_wall_start")] DateTime MatchWallStart,
+    [property: JsonPropertyName("bucket_ms")] int BucketMs,
+    [property: JsonPropertyName("players")] List<PlayerMatchTelemetryEntryResponseDto> Players,
+    [property: JsonPropertyName("created_at")] DateTime CreatedAt,
+    [property: JsonPropertyName("expires_at")] DateTime ExpiresAt
+);
+
+public static class PlayerMatchTelemetryMapper
+{
+    public static PlayerMatchTelemetryResponseDto ToResponseDto(PlayerMatchTelemetry doc)
+    {
+        return new PlayerMatchTelemetryResponseDto(
+            GameId: doc.GameId,
+            MatchWallStart: doc.MatchWallStart,
+            BucketMs: doc.BucketMs,
+            Players: doc.Players.Select(ToEntryResponseDto).ToList(),
+            CreatedAt: doc.CreatedAt,
+            ExpiresAt: doc.ExpiresAt
+        );
+    }
+
+    private static PlayerMatchTelemetryEntryResponseDto ToEntryResponseDto(PlayerMatchTelemetryEntry e)
+    {
+        return new PlayerMatchTelemetryEntryResponseDto(
+            BattleTag: e.BattleTag,
+            FloPlayerId: e.FloPlayerId,
+            ConnectionType: e.ConnectionType,
+            ServerNodeId: e.ServerNodeId,
+            ServerNodeName: e.ServerNodeName,
+            GameLengthMs: e.GameLengthMs,
+            Crashed: e.Crashed,
+            Disconnects: new DisconnectsDto(e.Disconnects.Count, e.Disconnects.TotalDurationMs, e.Disconnects.MeanDurationMs),
+            ActionLatencyAggregate: new ActionLatencyAggregateDto(
+                e.ActionLatencyAggregate.SampleCount,
+                e.ActionLatencyAggregate.P10Ms,
+                e.ActionLatencyAggregate.P50Ms,
+                e.ActionLatencyAggregate.P99Ms,
+                e.ActionLatencyAggregate.P999Ms,
+                e.ActionLatencyAggregate.MeanMs,
+                e.ActionLatencyAggregate.StddevMs
+            ),
+            BucketCount: e.BucketCount,
+            GameTimeOffsetsMs: ToEnvelope(e.GameTimeOffsetsMs),
+            MeansMs: ToEnvelope(e.MeansMs),
+            SampleCounts: ToEnvelope(e.SampleCounts),
+            DroppedUnmatchedCount: e.DroppedUnmatchedCount,
+            SubmittedAt: e.SubmittedAt
+        );
+    }
+
+    // Encodes a BsonBinaryData as a MongoDB Extended JSON v2 envelope:
+    //   { "$binary": { "base64": "...", "subType": "00" } }
+    // The website's IBinData decoder reads $binary.base64 (ignores subType),
+    // but we emit subType anyway to stay spec-compliant.
+    private static BinDataEnvelopeDto ToEnvelope(BsonBinaryData bin)
+    {
+        var base64 = Convert.ToBase64String(bin?.Bytes ?? Array.Empty<byte>());
+        var subType = ((byte)(bin?.SubType ?? BsonBinarySubType.Binary)).ToString("X2");
+        return new BinDataEnvelopeDto(new BinDataPayloadDto(base64, subType));
+    }
+}
+#nullable disable

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
@@ -1,22 +1,40 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
 
 // Spec: docs/superpowers/specs/2026-05-21-flo-action-latency-design.md §4.8.1.
+//
+// Launcher-e serializes via Rust serde with snake_case field names, so every
+// property needs an explicit [JsonPropertyName] to bind correctly under
+// ASP.NET Core's System.Text.Json defaults (which only case-fold PascalCase
+// ↔ camelCase, never snake_case). Mirrors the convention used by
+// LagReports/LagReportDtos.cs.
 public record PlayerMatchTelemetrySubmissionDto(
+    [property: JsonPropertyName("game_id")]
     [property: Range(1L, long.MaxValue)] long GameId,
+    [property: JsonPropertyName("bucket_ms")]
     [property: Range(100, 10_000)] int BucketMs,
+    [property: JsonPropertyName("match_wall_start")]
     DateTime MatchWallStart,
+    [property: JsonPropertyName("game_length_ms")]
     uint GameLengthMs,
+    [property: JsonPropertyName("crashed")]
     bool Crashed,
+    [property: JsonPropertyName("connection_type")]
     [property: RegularExpression("^(TCP|QUIC)$",
         ErrorMessage = "ConnectionType must be 'TCP' or 'QUIC'.")]
     string ConnectionType,
+    [property: JsonPropertyName("disconnects")]
     [property: Required] DisconnectsDto Disconnects,
+    [property: JsonPropertyName("action_latency_aggregate")]
     [property: Required] ActionLatencyAggregateDto ActionLatencyAggregate,
+    [property: JsonPropertyName("action_latency_timeseries")]
     [property: Required] ActionLatencyTimeseriesDto ActionLatencyTimeseries,
+    [property: JsonPropertyName("dropped_unmatched_count")]
     uint DroppedUnmatchedCount
 ) : IValidatableObject
 {
@@ -45,20 +63,65 @@ public record PlayerMatchTelemetrySubmissionDto(
     }
 }
 
-public record DisconnectsDto(uint Count, uint TotalDurationMs, uint MeanDurationMs);
+public record DisconnectsDto(
+    [property: JsonPropertyName("count")] uint Count,
+    [property: JsonPropertyName("total_duration_ms")] uint TotalDurationMs,
+    [property: JsonPropertyName("mean_duration_ms")] uint MeanDurationMs);
 
 public record ActionLatencyAggregateDto(
-    uint SampleCount,
-    ushort P10Ms,
-    ushort P50Ms,
-    ushort P99Ms,
-    ushort P999Ms,
-    ushort MeanMs,
-    ushort StddevMs
+    [property: JsonPropertyName("sample_count")] uint SampleCount,
+    [property: JsonPropertyName("p10_ms")] ushort P10Ms,
+    [property: JsonPropertyName("p50_ms")] ushort P50Ms,
+    [property: JsonPropertyName("p99_ms")] ushort P99Ms,
+    [property: JsonPropertyName("p999_ms")] ushort P999Ms,
+    [property: JsonPropertyName("mean_ms")] ushort MeanMs,
+    [property: JsonPropertyName("stddev_ms")] ushort StddevMs
 );
 
 public record ActionLatencyTimeseriesDto(
-    uint[] GameTimeOffsetsMs,
-    ushort[] MeansMs,
+    [property: JsonPropertyName("game_time_offsets_ms")] uint[] GameTimeOffsetsMs,
+    [property: JsonPropertyName("means_ms")] ushort[] MeansMs,
+    [property: JsonPropertyName("sample_counts")]
+    [property: JsonConverter(typeof(ByteArrayAsJsonNumberArrayConverter))]
     byte[] SampleCounts
 );
+
+/// <summary>
+/// Reads/writes a <c>byte[]</c> as a JSON array of unsigned integers (e.g.
+/// <c>[5, 7, 6]</c>) instead of System.Text.Json's default base64 string
+/// encoding. Launcher-e's Rust serde serializes <c>Vec&lt;u8&gt;</c> as a
+/// number array on the wire, so this converter is required for
+/// <see cref="ActionLatencyTimeseriesDto.SampleCounts"/> binding.
+/// </summary>
+public sealed class ByteArrayAsJsonNumberArrayConverter : JsonConverter<byte[]>
+{
+    public override byte[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartArray)
+        {
+            throw new JsonException(
+                $"Expected start of array for byte[] (sample_counts), got {reader.TokenType}.");
+        }
+        var buffer = new List<byte>(capacity: 256);
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+        {
+            if (reader.TokenType != JsonTokenType.Number)
+            {
+                throw new JsonException(
+                    $"Expected number element in byte[] (sample_counts), got {reader.TokenType}.");
+            }
+            buffer.Add(reader.GetByte()); // Throws OverflowException-derived JsonException if out of 0..255.
+        }
+        return buffer.ToArray();
+    }
+
+    public override void Write(Utf8JsonWriter writer, byte[] value, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray();
+        foreach (var b in value)
+        {
+            writer.WriteNumberValue(b);
+        }
+        writer.WriteEndArray();
+    }
+}

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryDtos.cs
@@ -16,19 +16,33 @@ namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
 // binding uses JsonSerializerDefaults.Web (PropertyNamingPolicy =
 // CamelCase, PropertyNameCaseInsensitive = true), so PascalCase C#
 // properties map automatically without [JsonPropertyName] attributes.
-public record PlayerMatchTelemetrySubmissionDto(
-    [property: Range(1L, long.MaxValue)] long GameId,
-    DateTime MatchWallStart,
-    [property: Range(0u, uint.MaxValue)] uint GameLengthMs,
-    DateTime? CrashedAt,
-    [property: Required, EnumDataType(typeof(Transport))] Transport ConnectionType,
-    [property: Required] List<DisconnectEventDto> DisconnectEvents,
-    [property: Required] ActionLatencyAggregateDto ActionLatencyAggregate,
-    [property: Required] ActionLatencyTimeseriesDto ActionLatencyTimeseries,
-    uint DroppedUnmatchedCount
-) : IValidatableObject
+public record PlayerMatchTelemetrySubmissionDto : IValidatableObject
 {
     private const int MaxTimeseriesBuckets = 28_800;
+
+    [Range(1L, long.MaxValue)]
+    public long GameId { get; init; }
+
+    public DateTime MatchWallStart { get; init; }
+
+    public uint GameLengthMs { get; init; }
+
+    public DateTime? CrashedAt { get; init; }
+
+    [EnumDataType(typeof(Transport))]
+    public Transport ConnectionType { get; init; }
+
+    [Required]
+    public List<DisconnectEventDto> DisconnectEvents { get; init; } = new();
+
+    [Required]
+    public ActionLatencyAggregateDto ActionLatencyAggregate { get; init; } = new(0, 0, 0, 0, 0, 0, 0);
+
+    [Required]
+    public ActionLatencyTimeseriesDto ActionLatencyTimeseries { get; init; } =
+        new(Array.Empty<uint>(), Array.Empty<ushort>(), Array.Empty<byte>());
+
+    public uint DroppedUnmatchedCount { get; init; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryRepository.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryRepository.cs
@@ -1,0 +1,80 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
+
+namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
+
+// Spec: docs/superpowers/specs/2026-05-21-flo-action-latency-design.md §4.8.2 + §4.8.4.
+// _id == GameId. Per-player entries merged into Players[] via idempotent upsert.
+[Trace]
+public class PlayerMatchTelemetryRepository(MongoClient mongoClient)
+    : MongoDbRepositoryBase(mongoClient), IPlayerMatchTelemetryRepository, IRequiresIndexes
+{
+    public string CollectionName => nameof(PlayerMatchTelemetry);
+
+    private IMongoCollection<PlayerMatchTelemetry> Collection
+        => CreateCollection<PlayerMatchTelemetry>();
+
+    public async Task UpsertPlayerEntryAsync(
+        long gameId,
+        DateTime matchWallStart,
+        int bucketMs,
+        PlayerMatchTelemetryEntry entry,
+        TimeSpan ttl)
+    {
+        var now = DateTime.UtcNow;
+        var filter = Builders<PlayerMatchTelemetry>.Filter.Eq(x => x.GameId, gameId);
+
+        // 1. Initial upsert — establish top-level fields exactly once.
+        var initUpdate = Builders<PlayerMatchTelemetry>.Update
+            .SetOnInsert(x => x.GameId, gameId)
+            .SetOnInsert(x => x.MatchWallStart, matchWallStart)
+            .SetOnInsert(x => x.BucketMs, bucketMs)
+            .SetOnInsert(x => x.CreatedAt, now)
+            .SetOnInsert(x => x.ExpiresAt, now + ttl)
+            .SetOnInsert(x => x.Players, new List<PlayerMatchTelemetryEntry>());
+        await Collection.UpdateOneAsync(filter, initUpdate, new UpdateOptions { IsUpsert = true });
+
+        // 2. Remove any existing entry for this BattleTag — keeps the merge idempotent
+        //    when the same player resubmits (e.g. after a crash recovery).
+        var pull = Builders<PlayerMatchTelemetry>.Update.PullFilter(
+            x => x.Players,
+            Builders<PlayerMatchTelemetryEntry>.Filter.Eq(p => p.BattleTag, entry.BattleTag));
+        await Collection.UpdateOneAsync(filter, pull);
+
+        // 3. Push the new entry.
+        var push = Builders<PlayerMatchTelemetry>.Update.Push(x => x.Players, entry);
+        await Collection.UpdateOneAsync(filter, push);
+    }
+
+    public async Task<PlayerMatchTelemetry?> GetByGameIdAsync(long gameId)
+    {
+        return await Collection
+            .Find(Builders<PlayerMatchTelemetry>.Filter.Eq(x => x.GameId, gameId))
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task EnsureIndexesAsync()
+    {
+        var indexes = new List<CreateIndexModel<PlayerMatchTelemetry>>
+        {
+            // TTL index — purges documents `expireAfterSeconds: 0` once ExpiresAt is reached.
+            new(
+                Builders<PlayerMatchTelemetry>.IndexKeys.Ascending(x => x.ExpiresAt),
+                new CreateIndexOptions { ExpireAfter = TimeSpan.Zero }),
+
+            // Secondary lookup index — "all matches for player X by recency".
+            new(
+                Builders<PlayerMatchTelemetry>.IndexKeys
+                    .Ascending("Players.BattleTag")
+                    .Descending(x => x.MatchWallStart),
+                new CreateIndexOptions { Name = "Players_BattleTag_MatchWallStart" }),
+        };
+
+        await Collection.Indexes.CreateManyAsync(indexes);
+    }
+}

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryRepository.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryRepository.cs
@@ -2,26 +2,19 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using W3C.Domain.Repositories;
 using W3C.Domain.Tracing;
 
 namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
 
-// Spec: docs/superpowers/specs/2026-05-21-flo-action-latency-design.md §4.8.2 + §4.8.4.
-// _id == GameId. Per-player entries merged into Players[] via idempotent upsert.
 /// <summary>
 /// Mongo repository for <see cref="PlayerMatchTelemetry"/>. Implements
 /// <see cref="IRequiresIndexes"/> so the existing
 /// <c>MongoIndexInitializationService</c> creates the TTL and lookup indexes
-/// at application startup — but only after this type is registered with DI.
+/// at application startup once this type is registered with DI.
 /// </summary>
-/// <remarks>
-/// DI registration is wired in Task 1.18 (see
-/// docs/superpowers/plans/2026-05-21-flo-action-latency-01-foundation.md).
-/// Until then, <see cref="EnsureIndexesAsync"/> must be called explicitly
-/// (the integration tests do this).
-/// </remarks>
 [Trace]
 public class PlayerMatchTelemetryRepository(MongoClient mongoClient)
     : MongoDbRepositoryBase(mongoClient), IPlayerMatchTelemetryRepository, IRequiresIndexes
@@ -32,49 +25,102 @@ public class PlayerMatchTelemetryRepository(MongoClient mongoClient)
         => CreateCollection<PlayerMatchTelemetry>();
 
     /// <summary>
-    /// Upserts a single player's entry into the per-game document. Uses a 3-step pattern
-    /// (init top-level via SetOnInsert → pull existing entry by BattleTag → push new entry),
-    /// mirroring <see cref="W3ChampionsStatisticService.LagReports.LagReportRepository"/>.
+    /// Upserts a single player's entry into the per-game document atomically
+    /// via a single aggregation-pipeline UpdateOneAsync.
     /// </summary>
     /// <remarks>
-    /// The 3-step sequence is NOT atomic. Concurrent invocations for the same
-    /// <paramref name="gameId"/> and <c>entry.BattleTag</c> can interleave between
-    /// the pull and push steps and produce duplicate array entries.
-    /// This is acceptable under the deployment assumption that one launcher
-    /// instance per player submits at most once per game (fire-and-forget, no retry —
-    /// see spec §4.7 and §4.8.4). If concurrent same-(gameId, battleTag) submissions
-    /// become possible, replace this with an arrayFilters-based atomic update.
+    /// One MongoDB round trip: the pipeline initializes top-level fields on insert
+    /// (via $ifNull), then either replaces the existing Players entry whose
+    /// BattleTag matches (via $map + $cond) or appends a new entry (via
+    /// $concatArrays). This eliminates the race window where two concurrent
+    /// submissions for the same (gameId, battleTag) could interleave and
+    /// produce duplicate array entries.
     /// </remarks>
     public async Task UpsertPlayerEntryAsync(
         long gameId,
         DateTime matchWallStart,
-        int bucketMs,
         PlayerMatchTelemetryEntry entry,
         TimeSpan ttl)
     {
         var now = DateTime.UtcNow;
+        var expiresAt = now + ttl;
+        var newEntryBson = entry.ToBsonDocument();
+
+        var setStage = new BsonDocument("$set", new BsonDocument
+        {
+            { "_id", gameId },
+            {
+                "MatchWallStart",
+                new BsonDocument("$ifNull", new BsonArray { "$MatchWallStart", matchWallStart })
+            },
+            {
+                "CreatedAt",
+                new BsonDocument("$ifNull", new BsonArray { "$CreatedAt", now })
+            },
+            {
+                "ExpiresAt",
+                new BsonDocument("$ifNull", new BsonArray { "$ExpiresAt", expiresAt })
+            },
+            {
+                "Players",
+                new BsonDocument("$cond", new BsonDocument
+                {
+                    {
+                        "if",
+                        new BsonDocument("$in", new BsonArray
+                        {
+                            entry.BattleTag,
+                            new BsonDocument("$ifNull", new BsonArray
+                            {
+                                "$Players.BattleTag",
+                                new BsonArray()
+                            })
+                        })
+                    },
+                    {
+                        "then",
+                        new BsonDocument("$map", new BsonDocument
+                        {
+                            { "input", "$Players" },
+                            { "as", "p" },
+                            {
+                                "in",
+                                new BsonDocument("$cond", new BsonDocument
+                                {
+                                    {
+                                        "if",
+                                        new BsonDocument("$eq", new BsonArray
+                                        {
+                                            "$$p.BattleTag",
+                                            entry.BattleTag
+                                        })
+                                    },
+                                    { "then", newEntryBson },
+                                    { "else", "$$p" }
+                                })
+                            }
+                        })
+                    },
+                    {
+                        "else",
+                        new BsonDocument("$concatArrays", new BsonArray
+                        {
+                            new BsonDocument("$ifNull", new BsonArray
+                            {
+                                "$Players",
+                                new BsonArray()
+                            }),
+                            new BsonArray { newEntryBson }
+                        })
+                    }
+                })
+            }
+        });
+
+        var pipeline = new BsonDocumentStagePipelineDefinition<PlayerMatchTelemetry, PlayerMatchTelemetry>(
+            new[] { setStage });
         var filter = Builders<PlayerMatchTelemetry>.Filter.Eq(x => x.GameId, gameId);
-
-        // 1. Initial upsert — establish top-level fields exactly once.
-        var initUpdate = Builders<PlayerMatchTelemetry>.Update
-            .SetOnInsert(x => x.GameId, gameId)
-            .SetOnInsert(x => x.MatchWallStart, matchWallStart)
-            .SetOnInsert(x => x.BucketMs, bucketMs)
-            .SetOnInsert(x => x.CreatedAt, now)
-            .SetOnInsert(x => x.ExpiresAt, now + ttl)
-            .SetOnInsert(x => x.Players, new List<PlayerMatchTelemetryEntry>());
-        await Collection.UpdateOneAsync(filter, initUpdate, new UpdateOptions { IsUpsert = true });
-
-        // 2. Remove any existing entry for this BattleTag — keeps the merge idempotent
-        //    when the same player resubmits (e.g. after a crash recovery).
-        var pull = Builders<PlayerMatchTelemetry>.Update.PullFilter(
-            x => x.Players,
-            Builders<PlayerMatchTelemetryEntry>.Filter.Eq(p => p.BattleTag, entry.BattleTag));
-        await Collection.UpdateOneAsync(filter, pull);
-
-        // 3. Push the new entry.
-        var push = Builders<PlayerMatchTelemetry>.Update.Push(x => x.Players, entry);
-        await Collection.UpdateOneAsync(filter, push);
+        await Collection.UpdateOneAsync(filter, pipeline, new UpdateOptions { IsUpsert = true });
     }
 
     public async Task<PlayerMatchTelemetry?> GetByGameIdAsync(long gameId)

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryRepository.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryRepository.cs
@@ -10,6 +10,18 @@ namespace W3ChampionsStatisticService.PlayerMatchTelemetry;
 
 // Spec: docs/superpowers/specs/2026-05-21-flo-action-latency-design.md §4.8.2 + §4.8.4.
 // _id == GameId. Per-player entries merged into Players[] via idempotent upsert.
+/// <summary>
+/// Mongo repository for <see cref="PlayerMatchTelemetry"/>. Implements
+/// <see cref="IRequiresIndexes"/> so the existing
+/// <c>MongoIndexInitializationService</c> creates the TTL and lookup indexes
+/// at application startup — but only after this type is registered with DI.
+/// </summary>
+/// <remarks>
+/// DI registration is wired in Task 1.18 (see
+/// docs/superpowers/plans/2026-05-21-flo-action-latency-01-foundation.md).
+/// Until then, <see cref="EnsureIndexesAsync"/> must be called explicitly
+/// (the integration tests do this).
+/// </remarks>
 [Trace]
 public class PlayerMatchTelemetryRepository(MongoClient mongoClient)
     : MongoDbRepositoryBase(mongoClient), IPlayerMatchTelemetryRepository, IRequiresIndexes
@@ -19,6 +31,20 @@ public class PlayerMatchTelemetryRepository(MongoClient mongoClient)
     private IMongoCollection<PlayerMatchTelemetry> Collection
         => CreateCollection<PlayerMatchTelemetry>();
 
+    /// <summary>
+    /// Upserts a single player's entry into the per-game document. Uses a 3-step pattern
+    /// (init top-level via SetOnInsert → pull existing entry by BattleTag → push new entry),
+    /// mirroring <see cref="W3ChampionsStatisticService.LagReports.LagReportRepository"/>.
+    /// </summary>
+    /// <remarks>
+    /// The 3-step sequence is NOT atomic. Concurrent invocations for the same
+    /// <paramref name="gameId"/> and <c>entry.BattleTag</c> can interleave between
+    /// the pull and push steps and produce duplicate array entries.
+    /// This is acceptable under the deployment assumption that one launcher
+    /// instance per player submits at most once per game (fire-and-forget, no retry —
+    /// see spec §4.7 and §4.8.4). If concurrent same-(gameId, battleTag) submissions
+    /// become possible, replace this with an arrayFilters-based atomic update.
+    /// </remarks>
     public async Task UpsertPlayerEntryAsync(
         long gameId,
         DateTime matchWallStart,

--- a/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryRepository.cs
+++ b/W3ChampionsStatisticService/PlayerMatchTelemetry/PlayerMatchTelemetryRepository.cs
@@ -145,6 +145,11 @@ public class PlayerMatchTelemetryRepository(MongoClient mongoClient)
                     .Ascending("Players.BattleTag")
                     .Descending(x => x.MatchWallStart),
                 new CreateIndexOptions { Name = "Players_BattleTag_MatchWallStart" }),
+
+            // Recency index — "N most recent telemetry submissions".
+            new(
+                Builders<PlayerMatchTelemetry>.IndexKeys.Descending(x => x.CreatedAt),
+                new CreateIndexOptions { Name = "CreatedAt_recency" }),
         };
 
         await Collection.Indexes.CreateManyAsync(indexes);

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -168,6 +168,8 @@ builder.Services.AddInterceptedTransient<IPatchRepository, PatchRepository>();
 builder.Services.AddInterceptedTransient<IAdminRepository, AdminRepository>();
 builder.Services.AddInterceptedTransient<W3ChampionsStatisticService.LagReports.LagReportRepository>();
 builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexes, W3ChampionsStatisticService.LagReports.LagReportRepository>();
+builder.Services.AddInterceptedTransient<W3ChampionsStatisticService.PlayerMatchTelemetry.IPlayerMatchTelemetryRepository, W3ChampionsStatisticService.PlayerMatchTelemetry.PlayerMatchTelemetryRepository>();
+builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexes, W3ChampionsStatisticService.PlayerMatchTelemetry.PlayerMatchTelemetryRepository>();
 builder.Services.AddInterceptedSingleton<W3ChampionsStatisticService.LagReports.IFloStatsService, W3ChampionsStatisticService.LagReports.FloStatsService>();
 builder.Services.AddInterceptedTransient<IPersonalSettingsRepository, PersonalSettingsRepository>();
 builder.Services.AddInterceptedTransient<IW3CAuthenticationService, W3CAuthenticationService>();

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTransportTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTransportTests.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using W3ChampionsStatisticService.LagReports;
@@ -8,10 +8,10 @@ using W3ChampionsStatisticService.LagReports;
 namespace WC3ChampionsStatisticService.Tests.LagReports;
 
 /// <summary>
-/// Phase 2 / Task 2.3 — verifies that the new <see cref="ConnectionTopologyDto.Transport"/>
-/// field is validated by the DTO's <see cref="RegularExpressionAttribute"/> and persisted
-/// onto <see cref="LagReportPlayer.Transport"/> through the controller's mapping +
-/// repository round-trip.
+/// Verifies that the <see cref="ConnectionTopologyDto.Transport"/> enum is
+/// validated by the DTO's <see cref="EnumDataTypeAttribute"/> and persisted
+/// onto <see cref="LagReportPlayer.Transport"/> through the controller's
+/// mapping + repository round-trip.
 /// </summary>
 [TestFixture]
 public class LagReportTransportTests : IntegrationTestBase
@@ -24,7 +24,7 @@ public class LagReportTransportTests : IntegrationTestBase
         _repo = new LagReportRepository(MongoClient);
     }
 
-    private static LagReportSubmissionDto CreateValidDto(string transport) => new()
+    private static LagReportSubmissionDto CreateValidDto(Transport transport) => new()
     {
         Diagnostics = new DiagnosticsDataDto
         {
@@ -61,13 +61,12 @@ public class LagReportTransportTests : IntegrationTestBase
     [Test]
     public async Task Posting_LagReport_With_Transport_Persists_The_Value()
     {
-        // Arrange: a submission with Transport = "QUIC".
-        var dto = CreateValidDto("QUIC");
+        // Arrange: a submission with Transport = QUIC.
+        var dto = CreateValidDto(Transport.QUIC);
 
         // The controller's static helpers are the integration seam: they encapsulate
         // exactly the DTO→domain transformation that SubmitReport performs before
-        // calling the repository. Mirrors the existing controller-against-repo pattern
-        // used by LagReportRepositoryTests + PlayerMatchTelemetryEndToEndTests.
+        // calling the repository.
         Assert.IsNull(LagReportController.ValidateSubmission(dto));
         var player = LagReportController.MapToPlayer(dto, "TransportTester#0001");
 
@@ -88,16 +87,17 @@ public class LagReportTransportTests : IntegrationTestBase
         // Assert: the QUIC value survives the BSON round-trip.
         Assert.That(fetched, Is.Not.Null);
         Assert.That(fetched.Players, Has.Count.EqualTo(1));
-        Assert.That(fetched.Players[0].Transport, Is.EqualTo("QUIC"));
+        Assert.That(fetched.Players[0].Transport, Is.EqualTo(Transport.QUIC));
     }
 
     [Test]
     public void Posting_LagReport_With_Invalid_Transport_Returns_400()
     {
-        // Arrange: same DTO shape but Transport = "UDP" — outside the allowed regex.
-        var dto = CreateValidDto("UDP");
+        // Arrange: the Transport enum can be cast from arbitrary ints. ASP.NET's
+        // ModelState validates EnumDataType against the enum's defined members.
+        var dto = CreateValidDto((Transport)999);
 
-        // Act: drive ASP.NET's DataAnnotations validation (this is exactly what
+        // Act: drive DataAnnotations validation (this is exactly what
         // [ApiController] invokes against the model when SubmitReport's parameter
         // binds). A failed Validator.TryValidateObject is what produces the 400
         // BadRequest response that the controller never even sees.
@@ -106,8 +106,58 @@ public class LagReportTransportTests : IntegrationTestBase
         var ok = Validator.TryValidateObject(dto.ConnectionTopology, ctx, errors, validateAllProperties: true);
 
         // Assert: ModelState would be invalid → ASP.NET returns 400 BadRequest.
-        Assert.That(ok, Is.False, "Validator should reject Transport=UDP");
+        Assert.That(ok, Is.False, "Validator should reject Transport=999");
         Assert.That(errors, Has.Some.Matches<ValidationResult>(e =>
             e.ErrorMessage != null && e.ErrorMessage.Contains("Transport")));
+    }
+
+    [Test]
+    public void Transport_json_payload_rejects_unknown_string()
+    {
+        // JsonStringEnumConverter throws on undefined enum members during
+        // deserialization. ASP.NET Core's [FromBody] surfaces this as a 400.
+        const string json = """
+        {
+          "server_node_id": 1,
+          "server_node_name": "EU West",
+          "connection_type": "Direct",
+          "client_ip": "203.0.113.1",
+          "transport": "UDP"
+        }
+        """;
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<ConnectionTopologyDto>(json, options));
+    }
+
+    [Test]
+    public void Transport_json_payload_accepts_TCP_and_QUIC()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+        const string tcp = """
+        {
+          "server_node_id": 1,
+          "server_node_name": "EU West",
+          "connection_type": "Direct",
+          "client_ip": "203.0.113.1",
+          "transport": "TCP"
+        }
+        """;
+        const string quic = """
+        {
+          "server_node_id": 1,
+          "server_node_name": "EU West",
+          "connection_type": "Direct",
+          "client_ip": "203.0.113.1",
+          "transport": "QUIC"
+        }
+        """;
+
+        var tcpDto = JsonSerializer.Deserialize<ConnectionTopologyDto>(tcp, options);
+        var quicDto = JsonSerializer.Deserialize<ConnectionTopologyDto>(quic, options);
+
+        Assert.That(tcpDto!.Transport, Is.EqualTo(Transport.TCP));
+        Assert.That(quicDto!.Transport, Is.EqualTo(Transport.QUIC));
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTransportTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTransportTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using W3ChampionsStatisticService.LagReports;
+
+namespace WC3ChampionsStatisticService.Tests.LagReports;
+
+/// <summary>
+/// Phase 2 / Task 2.3 — verifies that the new <see cref="ConnectionTopologyDto.Transport"/>
+/// field is validated by the DTO's <see cref="RegularExpressionAttribute"/> and persisted
+/// onto <see cref="LagReportPlayer.Transport"/> through the controller's mapping +
+/// repository round-trip.
+/// </summary>
+[TestFixture]
+public class LagReportTransportTests : IntegrationTestBase
+{
+    private LagReportRepository _repo;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repo = new LagReportRepository(MongoClient);
+    }
+
+    private static LagReportSubmissionDto CreateValidDto(string transport) => new()
+    {
+        Diagnostics = new DiagnosticsDataDto
+        {
+            GameId = 1001,
+            PlayerId = 1,
+            LagEvents = [],
+            TargetMtr = [],
+            AllServerBaselines = [],
+            ReverseMtr = [],
+            PingHistory = [],
+            ConnectionEvents = [],
+        },
+        GameMetadata = new GameMetadataDto
+        {
+            GameId = 5001,
+            FloGameId = 1001,
+            GameName = "transport-test-game",
+            MapPath = "(2)EchoIsles.w3x",
+        },
+        ConnectionTopology = new ConnectionTopologyDto
+        {
+            ServerNodeId = 1,
+            ServerNodeName = "EU West",
+            ConnectionType = EConnectionType.Direct,
+            ClientIp = "203.0.113.1",
+            Transport = transport,
+        },
+        IsExplicit = false,
+        Categories = [],
+        FreeText = "",
+        Annotations = [],
+    };
+
+    [Test]
+    public async Task Posting_LagReport_With_Transport_Persists_The_Value()
+    {
+        // Arrange: a submission with Transport = "QUIC".
+        var dto = CreateValidDto("QUIC");
+
+        // The controller's static helpers are the integration seam: they encapsulate
+        // exactly the DTO→domain transformation that SubmitReport performs before
+        // calling the repository. Mirrors the existing controller-against-repo pattern
+        // used by LagReportRepositoryTests + PlayerMatchTelemetryEndToEndTests.
+        Assert.IsNull(LagReportController.ValidateSubmission(dto));
+        var player = LagReportController.MapToPlayer(dto, "TransportTester#0001");
+
+        var template = new LagReport
+        {
+            GameId = dto.GameMetadata.GameId,
+            FloGameId = dto.GameMetadata.FloGameId,
+            GameName = dto.GameMetadata.GameName,
+            MapPath = dto.GameMetadata.MapPath,
+            ServerNodeId = dto.ConnectionTopology.ServerNodeId,
+            ServerNodeName = dto.ConnectionTopology.ServerNodeName,
+        };
+
+        // Act: persist and fetch back.
+        var reportId = await _repo.UpsertPlayerData(template.FloGameId, player, template);
+        var fetched = await _repo.GetById(reportId);
+
+        // Assert: the QUIC value survives the BSON round-trip.
+        Assert.That(fetched, Is.Not.Null);
+        Assert.That(fetched.Players, Has.Count.EqualTo(1));
+        Assert.That(fetched.Players[0].Transport, Is.EqualTo("QUIC"));
+    }
+
+    [Test]
+    public void Posting_LagReport_With_Invalid_Transport_Returns_400()
+    {
+        // Arrange: same DTO shape but Transport = "UDP" — outside the allowed regex.
+        var dto = CreateValidDto("UDP");
+
+        // Act: drive ASP.NET's DataAnnotations validation (this is exactly what
+        // [ApiController] invokes against the model when SubmitReport's parameter
+        // binds). A failed Validator.TryValidateObject is what produces the 400
+        // BadRequest response that the controller never even sees.
+        var ctx = new ValidationContext(dto.ConnectionTopology);
+        var errors = new List<ValidationResult>();
+        var ok = Validator.TryValidateObject(dto.ConnectionTopology, ctx, errors, validateAllProperties: true);
+
+        // Assert: ModelState would be invalid → ASP.NET returns 400 BadRequest.
+        Assert.That(ok, Is.False, "Validator should reject Transport=UDP");
+        Assert.That(errors, Has.Some.Matches<ValidationResult>(e =>
+            e.ErrorMessage != null && e.ErrorMessage.Contains("Transport")));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryControllerTests.cs
@@ -1,0 +1,73 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsStatisticService.PlayerMatchTelemetry;
+using PlayerMatchTelemetryDoc = W3ChampionsStatisticService.PlayerMatchTelemetry.PlayerMatchTelemetry;
+
+namespace WC3ChampionsStatisticService.Tests.PlayerMatchTelemetry;
+
+[TestFixture]
+public class PlayerMatchTelemetryControllerTests
+{
+    private Mock<IPlayerMatchTelemetryRepository> _repo = null!;
+    private PlayerMatchTelemetryController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repo = new Mock<IPlayerMatchTelemetryRepository>();
+        _controller = new PlayerMatchTelemetryController(_repo.Object);
+    }
+
+    private static PlayerMatchTelemetrySubmissionDto MakeSubmission(int buckets = 3)
+        => new(
+            GameId: 12345,
+            BucketMs: 1000,
+            MatchWallStart: new DateTime(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc),
+            GameLengthMs: 600_000,
+            Crashed: false,
+            ConnectionType: "QUIC",
+            Disconnects: new DisconnectsDto(0, 0, 0),
+            ActionLatencyAggregate: new ActionLatencyAggregateDto(100, 20, 40, 200, 400, 60, 30),
+            ActionLatencyTimeseries: new ActionLatencyTimeseriesDto(
+                Enumerable.Range(0, buckets).Select(i => (uint)(i * 1000)).ToArray(),
+                Enumerable.Repeat<ushort>(30, buckets).ToArray(),
+                Enumerable.Repeat<byte>(5, buckets).ToArray()),
+            DroppedUnmatchedCount: 0);
+
+    [Test]
+    public async Task Submit_calls_repository_with_authenticated_battletag()
+    {
+        var result = await _controller.Submit(MakeSubmission(), "Alice#1234");
+        Assert.That(result, Is.InstanceOf<OkResult>());
+        _repo.Verify(r => r.UpsertPlayerEntryAsync(
+            12345L,
+            It.IsAny<DateTime>(),
+            1000,
+            It.Is<PlayerMatchTelemetryEntry>(e => e.BattleTag == "Alice#1234" && e.BucketCount == 3),
+            It.IsAny<TimeSpan>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task GetByGame_returns_404_when_missing()
+    {
+        _repo.Setup(r => r.GetByGameIdAsync(99)).ReturnsAsync((PlayerMatchTelemetryDoc?)null);
+        var result = await _controller.GetByGame(99);
+        Assert.That(result, Is.InstanceOf<NotFoundResult>());
+    }
+
+    [Test]
+    public async Task GetByGame_returns_doc_when_present()
+    {
+        var doc = new PlayerMatchTelemetryDoc { GameId = 99 };
+        _repo.Setup(r => r.GetByGameIdAsync(99)).ReturnsAsync(doc);
+        var result = await _controller.GetByGame(99);
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(((OkObjectResult)result).Value, Is.SameAs(doc));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryControllerTests.cs
@@ -64,10 +64,15 @@ public class PlayerMatchTelemetryControllerTests
     [Test]
     public async Task GetByGame_returns_doc_when_present()
     {
+        // The controller now projects the domain model to a response DTO so
+        // System.Text.Json can serialize BsonBinaryData fields (the raw domain
+        // model would 500). Verify identity-by-projection on GameId.
         var doc = new PlayerMatchTelemetryDoc { GameId = 99 };
         _repo.Setup(r => r.GetByGameIdAsync(99)).ReturnsAsync(doc);
         var result = await _controller.GetByGame(99);
         Assert.That(result, Is.InstanceOf<OkObjectResult>());
-        Assert.That(((OkObjectResult)result).Value, Is.SameAs(doc));
+        var value = ((OkObjectResult)result).Value;
+        Assert.That(value, Is.InstanceOf<PlayerMatchTelemetryResponseDto>());
+        Assert.That(((PlayerMatchTelemetryResponseDto)value!).GameId, Is.EqualTo(99));
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryControllerTests.cs
@@ -26,19 +26,21 @@ public class PlayerMatchTelemetryControllerTests
     }
 
     private static PlayerMatchTelemetrySubmissionDto MakeSubmission(int buckets = 3)
-        => new(
-            GameId: 12345,
-            MatchWallStart: new DateTime(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc),
-            GameLengthMs: 600_000,
-            CrashedAt: null,
-            ConnectionType: Transport.QUIC,
-            DisconnectEvents: new List<DisconnectEventDto>(),
-            ActionLatencyAggregate: new ActionLatencyAggregateDto(100, 20, 40, 200, 400, 60, 30),
-            ActionLatencyTimeseries: new ActionLatencyTimeseriesDto(
+        => new()
+        {
+            GameId = 12345,
+            MatchWallStart = new DateTime(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc),
+            GameLengthMs = 600_000,
+            CrashedAt = null,
+            ConnectionType = Transport.QUIC,
+            DisconnectEvents = new List<DisconnectEventDto>(),
+            ActionLatencyAggregate = new ActionLatencyAggregateDto(100, 20, 40, 200, 400, 60, 30),
+            ActionLatencyTimeseries = new ActionLatencyTimeseriesDto(
                 Enumerable.Range(0, buckets).Select(i => (uint)(i * 1000)).ToArray(),
                 Enumerable.Repeat<ushort>(30, buckets).ToArray(),
                 Enumerable.Repeat<byte>(5, buckets).ToArray()),
-            DroppedUnmatchedCount: 0);
+            DroppedUnmatchedCount = 0,
+        };
 
     [Test]
     public async Task Submit_calls_repository_with_authenticated_battletag()

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryControllerTests.cs
@@ -1,10 +1,12 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NUnit.Framework;
+using W3ChampionsStatisticService.LagReports;
 using W3ChampionsStatisticService.PlayerMatchTelemetry;
 using PlayerMatchTelemetryDoc = W3ChampionsStatisticService.PlayerMatchTelemetry.PlayerMatchTelemetry;
 
@@ -26,12 +28,11 @@ public class PlayerMatchTelemetryControllerTests
     private static PlayerMatchTelemetrySubmissionDto MakeSubmission(int buckets = 3)
         => new(
             GameId: 12345,
-            BucketMs: 1000,
             MatchWallStart: new DateTime(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc),
             GameLengthMs: 600_000,
-            Crashed: false,
-            ConnectionType: "QUIC",
-            Disconnects: new DisconnectsDto(0, 0, 0),
+            CrashedAt: null,
+            ConnectionType: Transport.QUIC,
+            DisconnectEvents: new List<DisconnectEventDto>(),
             ActionLatencyAggregate: new ActionLatencyAggregateDto(100, 20, 40, 200, 400, 60, 30),
             ActionLatencyTimeseries: new ActionLatencyTimeseriesDto(
                 Enumerable.Range(0, buckets).Select(i => (uint)(i * 1000)).ToArray(),
@@ -47,7 +48,6 @@ public class PlayerMatchTelemetryControllerTests
         _repo.Verify(r => r.UpsertPlayerEntryAsync(
             12345L,
             It.IsAny<DateTime>(),
-            1000,
             It.Is<PlayerMatchTelemetryEntry>(e => e.BattleTag == "Alice#1234" && e.BucketCount == 3),
             It.IsAny<TimeSpan>()),
             Times.Once);
@@ -64,9 +64,10 @@ public class PlayerMatchTelemetryControllerTests
     [Test]
     public async Task GetByGame_returns_doc_when_present()
     {
-        // The controller now projects the domain model to a response DTO so
-        // System.Text.Json can serialize BsonBinaryData fields (the raw domain
-        // model would 500). Verify identity-by-projection on GameId.
+        // The controller projects the domain model to a response DTO that decodes
+        // BsonBinaryData fields into plain number arrays (the raw domain model
+        // would 500 because System.Text.Json can't serialize BsonBinaryData).
+        // Verify identity-by-projection on GameId.
         var doc = new PlayerMatchTelemetryDoc { GameId = 99 };
         _repo.Setup(r => r.GetByGameIdAsync(99)).ReturnsAsync(doc);
         var result = await _controller.GetByGame(99);

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryDtosTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryDtosTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using NUnit.Framework;
+using W3ChampionsStatisticService.PlayerMatchTelemetry;
+
+namespace WC3ChampionsStatisticService.Tests.PlayerMatchTelemetry;
+
+[TestFixture]
+public class PlayerMatchTelemetryDtosTests
+{
+    private static (bool ok, IList<ValidationResult> errors) Validate(object dto)
+    {
+        var ctx = new ValidationContext(dto);
+        var errors = new List<ValidationResult>();
+        var ok = Validator.TryValidateObject(dto, ctx, errors, validateAllProperties: true);
+        return (ok, errors);
+    }
+
+    private static PlayerMatchTelemetrySubmissionDto MakeValid()
+        => new(
+            GameId: 12345,
+            BucketMs: 1000,
+            MatchWallStart: new DateTime(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc),
+            GameLengthMs: 600_000,
+            Crashed: false,
+            ConnectionType: "QUIC",
+            Disconnects: new DisconnectsDto(0, 0, 0),
+            ActionLatencyAggregate: new ActionLatencyAggregateDto(100, 20, 40, 200, 400, 60, 30),
+            ActionLatencyTimeseries: new ActionLatencyTimeseriesDto(
+                new uint[] { 0, 1000, 2000 },
+                new ushort[] { 30, 42, 38 },
+                new byte[] { 5, 7, 6 }),
+            DroppedUnmatchedCount: 0);
+
+    [Test]
+    public void Valid_dto_passes_validation()
+    {
+        var (ok, errors) = Validate(MakeValid());
+        Assert.That(ok, Is.True, string.Join("; ", errors));
+    }
+
+    [Test]
+    public void Mismatched_array_lengths_fail_validation()
+    {
+        var v = MakeValid();
+        var bad = v with
+        {
+            ActionLatencyTimeseries = new ActionLatencyTimeseriesDto(
+                new uint[] { 0, 1000 },
+                new ushort[] { 30, 42, 38 },
+                new byte[] { 5, 7, 6 })
+        };
+        var (ok, errors) = Validate(bad);
+        Assert.That(ok, Is.False);
+        Assert.That(string.Join(";", errors).ToLower(), Does.Contain("parallel arrays"));
+    }
+
+    [Test]
+    public void Bucket_count_over_28800_fails_validation()
+    {
+        var huge = new uint[28_801];
+        var means = new ushort[28_801];
+        var counts = new byte[28_801];
+        var v = MakeValid();
+        var bad = v with
+        {
+            ActionLatencyTimeseries = new ActionLatencyTimeseriesDto(huge, means, counts)
+        };
+        var (ok, errors) = Validate(bad);
+        Assert.That(ok, Is.False);
+        Assert.That(string.Join(";", errors), Does.Contain("28800"));
+    }
+
+    [Test]
+    public void Invalid_connection_type_fails_validation()
+    {
+        var v = MakeValid();
+        var bad = v with { ConnectionType = "UDP" };
+        var (ok, _) = Validate(bad);
+        Assert.That(ok, Is.False);
+    }
+
+    [Test]
+    public void Bucket_ms_out_of_range_fails_validation()
+    {
+        var v = MakeValid();
+        var bad = v with { BucketMs = 50 };  // below 100
+        var (ok, _) = Validate(bad);
+        Assert.That(ok, Is.False);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryDtosTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryDtosTests.cs
@@ -19,19 +19,21 @@ public class PlayerMatchTelemetryDtosTests
     }
 
     private static PlayerMatchTelemetrySubmissionDto MakeValid()
-        => new(
-            GameId: 12345,
-            MatchWallStart: new DateTime(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc),
-            GameLengthMs: 600_000,
-            CrashedAt: null,
-            ConnectionType: Transport.QUIC,
-            DisconnectEvents: new List<DisconnectEventDto>(),
-            ActionLatencyAggregate: new ActionLatencyAggregateDto(100, 20, 40, 200, 400, 60, 30),
-            ActionLatencyTimeseries: new ActionLatencyTimeseriesDto(
+        => new()
+        {
+            GameId = 12345,
+            MatchWallStart = new DateTime(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc),
+            GameLengthMs = 600_000,
+            CrashedAt = null,
+            ConnectionType = Transport.QUIC,
+            DisconnectEvents = new List<DisconnectEventDto>(),
+            ActionLatencyAggregate = new ActionLatencyAggregateDto(100, 20, 40, 200, 400, 60, 30),
+            ActionLatencyTimeseries = new ActionLatencyTimeseriesDto(
                 new uint[] { 0, 1000, 2000 },
                 new ushort[] { 30, 42, 38 },
                 new byte[] { 5, 7, 6 }),
-            DroppedUnmatchedCount: 0);
+            DroppedUnmatchedCount = 0,
+        };
 
     [Test]
     public void Valid_dto_passes_validation()

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryDtosTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryDtosTests.cs
@@ -59,9 +59,10 @@ public class PlayerMatchTelemetryDtosTests
     [Test]
     public void Bucket_count_over_28800_fails_validation()
     {
-        var huge = new uint[28_801];
-        var means = new ushort[28_801];
-        var counts = new byte[28_801];
+        const int MaxTimeseriesBuckets = 28_800;
+        var huge = new uint[MaxTimeseriesBuckets + 1];
+        var means = new ushort[MaxTimeseriesBuckets + 1];
+        var counts = new byte[MaxTimeseriesBuckets + 1];
         var v = MakeValid();
         var bad = v with
         {
@@ -69,7 +70,7 @@ public class PlayerMatchTelemetryDtosTests
         };
         var (ok, errors) = Validate(bad);
         Assert.That(ok, Is.False);
-        Assert.That(string.Join(";", errors), Does.Contain("28800"));
+        Assert.That(string.Join(";", errors), Does.Contain(MaxTimeseriesBuckets.ToString()));
     }
 
     [Test]
@@ -82,10 +83,37 @@ public class PlayerMatchTelemetryDtosTests
     }
 
     [Test]
+    public void Lowercase_connection_type_is_rejected_after_tightening()
+    {
+        var v = MakeValid();
+        var bad = v with { ConnectionType = "Tcp" };
+        var (ok, _) = Validate(bad);
+        Assert.That(ok, Is.False);
+    }
+
+    [Test]
     public void Bucket_ms_out_of_range_fails_validation()
     {
         var v = MakeValid();
         var bad = v with { BucketMs = 50 };  // below 100
+        var (ok, _) = Validate(bad);
+        Assert.That(ok, Is.False);
+    }
+
+    [Test]
+    public void Null_disconnects_fails_validation()
+    {
+        var v = MakeValid();
+        var bad = v with { Disconnects = null! };
+        var (ok, _) = Validate(bad);
+        Assert.That(ok, Is.False);
+    }
+
+    [Test]
+    public void Null_action_latency_aggregate_fails_validation()
+    {
+        var v = MakeValid();
+        var bad = v with { ActionLatencyAggregate = null! };
         var (ok, _) = Validate(bad);
         Assert.That(ok, Is.False);
     }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryDtosTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryDtosTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using NUnit.Framework;
+using W3ChampionsStatisticService.LagReports;
 using W3ChampionsStatisticService.PlayerMatchTelemetry;
 
 namespace WC3ChampionsStatisticService.Tests.PlayerMatchTelemetry;
@@ -20,12 +21,11 @@ public class PlayerMatchTelemetryDtosTests
     private static PlayerMatchTelemetrySubmissionDto MakeValid()
         => new(
             GameId: 12345,
-            BucketMs: 1000,
             MatchWallStart: new DateTime(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc),
             GameLengthMs: 600_000,
-            Crashed: false,
-            ConnectionType: "QUIC",
-            Disconnects: new DisconnectsDto(0, 0, 0),
+            CrashedAt: null,
+            ConnectionType: Transport.QUIC,
+            DisconnectEvents: new List<DisconnectEventDto>(),
             ActionLatencyAggregate: new ActionLatencyAggregateDto(100, 20, 40, 200, 400, 60, 30),
             ActionLatencyTimeseries: new ActionLatencyTimeseriesDto(
                 new uint[] { 0, 1000, 2000 },
@@ -74,37 +74,33 @@ public class PlayerMatchTelemetryDtosTests
     }
 
     [Test]
-    public void Invalid_connection_type_fails_validation()
+    public void Invalid_connection_type_value_fails_validation()
     {
+        // The Transport enum can be cast from an arbitrary int — DataAnnotations'
+        // EnumDataType attribute catches values that aren't defined members.
         var v = MakeValid();
-        var bad = v with { ConnectionType = "UDP" };
+        var bad = v with { ConnectionType = (Transport)999 };
         var (ok, _) = Validate(bad);
         Assert.That(ok, Is.False);
     }
 
     [Test]
-    public void Lowercase_connection_type_is_rejected_after_tightening()
+    public void Game_id_zero_fails_range_validation()
     {
+        // [Range(1, long.MaxValue)] on GameId — repurposed from the dropped
+        // BucketMs range check now that bucketMs is hardcoded to 1 s and gone
+        // from the wire.
         var v = MakeValid();
-        var bad = v with { ConnectionType = "Tcp" };
+        var bad = v with { GameId = 0 };
         var (ok, _) = Validate(bad);
         Assert.That(ok, Is.False);
     }
 
     [Test]
-    public void Bucket_ms_out_of_range_fails_validation()
+    public void Null_disconnect_events_fails_validation()
     {
         var v = MakeValid();
-        var bad = v with { BucketMs = 50 };  // below 100
-        var (ok, _) = Validate(bad);
-        Assert.That(ok, Is.False);
-    }
-
-    [Test]
-    public void Null_disconnects_fails_validation()
-    {
-        var v = MakeValid();
-        var bad = v with { Disconnects = null! };
+        var bad = v with { DisconnectEvents = null! };
         var (ok, _) = Validate(bad);
         Assert.That(ok, Is.False);
     }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryEndToEndTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryEndToEndTests.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using W3ChampionsStatisticService.PlayerMatchTelemetry;
-using PlayerMatchTelemetryDoc = W3ChampionsStatisticService.PlayerMatchTelemetry.PlayerMatchTelemetry;
 
 namespace WC3ChampionsStatisticService.Tests.PlayerMatchTelemetry;
 
@@ -46,17 +45,18 @@ public class PlayerMatchTelemetryEndToEndTests : IntegrationTestBase
 
         var getResult = await _controller.GetByGame(54321);
         Assert.That(getResult, Is.InstanceOf<OkObjectResult>());
-        var doc = (PlayerMatchTelemetryDoc)((OkObjectResult)getResult).Value!;
+        var doc = (PlayerMatchTelemetryResponseDto)((OkObjectResult)getResult).Value!;
         Assert.That(doc.GameId, Is.EqualTo(54321));
         Assert.That(doc.Players.Count, Is.EqualTo(1));
 
         var p = doc.Players[0];
         Assert.That(p.BattleTag, Is.EqualTo("Alice#1234"));
         Assert.That(p.BucketCount, Is.EqualTo(3));
-        Assert.That(p.GameTimeOffsetsMs.Bytes.Length, Is.EqualTo(12)); // 3 × uint32
-        Assert.That(p.MeansMs.Bytes.Length, Is.EqualTo(6));            // 3 × uint16
-        Assert.That(p.SampleCounts.Bytes.Length, Is.EqualTo(3));       // 3 × uint8
-        Assert.That(p.SampleCounts.Bytes.SequenceEqual(new byte[] { 5, 7, 6 }), Is.True);
+        // BinData envelopes: base64 strings whose decoded length matches the
+        // little-endian byte counts (3 × uint32 = 12, 3 × uint16 = 6, 3 × uint8 = 3).
+        Assert.That(Convert.FromBase64String(p.GameTimeOffsetsMs.Binary.Base64).Length, Is.EqualTo(12));
+        Assert.That(Convert.FromBase64String(p.MeansMs.Binary.Base64).Length, Is.EqualTo(6));
+        Assert.That(p.SampleCounts.Binary.Base64, Is.EqualTo(Convert.ToBase64String(new byte[] { 5, 7, 6 })));
     }
 
     [Test]
@@ -66,7 +66,7 @@ public class PlayerMatchTelemetryEndToEndTests : IntegrationTestBase
         await _controller.Submit(sub, "Alice#1234");
         await _controller.Submit(sub, "Bob#5678");
         var getResult = await _controller.GetByGame(54322);
-        var doc = (PlayerMatchTelemetryDoc)((OkObjectResult)getResult).Value!;
+        var doc = (PlayerMatchTelemetryResponseDto)((OkObjectResult)getResult).Value!;
         Assert.That(doc.Players.Count, Is.EqualTo(2));
         Assert.That(doc.Players.Select(p => p.BattleTag).ToHashSet(),
             Is.EquivalentTo(new[] { "Alice#1234", "Bob#5678" }));

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryEndToEndTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryEndToEndTests.cs
@@ -23,19 +23,21 @@ public class PlayerMatchTelemetryEndToEndTests : IntegrationTestBase
     }
 
     private static PlayerMatchTelemetrySubmissionDto MakeSubmission(long gameId)
-        => new(
-            GameId: gameId,
-            MatchWallStart: new DateTime(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc),
-            GameLengthMs: 600_000,
-            CrashedAt: null,
-            ConnectionType: Transport.QUIC,
-            DisconnectEvents: new List<DisconnectEventDto>(),
-            ActionLatencyAggregate: new ActionLatencyAggregateDto(100, 20, 40, 200, 400, 60, 30),
-            ActionLatencyTimeseries: new ActionLatencyTimeseriesDto(
+        => new()
+        {
+            GameId = gameId,
+            MatchWallStart = new DateTime(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc),
+            GameLengthMs = 600_000,
+            CrashedAt = null,
+            ConnectionType = Transport.QUIC,
+            DisconnectEvents = new List<DisconnectEventDto>(),
+            ActionLatencyAggregate = new ActionLatencyAggregateDto(100, 20, 40, 200, 400, 60, 30),
+            ActionLatencyTimeseries = new ActionLatencyTimeseriesDto(
                 new uint[] { 0, 1000, 2000 },
                 new ushort[] { 30, 42, 38 },
                 new byte[] { 5, 7, 6 }),
-            DroppedUnmatchedCount: 0);
+            DroppedUnmatchedCount = 0,
+        };
 
     [Test]
     public async Task Post_then_get_round_trips_with_decoded_arrays()

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryEndToEndTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryEndToEndTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+using W3ChampionsStatisticService.PlayerMatchTelemetry;
+using PlayerMatchTelemetryDoc = W3ChampionsStatisticService.PlayerMatchTelemetry.PlayerMatchTelemetry;
+
+namespace WC3ChampionsStatisticService.Tests.PlayerMatchTelemetry;
+
+[TestFixture]
+public class PlayerMatchTelemetryEndToEndTests : IntegrationTestBase
+{
+    private PlayerMatchTelemetryRepository _repo = null!;
+    private PlayerMatchTelemetryController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repo = new PlayerMatchTelemetryRepository(MongoClient);
+        _controller = new PlayerMatchTelemetryController(_repo);
+    }
+
+    private static PlayerMatchTelemetrySubmissionDto MakeSubmission(long gameId)
+        => new(
+            GameId: gameId,
+            BucketMs: 1000,
+            MatchWallStart: new DateTime(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc),
+            GameLengthMs: 600_000,
+            Crashed: false,
+            ConnectionType: "QUIC",
+            Disconnects: new DisconnectsDto(0, 0, 0),
+            ActionLatencyAggregate: new ActionLatencyAggregateDto(100, 20, 40, 200, 400, 60, 30),
+            ActionLatencyTimeseries: new ActionLatencyTimeseriesDto(
+                new uint[] { 0, 1000, 2000 },
+                new ushort[] { 30, 42, 38 },
+                new byte[] { 5, 7, 6 }),
+            DroppedUnmatchedCount: 0);
+
+    [Test]
+    public async Task Post_then_get_round_trips_with_bindata_intact()
+    {
+        var sub = MakeSubmission(54321);
+        var postResult = await _controller.Submit(sub, "Alice#1234");
+        Assert.That(postResult, Is.InstanceOf<OkResult>());
+
+        var getResult = await _controller.GetByGame(54321);
+        Assert.That(getResult, Is.InstanceOf<OkObjectResult>());
+        var doc = (PlayerMatchTelemetryDoc)((OkObjectResult)getResult).Value!;
+        Assert.That(doc.GameId, Is.EqualTo(54321));
+        Assert.That(doc.Players.Count, Is.EqualTo(1));
+
+        var p = doc.Players[0];
+        Assert.That(p.BattleTag, Is.EqualTo("Alice#1234"));
+        Assert.That(p.BucketCount, Is.EqualTo(3));
+        Assert.That(p.GameTimeOffsetsMs.Bytes.Length, Is.EqualTo(12)); // 3 × uint32
+        Assert.That(p.MeansMs.Bytes.Length, Is.EqualTo(6));            // 3 × uint16
+        Assert.That(p.SampleCounts.Bytes.Length, Is.EqualTo(3));       // 3 × uint8
+        Assert.That(p.SampleCounts.Bytes.SequenceEqual(new byte[] { 5, 7, 6 }), Is.True);
+    }
+
+    [Test]
+    public async Task Two_players_same_game_id_merge_into_one_doc()
+    {
+        var sub = MakeSubmission(54322);
+        await _controller.Submit(sub, "Alice#1234");
+        await _controller.Submit(sub, "Bob#5678");
+        var getResult = await _controller.GetByGame(54322);
+        var doc = (PlayerMatchTelemetryDoc)((OkObjectResult)getResult).Value!;
+        Assert.That(doc.Players.Count, Is.EqualTo(2));
+        Assert.That(doc.Players.Select(p => p.BattleTag).ToHashSet(),
+            Is.EquivalentTo(new[] { "Alice#1234", "Bob#5678" }));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryEndToEndTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryEndToEndTests.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
+using W3ChampionsStatisticService.LagReports;
 using W3ChampionsStatisticService.PlayerMatchTelemetry;
 
 namespace WC3ChampionsStatisticService.Tests.PlayerMatchTelemetry;
@@ -23,12 +25,11 @@ public class PlayerMatchTelemetryEndToEndTests : IntegrationTestBase
     private static PlayerMatchTelemetrySubmissionDto MakeSubmission(long gameId)
         => new(
             GameId: gameId,
-            BucketMs: 1000,
             MatchWallStart: new DateTime(2026, 5, 21, 12, 0, 0, DateTimeKind.Utc),
             GameLengthMs: 600_000,
-            Crashed: false,
-            ConnectionType: "QUIC",
-            Disconnects: new DisconnectsDto(0, 0, 0),
+            CrashedAt: null,
+            ConnectionType: Transport.QUIC,
+            DisconnectEvents: new List<DisconnectEventDto>(),
             ActionLatencyAggregate: new ActionLatencyAggregateDto(100, 20, 40, 200, 400, 60, 30),
             ActionLatencyTimeseries: new ActionLatencyTimeseriesDto(
                 new uint[] { 0, 1000, 2000 },
@@ -37,7 +38,7 @@ public class PlayerMatchTelemetryEndToEndTests : IntegrationTestBase
             DroppedUnmatchedCount: 0);
 
     [Test]
-    public async Task Post_then_get_round_trips_with_bindata_intact()
+    public async Task Post_then_get_round_trips_with_decoded_arrays()
     {
         var sub = MakeSubmission(54321);
         var postResult = await _controller.Submit(sub, "Alice#1234");
@@ -52,11 +53,11 @@ public class PlayerMatchTelemetryEndToEndTests : IntegrationTestBase
         var p = doc.Players[0];
         Assert.That(p.BattleTag, Is.EqualTo("Alice#1234"));
         Assert.That(p.BucketCount, Is.EqualTo(3));
-        // BinData envelopes: base64 strings whose decoded length matches the
-        // little-endian byte counts (3 × uint32 = 12, 3 × uint16 = 6, 3 × uint8 = 3).
-        Assert.That(Convert.FromBase64String(p.GameTimeOffsetsMs.Binary.Base64).Length, Is.EqualTo(12));
-        Assert.That(Convert.FromBase64String(p.MeansMs.Binary.Base64).Length, Is.EqualTo(6));
-        Assert.That(p.SampleCounts.Binary.Base64, Is.EqualTo(Convert.ToBase64String(new byte[] { 5, 7, 6 })));
+        // Plain arrays decoded on the backend — the response DTO no longer
+        // ships MongoDB Extended JSON BinData envelopes.
+        Assert.That(p.GameTimeOffsetsMs, Is.EqualTo(new uint[] { 0, 1000, 2000 }));
+        Assert.That(p.MeansMs, Is.EqualTo(new ushort[] { 30, 42, 38 }));
+        Assert.That(p.SampleCounts, Is.EqualTo(new byte[] { 5, 7, 6 }));
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryJsonBindingTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryJsonBindingTests.cs
@@ -2,61 +2,58 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using NUnit.Framework;
+using W3ChampionsStatisticService.LagReports;
 using W3ChampionsStatisticService.PlayerMatchTelemetry;
 
 namespace WC3ChampionsStatisticService.Tests.PlayerMatchTelemetry;
 
-// Regression: launcher-e sends snake_case JSON (Rust serde default). ASP.NET
-// Core's System.Text.Json defaults (JsonSerializerDefaults.Web) only fold
-// PascalCase/camelCase property names — snake_case fields would silently
-// deserialize to zero/null and trip [Range(1, …)] on GameId. Confirms every
-// property on the submission DTO graph has a [JsonPropertyName] mapping.
+// Regression: launcher-e now sends camelCase JSON (Rust serde with
+// #[serde(rename_all = "camelCase")]). ASP.NET Core's
+// JsonSerializerDefaults.Web (used by [FromBody]) folds PascalCase C#
+// property names ↔ camelCase wire keys automatically — no
+// [JsonPropertyName] attributes required on the submission DTO graph.
 [TestFixture]
 public class PlayerMatchTelemetryJsonBindingTests
 {
     // Mirrors the JsonSerializerOptions ASP.NET Core 8 uses for [FromBody] binding.
     private static readonly JsonSerializerOptions WebDefaults = new(JsonSerializerDefaults.Web);
 
-    private const string SnakeCasePayload = """
+    private const string CamelCasePayload = """
     {
-      "game_id": 12345,
-      "bucket_ms": 1000,
-      "match_wall_start": "2026-05-21T12:00:00Z",
-      "game_length_ms": 600000,
-      "crashed": false,
-      "connection_type": "QUIC",
-      "disconnects": { "count": 0, "total_duration_ms": 0, "mean_duration_ms": 0 },
-      "action_latency_aggregate": {
-        "sample_count": 100, "p10_ms": 20, "p50_ms": 40,
-        "p99_ms": 200, "p999_ms": 400, "mean_ms": 60, "stddev_ms": 30
+      "gameId": 12345,
+      "matchWallStart": "2026-05-21T12:00:00Z",
+      "gameLengthMs": 600000,
+      "crashedAt": null,
+      "connectionType": "QUIC",
+      "disconnectEvents": [],
+      "actionLatencyAggregate": {
+        "sampleCount": 100, "p10Ms": 20, "p50Ms": 40,
+        "p99Ms": 200, "p999Ms": 400, "meanMs": 60, "stddevMs": 30
       },
-      "action_latency_timeseries": {
-        "game_time_offsets_ms": [0, 1000, 2000],
-        "means_ms": [30, 42, 38],
-        "sample_counts": [5, 7, 6]
+      "actionLatencyTimeseries": {
+        "gameTimeOffsetsMs": [0, 1000, 2000],
+        "meansMs": [30, 42, 38],
+        "sampleCounts": [5, 7, 6]
       },
-      "dropped_unmatched_count": 0
+      "droppedUnmatchedCount": 0
     }
     """;
 
     [Test]
-    public void Snake_case_json_deserializes_into_submission_dto()
+    public void CamelCase_json_deserializes_into_submission_dto()
     {
-        var dto = JsonSerializer.Deserialize<PlayerMatchTelemetrySubmissionDto>(SnakeCasePayload, WebDefaults);
+        var dto = JsonSerializer.Deserialize<PlayerMatchTelemetrySubmissionDto>(CamelCasePayload, WebDefaults);
 
         Assert.That(dto, Is.Not.Null);
         Assert.That(dto!.GameId, Is.EqualTo(12345L));
-        Assert.That(dto.BucketMs, Is.EqualTo(1000));
         Assert.That(dto.MatchWallStart.Year, Is.EqualTo(2026));
         Assert.That(dto.GameLengthMs, Is.EqualTo(600_000u));
-        Assert.That(dto.Crashed, Is.False);
-        Assert.That(dto.ConnectionType, Is.EqualTo("QUIC"));
+        Assert.That(dto.CrashedAt, Is.Null);
+        Assert.That(dto.ConnectionType, Is.EqualTo(Transport.QUIC));
         Assert.That(dto.DroppedUnmatchedCount, Is.EqualTo(0u));
 
-        Assert.That(dto.Disconnects, Is.Not.Null);
-        Assert.That(dto.Disconnects.Count, Is.EqualTo(0u));
-        Assert.That(dto.Disconnects.TotalDurationMs, Is.EqualTo(0u));
-        Assert.That(dto.Disconnects.MeanDurationMs, Is.EqualTo(0u));
+        Assert.That(dto.DisconnectEvents, Is.Not.Null);
+        Assert.That(dto.DisconnectEvents, Is.Empty);
 
         Assert.That(dto.ActionLatencyAggregate, Is.Not.Null);
         Assert.That(dto.ActionLatencyAggregate.SampleCount, Is.EqualTo(100u));
@@ -74,6 +71,43 @@ public class PlayerMatchTelemetryJsonBindingTests
     }
 
     [Test]
+    public void Disconnect_events_deserialize_into_typed_records()
+    {
+        const string payload = """
+        {
+          "gameId": 1,
+          "matchWallStart": "2026-05-21T12:00:00Z",
+          "gameLengthMs": 600000,
+          "crashedAt": "2026-05-21T12:05:00Z",
+          "connectionType": "TCP",
+          "disconnectEvents": [
+            { "startedAt": "2026-05-21T12:03:00Z", "durationMs": 4500 },
+            { "startedAt": "2026-05-21T12:04:00Z", "durationMs": 2100 }
+          ],
+          "actionLatencyAggregate": {
+            "sampleCount": 100, "p10Ms": 20, "p50Ms": 40,
+            "p99Ms": 200, "p999Ms": 400, "meanMs": 60, "stddevMs": 30
+          },
+          "actionLatencyTimeseries": {
+            "gameTimeOffsetsMs": [0],
+            "meansMs": [30],
+            "sampleCounts": [5]
+          },
+          "droppedUnmatchedCount": 0
+        }
+        """;
+
+        var dto = JsonSerializer.Deserialize<PlayerMatchTelemetrySubmissionDto>(payload, WebDefaults);
+
+        Assert.That(dto, Is.Not.Null);
+        Assert.That(dto!.CrashedAt, Is.Not.Null);
+        Assert.That(dto.CrashedAt!.Value.Year, Is.EqualTo(2026));
+        Assert.That(dto.DisconnectEvents.Count, Is.EqualTo(2));
+        Assert.That(dto.DisconnectEvents[0].DurationMs, Is.EqualTo(4500u));
+        Assert.That(dto.DisconnectEvents[1].DurationMs, Is.EqualTo(2100u));
+    }
+
+    [Test]
     public void Sample_counts_writes_as_number_array_not_base64()
     {
         var dto = new ActionLatencyTimeseriesDto(
@@ -84,7 +118,7 @@ public class PlayerMatchTelemetryJsonBindingTests
         var json = JsonSerializer.Serialize(dto, WebDefaults);
 
         // Must serialize as JSON array of numbers, never as base64 ("BQcG"==[5,7,6]).
-        Assert.That(json, Does.Contain("\"sample_counts\":[5,7,6]"));
+        Assert.That(json, Does.Contain("\"sampleCounts\":[5,7,6]"));
         Assert.That(json, Does.Not.Contain("BQcG"));
     }
 
@@ -93,9 +127,9 @@ public class PlayerMatchTelemetryJsonBindingTests
     {
         const string bad = """
         {
-          "game_time_offsets_ms": [0],
-          "means_ms": [30],
-          "sample_counts": [300]
+          "gameTimeOffsetsMs": [0],
+          "meansMs": [30],
+          "sampleCounts": [300]
         }
         """;
         Assert.Throws<JsonException>(() =>
@@ -103,15 +137,14 @@ public class PlayerMatchTelemetryJsonBindingTests
     }
 
     [Test]
-    public void Response_dto_serializes_with_camelcase_outer_and_bindata_inner_shape()
+    public void Response_dto_serializes_with_camelcase_outer_and_plain_arrays()
     {
-        // Regression for the GET /api/player-match-telemetry/by-game/{gameId} 500-error
-        // bug: the raw domain model has BsonBinaryData fields that System.Text.Json
-        // cannot serialize. The response DTO must emit MongoDB Extended JSON v2
-        // envelopes — { "$binary": { "base64": "...", "subType": "00" } } — so the
-        // website's IBinData decoder can parse them.
+        // The GET /api/player-match-telemetry/by-game/{gameId} response uses
+        // plain JSON number arrays (uint[]/ushort[]/byte[]) instead of MongoDB
+        // Extended JSON BinData envelopes. The frontend consumes ordinary arrays
+        // directly — no Base64 decode step required.
         //
-        // Additionally, the outer/entry property names must serialize as camelCase
+        // The outer/entry property names must serialize as camelCase
         // (battleTag, gameId, sampleCounts, …) so the website's TypeScript
         // IPlayerMatchTelemetry interface (src/store/admin/playerMatchTelemetry/types.ts)
         // can consume the response via a typed cast. ASP.NET Core's HTTP pipeline
@@ -120,23 +153,19 @@ public class PlayerMatchTelemetryJsonBindingTests
         var dto = new PlayerMatchTelemetryResponseDto(
             GameId: 1L,
             MatchWallStart: DateTime.UtcNow,
-            BucketMs: 1000,
             Players: new List<PlayerMatchTelemetryEntryResponseDto>
             {
                 new(
                     BattleTag: "Alice#1234",
-                    FloPlayerId: null,
-                    ConnectionType: "QUIC",
-                    ServerNodeId: null,
-                    ServerNodeName: null,
+                    ConnectionType: Transport.QUIC,
                     GameLengthMs: 100,
-                    Crashed: false,
-                    Disconnects: new DisconnectsResponseDto(0, 0, 0),
-                    ActionLatencyAggregate: new ActionLatencyAggregateResponseDto(1, 1, 1, 1, 1, 1, 1),
+                    CrashedAt: null,
+                    DisconnectEvents: new List<DisconnectEvent>(),
+                    ActionLatencyAggregate: new ActionLatencyAggregate { SampleCount = 1, P10Ms = 1, P50Ms = 1, P99Ms = 1, P999Ms = 1, MeanMs = 1, StddevMs = 1 },
                     BucketCount: 1,
-                    GameTimeOffsetsMs: new BinDataEnvelopeDto(new BinDataPayloadDto(Convert.ToBase64String(new byte[] { 0, 0, 0, 0 }), "00")),
-                    MeansMs: new BinDataEnvelopeDto(new BinDataPayloadDto(Convert.ToBase64String(new byte[] { 5, 0 }), "00")),
-                    SampleCounts: new BinDataEnvelopeDto(new BinDataPayloadDto(Convert.ToBase64String(new byte[] { 1 }), "00")),
+                    GameTimeOffsetsMs: new uint[] { 0 },
+                    MeansMs: new ushort[] { 5 },
+                    SampleCounts: new byte[] { 1 },
                     DroppedUnmatchedCount: 0,
                     SubmittedAt: DateTime.UtcNow
                 )
@@ -150,29 +179,28 @@ public class PlayerMatchTelemetryJsonBindingTests
         // camelCase outer wire shape (matches website's IPlayerMatchTelemetry types).
         Assert.That(json, Does.Contain("\"gameId\":1"));
         Assert.That(json, Does.Contain("\"battleTag\":\"Alice#1234\""));
-        Assert.That(json, Does.Contain("\"bucketMs\":1000"));
         Assert.That(json, Does.Contain("\"bucketCount\":1"));
-        Assert.That(json, Does.Contain("\"gameTimeOffsetsMs\":{\"$binary\":"));
-        Assert.That(json, Does.Contain("\"meansMs\":{\"$binary\":"));
-        Assert.That(json, Does.Contain("\"sampleCounts\":{\"$binary\":"));
+        Assert.That(json, Does.Contain("\"gameTimeOffsetsMs\":[0]"));
+        Assert.That(json, Does.Contain("\"meansMs\":[5]"));
+        Assert.That(json, Does.Contain("\"sampleCounts\":[1]"));
         Assert.That(json, Does.Contain("\"droppedUnmatchedCount\":0"));
+        Assert.That(json, Does.Contain("\"connectionType\":\"QUIC\""));
 
-        // Nested aggregates also camelCase (separate response-side records, no snake_case attrs).
-        Assert.That(json, Does.Contain("\"totalDurationMs\":0"));
+        // Nested aggregates also camelCase.
         Assert.That(json, Does.Contain("\"sampleCount\":1"));
         Assert.That(json, Does.Contain("\"p999Ms\":1"));
 
-        // BinData inner literal keys ($binary, base64, subType) are NOT camelCase-derived
-        // and must remain exactly as MongoDB Extended JSON v2 specifies.
-        Assert.That(json, Does.Contain("\"$binary\":{\"base64\":"),
-            "BinData envelopes must serialize with $binary wrapper and literal base64 key");
-        Assert.That(json, Does.Contain("\"subType\":\"00\""));
+        // No BinData envelope leakage on the response wire shape.
+        Assert.That(json, Does.Not.Contain("$binary"));
+        Assert.That(json, Does.Not.Contain("\"base64\""));
 
-        // Negative assertions: no snake_case leakage on the response wire shape.
+        // No snake_case leakage.
         Assert.That(json, Does.Not.Contain("\"battle_tag\""));
         Assert.That(json, Does.Not.Contain("\"game_id\""));
         Assert.That(json, Does.Not.Contain("\"sample_counts\""));
-        Assert.That(json, Does.Not.Contain("\"total_duration_ms\""));
         Assert.That(json, Does.Not.Contain("\"p999_ms\""));
+
+        // BucketMs is dropped from the wire (hardcoded to 1 s flo-side).
+        Assert.That(json, Does.Not.Contain("\"bucketMs\""));
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryJsonBindingTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryJsonBindingTests.cs
@@ -1,0 +1,102 @@
+using System.Text.Json;
+using NUnit.Framework;
+using W3ChampionsStatisticService.PlayerMatchTelemetry;
+
+namespace WC3ChampionsStatisticService.Tests.PlayerMatchTelemetry;
+
+// Regression: launcher-e sends snake_case JSON (Rust serde default). ASP.NET
+// Core's System.Text.Json defaults (JsonSerializerDefaults.Web) only fold
+// PascalCase/camelCase property names — snake_case fields would silently
+// deserialize to zero/null and trip [Range(1, …)] on GameId. Confirms every
+// property on the submission DTO graph has a [JsonPropertyName] mapping.
+[TestFixture]
+public class PlayerMatchTelemetryJsonBindingTests
+{
+    // Mirrors the JsonSerializerOptions ASP.NET Core 8 uses for [FromBody] binding.
+    private static readonly JsonSerializerOptions WebDefaults = new(JsonSerializerDefaults.Web);
+
+    private const string SnakeCasePayload = """
+    {
+      "game_id": 12345,
+      "bucket_ms": 1000,
+      "match_wall_start": "2026-05-21T12:00:00Z",
+      "game_length_ms": 600000,
+      "crashed": false,
+      "connection_type": "QUIC",
+      "disconnects": { "count": 0, "total_duration_ms": 0, "mean_duration_ms": 0 },
+      "action_latency_aggregate": {
+        "sample_count": 100, "p10_ms": 20, "p50_ms": 40,
+        "p99_ms": 200, "p999_ms": 400, "mean_ms": 60, "stddev_ms": 30
+      },
+      "action_latency_timeseries": {
+        "game_time_offsets_ms": [0, 1000, 2000],
+        "means_ms": [30, 42, 38],
+        "sample_counts": [5, 7, 6]
+      },
+      "dropped_unmatched_count": 0
+    }
+    """;
+
+    [Test]
+    public void Snake_case_json_deserializes_into_submission_dto()
+    {
+        var dto = JsonSerializer.Deserialize<PlayerMatchTelemetrySubmissionDto>(SnakeCasePayload, WebDefaults);
+
+        Assert.That(dto, Is.Not.Null);
+        Assert.That(dto!.GameId, Is.EqualTo(12345L));
+        Assert.That(dto.BucketMs, Is.EqualTo(1000));
+        Assert.That(dto.MatchWallStart.Year, Is.EqualTo(2026));
+        Assert.That(dto.GameLengthMs, Is.EqualTo(600_000u));
+        Assert.That(dto.Crashed, Is.False);
+        Assert.That(dto.ConnectionType, Is.EqualTo("QUIC"));
+        Assert.That(dto.DroppedUnmatchedCount, Is.EqualTo(0u));
+
+        Assert.That(dto.Disconnects, Is.Not.Null);
+        Assert.That(dto.Disconnects.Count, Is.EqualTo(0u));
+        Assert.That(dto.Disconnects.TotalDurationMs, Is.EqualTo(0u));
+        Assert.That(dto.Disconnects.MeanDurationMs, Is.EqualTo(0u));
+
+        Assert.That(dto.ActionLatencyAggregate, Is.Not.Null);
+        Assert.That(dto.ActionLatencyAggregate.SampleCount, Is.EqualTo(100u));
+        Assert.That(dto.ActionLatencyAggregate.P10Ms, Is.EqualTo((ushort)20));
+        Assert.That(dto.ActionLatencyAggregate.P50Ms, Is.EqualTo((ushort)40));
+        Assert.That(dto.ActionLatencyAggregate.P99Ms, Is.EqualTo((ushort)200));
+        Assert.That(dto.ActionLatencyAggregate.P999Ms, Is.EqualTo((ushort)400));
+        Assert.That(dto.ActionLatencyAggregate.MeanMs, Is.EqualTo((ushort)60));
+        Assert.That(dto.ActionLatencyAggregate.StddevMs, Is.EqualTo((ushort)30));
+
+        Assert.That(dto.ActionLatencyTimeseries, Is.Not.Null);
+        Assert.That(dto.ActionLatencyTimeseries.GameTimeOffsetsMs, Is.EqualTo(new uint[] { 0, 1000, 2000 }));
+        Assert.That(dto.ActionLatencyTimeseries.MeansMs, Is.EqualTo(new ushort[] { 30, 42, 38 }));
+        Assert.That(dto.ActionLatencyTimeseries.SampleCounts, Is.EqualTo(new byte[] { 5, 7, 6 }));
+    }
+
+    [Test]
+    public void Sample_counts_writes_as_number_array_not_base64()
+    {
+        var dto = new ActionLatencyTimeseriesDto(
+            GameTimeOffsetsMs: new uint[] { 0, 1000 },
+            MeansMs: new ushort[] { 30, 42 },
+            SampleCounts: new byte[] { 5, 7, 6 });
+
+        var json = JsonSerializer.Serialize(dto, WebDefaults);
+
+        // Must serialize as JSON array of numbers, never as base64 ("BQcG"==[5,7,6]).
+        Assert.That(json, Does.Contain("\"sample_counts\":[5,7,6]"));
+        Assert.That(json, Does.Not.Contain("BQcG"));
+    }
+
+    [Test]
+    public void Sample_counts_rejects_out_of_range_byte_values()
+    {
+        const string bad = """
+        {
+          "game_time_offsets_ms": [0],
+          "means_ms": [30],
+          "sample_counts": [300]
+        }
+        """;
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<ActionLatencyTimeseriesDto>(bad, WebDefaults));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryJsonBindingTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryJsonBindingTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using NUnit.Framework;
 using W3ChampionsStatisticService.PlayerMatchTelemetry;
@@ -98,5 +100,47 @@ public class PlayerMatchTelemetryJsonBindingTests
         """;
         Assert.Throws<JsonException>(() =>
             JsonSerializer.Deserialize<ActionLatencyTimeseriesDto>(bad, WebDefaults));
+    }
+
+    [Test]
+    public void Response_dto_serializes_with_extended_json_v2_bindata_shape()
+    {
+        // Regression for the GET /api/player-match-telemetry/by-game/{gameId} 500-error
+        // bug: the raw domain model has BsonBinaryData fields that System.Text.Json
+        // cannot serialize. The response DTO must emit MongoDB Extended JSON v2
+        // envelopes — { "$binary": { "base64": "...", "subType": "00" } } — so the
+        // website's IBinData decoder can parse them.
+        var dto = new PlayerMatchTelemetryResponseDto(
+            GameId: 1L,
+            MatchWallStart: DateTime.UtcNow,
+            BucketMs: 1000,
+            Players: new List<PlayerMatchTelemetryEntryResponseDto>
+            {
+                new(
+                    BattleTag: "Alice#1234",
+                    FloPlayerId: null,
+                    ConnectionType: "QUIC",
+                    ServerNodeId: null,
+                    ServerNodeName: null,
+                    GameLengthMs: 100,
+                    Crashed: false,
+                    Disconnects: new DisconnectsDto(0, 0, 0),
+                    ActionLatencyAggregate: new ActionLatencyAggregateDto(1, 1, 1, 1, 1, 1, 1),
+                    BucketCount: 1,
+                    GameTimeOffsetsMs: new BinDataEnvelopeDto(new BinDataPayloadDto(Convert.ToBase64String(new byte[] { 0, 0, 0, 0 }), "00")),
+                    MeansMs: new BinDataEnvelopeDto(new BinDataPayloadDto(Convert.ToBase64String(new byte[] { 5, 0 }), "00")),
+                    SampleCounts: new BinDataEnvelopeDto(new BinDataPayloadDto(Convert.ToBase64String(new byte[] { 1 }), "00")),
+                    DroppedUnmatchedCount: 0,
+                    SubmittedAt: DateTime.UtcNow
+                )
+            },
+            CreatedAt: DateTime.UtcNow,
+            ExpiresAt: DateTime.UtcNow.AddDays(90)
+        );
+
+        var json = JsonSerializer.Serialize(dto);
+        Assert.That(json, Does.Contain("\"$binary\":{\"base64\":"), "BinData envelopes must serialize with $binary wrapper");
+        Assert.That(json, Does.Contain("\"sample_counts\":{\"$binary\":"), "sample_counts is on the entry, not nested");
+        Assert.That(json, Does.Contain("\"game_id\":1"));
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryJsonBindingTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryJsonBindingTests.cs
@@ -103,13 +103,20 @@ public class PlayerMatchTelemetryJsonBindingTests
     }
 
     [Test]
-    public void Response_dto_serializes_with_extended_json_v2_bindata_shape()
+    public void Response_dto_serializes_with_camelcase_outer_and_bindata_inner_shape()
     {
         // Regression for the GET /api/player-match-telemetry/by-game/{gameId} 500-error
         // bug: the raw domain model has BsonBinaryData fields that System.Text.Json
         // cannot serialize. The response DTO must emit MongoDB Extended JSON v2
         // envelopes — { "$binary": { "base64": "...", "subType": "00" } } — so the
         // website's IBinData decoder can parse them.
+        //
+        // Additionally, the outer/entry property names must serialize as camelCase
+        // (battleTag, gameId, sampleCounts, …) so the website's TypeScript
+        // IPlayerMatchTelemetry interface (src/store/admin/playerMatchTelemetry/types.ts)
+        // can consume the response via a typed cast. ASP.NET Core's HTTP pipeline
+        // applies PropertyNamingPolicy = CamelCase by default — we replicate that
+        // here via WebDefaults so the assertion matches the real wire shape.
         var dto = new PlayerMatchTelemetryResponseDto(
             GameId: 1L,
             MatchWallStart: DateTime.UtcNow,
@@ -124,8 +131,8 @@ public class PlayerMatchTelemetryJsonBindingTests
                     ServerNodeName: null,
                     GameLengthMs: 100,
                     Crashed: false,
-                    Disconnects: new DisconnectsDto(0, 0, 0),
-                    ActionLatencyAggregate: new ActionLatencyAggregateDto(1, 1, 1, 1, 1, 1, 1),
+                    Disconnects: new DisconnectsResponseDto(0, 0, 0),
+                    ActionLatencyAggregate: new ActionLatencyAggregateResponseDto(1, 1, 1, 1, 1, 1, 1),
                     BucketCount: 1,
                     GameTimeOffsetsMs: new BinDataEnvelopeDto(new BinDataPayloadDto(Convert.ToBase64String(new byte[] { 0, 0, 0, 0 }), "00")),
                     MeansMs: new BinDataEnvelopeDto(new BinDataPayloadDto(Convert.ToBase64String(new byte[] { 5, 0 }), "00")),
@@ -138,9 +145,34 @@ public class PlayerMatchTelemetryJsonBindingTests
             ExpiresAt: DateTime.UtcNow.AddDays(90)
         );
 
-        var json = JsonSerializer.Serialize(dto);
-        Assert.That(json, Does.Contain("\"$binary\":{\"base64\":"), "BinData envelopes must serialize with $binary wrapper");
-        Assert.That(json, Does.Contain("\"sample_counts\":{\"$binary\":"), "sample_counts is on the entry, not nested");
-        Assert.That(json, Does.Contain("\"game_id\":1"));
+        var json = JsonSerializer.Serialize(dto, WebDefaults);
+
+        // camelCase outer wire shape (matches website's IPlayerMatchTelemetry types).
+        Assert.That(json, Does.Contain("\"gameId\":1"));
+        Assert.That(json, Does.Contain("\"battleTag\":\"Alice#1234\""));
+        Assert.That(json, Does.Contain("\"bucketMs\":1000"));
+        Assert.That(json, Does.Contain("\"bucketCount\":1"));
+        Assert.That(json, Does.Contain("\"gameTimeOffsetsMs\":{\"$binary\":"));
+        Assert.That(json, Does.Contain("\"meansMs\":{\"$binary\":"));
+        Assert.That(json, Does.Contain("\"sampleCounts\":{\"$binary\":"));
+        Assert.That(json, Does.Contain("\"droppedUnmatchedCount\":0"));
+
+        // Nested aggregates also camelCase (separate response-side records, no snake_case attrs).
+        Assert.That(json, Does.Contain("\"totalDurationMs\":0"));
+        Assert.That(json, Does.Contain("\"sampleCount\":1"));
+        Assert.That(json, Does.Contain("\"p999Ms\":1"));
+
+        // BinData inner literal keys ($binary, base64, subType) are NOT camelCase-derived
+        // and must remain exactly as MongoDB Extended JSON v2 specifies.
+        Assert.That(json, Does.Contain("\"$binary\":{\"base64\":"),
+            "BinData envelopes must serialize with $binary wrapper and literal base64 key");
+        Assert.That(json, Does.Contain("\"subType\":\"00\""));
+
+        // Negative assertions: no snake_case leakage on the response wire shape.
+        Assert.That(json, Does.Not.Contain("\"battle_tag\""));
+        Assert.That(json, Does.Not.Contain("\"game_id\""));
+        Assert.That(json, Does.Not.Contain("\"sample_counts\""));
+        Assert.That(json, Does.Not.Contain("\"total_duration_ms\""));
+        Assert.That(json, Does.Not.Contain("\"p999_ms\""));
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryRepositoryTests.cs
@@ -91,7 +91,7 @@ public class PlayerMatchTelemetryRepositoryTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task EnsureIndexes_creates_ttl_and_lookup()
+    public async Task EnsureIndexes_creates_ttl_lookup_and_recency()
     {
         await _repo.EnsureIndexesAsync();
 
@@ -117,6 +117,11 @@ public class PlayerMatchTelemetryRepositoryTests : IntegrationTestBase
             }),
             Is.True,
             "Players.BattleTag lookup index missing — got: " + indexDump);
+
+        Assert.That(
+            indexes.Any(i => i.GetValue("name", BsonString.Empty).AsString == "CreatedAt_recency"),
+            Is.True,
+            "CreatedAt recency index missing — got: " + indexDump);
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryRepositoryTests.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using NUnit.Framework;
+using W3ChampionsStatisticService.LagReports;
 using W3ChampionsStatisticService.PlayerMatchTelemetry;
 using PlayerMatchTelemetryDoc = W3ChampionsStatisticService.PlayerMatchTelemetry.PlayerMatchTelemetry;
 
@@ -26,10 +28,10 @@ public class PlayerMatchTelemetryRepositoryTests : IntegrationTestBase
     private static PlayerMatchTelemetryEntry MakeEntry(string battleTag) => new()
     {
         BattleTag = battleTag,
-        ConnectionType = "QUIC",
+        ConnectionType = Transport.QUIC,
         GameLengthMs = 600_000,
-        Crashed = false,
-        Disconnects = new DisconnectStats(),
+        CrashedAt = null,
+        DisconnectEvents = new List<DisconnectEvent>(),
         ActionLatencyAggregate = new ActionLatencyAggregate { SampleCount = 100, P50Ms = 42 },
         BucketCount = 3,
         GameTimeOffsetsMs = new BsonBinaryData(new byte[12]),
@@ -42,7 +44,7 @@ public class PlayerMatchTelemetryRepositoryTests : IntegrationTestBase
     public async Task Upsert_then_get_round_trips()
     {
         var gameId = 7777L;
-        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow, 1000,
+        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow,
             MakeEntry("Alice#1234"), TimeSpan.FromDays(90));
 
         var doc = await _repo.GetByGameIdAsync(gameId);
@@ -56,9 +58,9 @@ public class PlayerMatchTelemetryRepositoryTests : IntegrationTestBase
     public async Task Two_players_same_game_id_produce_one_doc_with_two_entries()
     {
         var gameId = 7778L;
-        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow, 1000,
+        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow,
             MakeEntry("Alice#1234"), TimeSpan.FromDays(90));
-        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow, 1000,
+        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow,
             MakeEntry("Bob#5678"), TimeSpan.FromDays(90));
 
         var doc = await _repo.GetByGameIdAsync(gameId);
@@ -75,11 +77,11 @@ public class PlayerMatchTelemetryRepositoryTests : IntegrationTestBase
 
         var entry1 = MakeEntry("Alice#1234");
         entry1.ActionLatencyAggregate.P50Ms = 42;
-        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow, 1000, entry1, TimeSpan.FromDays(90));
+        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow, entry1, TimeSpan.FromDays(90));
 
         var entry2 = MakeEntry("Alice#1234");
         entry2.ActionLatencyAggregate.P50Ms = 99;
-        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow, 1000, entry2, TimeSpan.FromDays(90));
+        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow, entry2, TimeSpan.FromDays(90));
 
         var doc = await _repo.GetByGameIdAsync(gameId);
 

--- a/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerMatchTelemetry/PlayerMatchTelemetryRepositoryTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using NUnit.Framework;
+using W3ChampionsStatisticService.PlayerMatchTelemetry;
+using PlayerMatchTelemetryDoc = W3ChampionsStatisticService.PlayerMatchTelemetry.PlayerMatchTelemetry;
+
+namespace WC3ChampionsStatisticService.Tests.PlayerMatchTelemetry;
+
+[TestFixture]
+public class PlayerMatchTelemetryRepositoryTests : IntegrationTestBase
+{
+    // MongoDbRepositoryBase hardcodes this database name.
+    private const string DatabaseName = "W3Champions-Statistic-Service";
+
+    private PlayerMatchTelemetryRepository _repo;
+
+    [SetUp]
+    public void SetUpRepo()
+    {
+        _repo = new PlayerMatchTelemetryRepository(MongoClient);
+    }
+
+    private static PlayerMatchTelemetryEntry MakeEntry(string battleTag) => new()
+    {
+        BattleTag = battleTag,
+        ConnectionType = "QUIC",
+        GameLengthMs = 600_000,
+        Crashed = false,
+        Disconnects = new DisconnectStats(),
+        ActionLatencyAggregate = new ActionLatencyAggregate { SampleCount = 100, P50Ms = 42 },
+        BucketCount = 3,
+        GameTimeOffsetsMs = new BsonBinaryData(new byte[12]),
+        MeansMs = new BsonBinaryData(new byte[6]),
+        SampleCounts = new BsonBinaryData(new byte[3]),
+        SubmittedAt = DateTime.UtcNow,
+    };
+
+    [Test]
+    public async Task Upsert_then_get_round_trips()
+    {
+        var gameId = 7777L;
+        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow, 1000,
+            MakeEntry("Alice#1234"), TimeSpan.FromDays(90));
+
+        var doc = await _repo.GetByGameIdAsync(gameId);
+
+        Assert.That(doc, Is.Not.Null);
+        Assert.That(doc!.Players.Count, Is.EqualTo(1));
+        Assert.That(doc.Players[0].BattleTag, Is.EqualTo("Alice#1234"));
+    }
+
+    [Test]
+    public async Task Two_players_same_game_id_produce_one_doc_with_two_entries()
+    {
+        var gameId = 7778L;
+        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow, 1000,
+            MakeEntry("Alice#1234"), TimeSpan.FromDays(90));
+        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow, 1000,
+            MakeEntry("Bob#5678"), TimeSpan.FromDays(90));
+
+        var doc = await _repo.GetByGameIdAsync(gameId);
+
+        Assert.That(doc, Is.Not.Null);
+        Assert.That(doc!.Players.Count, Is.EqualTo(2));
+        Assert.That(doc.Players.Select(p => p.BattleTag), Is.EquivalentTo(new[] { "Alice#1234", "Bob#5678" }));
+    }
+
+    [Test]
+    public async Task Resubmit_same_battletag_replaces_entry()
+    {
+        var gameId = 7779L;
+
+        var entry1 = MakeEntry("Alice#1234");
+        entry1.ActionLatencyAggregate.P50Ms = 42;
+        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow, 1000, entry1, TimeSpan.FromDays(90));
+
+        var entry2 = MakeEntry("Alice#1234");
+        entry2.ActionLatencyAggregate.P50Ms = 99;
+        await _repo.UpsertPlayerEntryAsync(gameId, DateTime.UtcNow, 1000, entry2, TimeSpan.FromDays(90));
+
+        var doc = await _repo.GetByGameIdAsync(gameId);
+
+        Assert.That(doc, Is.Not.Null);
+        Assert.That(doc!.Players.Count, Is.EqualTo(1));
+        Assert.That(doc.Players[0].ActionLatencyAggregate.P50Ms, Is.EqualTo(99));
+    }
+
+    [Test]
+    public async Task EnsureIndexes_creates_ttl_and_lookup()
+    {
+        await _repo.EnsureIndexesAsync();
+
+        // Note: `nameof(PlayerMatchTelemetryDoc)` would return the alias identifier,
+        // not the underlying type name — use `typeof(...).Name` to get the actual
+        // collection name MongoDbRepositoryBase uses.
+        var coll = MongoClient
+            .GetDatabase(DatabaseName)
+            .GetCollection<PlayerMatchTelemetryDoc>(typeof(PlayerMatchTelemetryDoc).Name);
+        var indexes = await (await coll.Indexes.ListAsync()).ToListAsync();
+        var indexDump = $"count={indexes.Count}; " + string.Join(" | ", indexes.Select(i => i.ToJson()));
+
+        Assert.That(
+            indexes.Any(i => i.Contains("expireAfterSeconds")),
+            Is.True,
+            "TTL index missing — got: " + indexDump);
+
+        Assert.That(
+            indexes.Any(i =>
+            {
+                var name = i.GetValue("name", BsonString.Empty).AsString;
+                return name.Contains("BattleTag");
+            }),
+            Is.True,
+            "Players.BattleTag lookup index missing — got: " + indexDump);
+    }
+
+    [Test]
+    public async Task EnsureIndexes_is_idempotent()
+    {
+        await _repo.EnsureIndexesAsync();
+        // Identical key + options must be a no-op on the second call.
+        Assert.DoesNotThrowAsync(async () => await _repo.EnsureIndexesAsync());
+    }
+}


### PR DESCRIPTION
## Summary

Always-on per-player per-match telemetry endpoint that receives `PlayerMatchTelemetryReport` from launcher-e, persists it in a new MongoDB collection with a 90-day TTL, and exposes it via an admin-only `by-game/{gameId}` GET. Also extends the existing `LagReport.ConnectionTopology` with a `Transport` enum field so transport-quality comparisons (legacy TCP vs experimental QUIC) work alongside the existing lag-report flow.

- `POST /api/player-match-telemetry` — authenticated via `[InjectActingPlayerAuthCode]`. Validates DTO; upserts per-player entries into one document keyed by `_id == GameId`. **Atomic** via single `UpdateOneAsync` with an aggregation-pipeline `$set` stage (uses `$ifNull` for the once-only top-level fields and `$cond + $map / $concatArrays` for the players-array replace-or-append). One round-trip, no race.
- `GET /api/player-match-telemetry/by-game/{gameId}` — gated on `EPermission.Proxies` (same admin permission used by lag-reports endpoints). Returns the document projected to a response DTO with **plain typed arrays** (`uint[]`, `ushort[]`, `byte[]`) — backend decodes BinData server-side, frontend no longer needs a decoder.
- New `PlayerMatchTelemetry` MongoDB collection: TTL index on `ExpiresAt` (`ExpireAfter = TimeSpan.Zero`) + secondary `{Players.BattleTag: 1, MatchWallStart: -1}` lookup index for future "player history" queries. Registered via `IRequiresIndexes` so `MongoIndexInitializationService` creates the indexes at startup.
- Packed BinData arrays in storage (timeseries stays compact at rest): `uint32[]` game-time offsets, `uint16[]` means, `uint8[]` sample counts. Decoded into plain JSON arrays only at response time. Yields ~6 GB hot storage at 90-day retention on production scale (~7.4 M player-games/year).
- `Transport` enum (`{ TCP, QUIC }`) shared by both `LagReport.ConnectionTopology.Transport` and `PlayerMatchTelemetry.ConnectionType`. Lives in `LagReports/LagReportEnums.cs` with `[JsonConverter(typeof(JsonStringEnumConverter))]`. Replaces the previous regex-validated string fields. Default `TCP` on `ConnectionTopologyDto.Transport` keeps pre-Wave-C launcher-e submissions valid.
- Per-event disconnects: `List<DisconnectEvent> DisconnectEvents` (each event has `StartedAt` + `DurationMs`) replaces the previous aggregated `DisconnectStats`. Consumers compute count / total / max as needed.
- `CrashedAt: DateTime?` replaces `Crashed: bool` — captures the timestamp of the crash, consumers get "did it crash?" via `CrashedAt != null`.

## Wire shape (camelCase, plain arrays)

Receives from launcher-e (camelCase, plain `byte[]` sample counts via a custom `ByteArrayAsJsonNumberArrayConverter`):
```json
{
  "gameId": 12345,
  "matchWallStart": "2026-05-22T12:00:00Z",
  "gameLengthMs": 600000,
  "crashedAt": null,
  "connectionType": "QUIC",
  "disconnectEvents": [],
  "actionLatencyAggregate": { "sampleCount": 100, "p10Ms": 20, ... },
  "actionLatencyTimeseries": {
    "gameTimeOffsetsMs": [0, 1000, 2000],
    "meansMs": [30, 42, 38],
    "sampleCounts": [5, 7, 6]
  },
  "droppedUnmatchedCount": 0
}
```

Returns to website (same wire conventions: camelCase, plain arrays — no BinData envelopes):
```json
{
  "gameId": 12345,
  "matchWallStart": "...",
  "players": [{
    "battleTag": "Alice#1234",
    "connectionType": "QUIC",
    "crashedAt": null,
    "disconnectEvents": [...],
    "actionLatencyAggregate": {...},
    "gameTimeOffsetsMs": [...],
    "meansMs": [...],
    "sampleCounts": [...],
    ...
  }],
  "createdAt": "...",
  "expiresAt": "..."
}
```

Dropped fields from the original design: `bucketMs` (hardcoded to 1s), `floPlayerId` / `serverNodeId` / `serverNodeName` (always null — never resolved server-side; resolvable from `gameId` if ever needed). Schema-evolution safety via `[BsonIgnoreExtraElements]` on the top-level domain class.

## Companion PRs (4-PR coordinated feature)

- **flo** w3champions/flo#146 — produces `PlayerMatchTelemetryReport` at game-end with the camelCase wire shape.
- **website** w3champions/website#1071 — admin lag-report detail page renders the chart traces + aggregate table columns.
- **launcher-e** w3champions/launcher-e#765 — forwards the report from flo-client to the backend + adds `transport` to lag-report submission.

This backend PR ships **first** in the rollout — the endpoint becomes ready and idle while old launcher-e installs continue submitting lag reports without the new `Transport` field (handled by the default).

## Test plan

- [ ] CI green
- [ ] `dotnet test --filter "FullyQualifiedName~PlayerMatchTelemetry"` — 22/22 pass
- [ ] `dotnet test --filter "FullyQualifiedName~LagReport"` — 37/37 pass (existing + new `LagReportTransportTests`)
- [ ] Full `dotnet test` — 567/567 passed, 0 failed, 9 skipped (pre-existing)
- [ ] `dotnet build` clean
- [ ] Manual: POST a camelCase sample payload (regression test embeds one) → 200 OK + document inserted with `_id == game_id`. GET with the admin permission → 200 with plain-array JSON. Verify TTL index exists via `db.PlayerMatchTelemetry.getIndexes()`.

## Notes

- Concurrent same-`(gameId, battleTag)` submissions are now race-free via the single-pipeline atomic upsert. The deployment contract (one launcher per player, fire-and-forget) means this concern is mostly theoretical, but the implementation is correct regardless.
- The `JsonStringEnumConverter` in .NET 8 is case-insensitive by default (accepts `"TCP"`, `"tcp"`, `"Tcp"`). flo always emits exact `"TCP"` / `"QUIC"` per its locked-in serde test, so this is benign.
- Known pre-existing concerns this PR does not address: CS1998 warning in `RateLimitAttributeTests.cs`.
