### PR TITLE
Store rating_lower_bound so it's available from game-mode-stats

### DIFF
--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGateway.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGateway.cs
@@ -30,6 +30,7 @@ public class PlayerGameModeStatPerGateway : WinLoss, IIdentifiable
     public int Season { get; set; }
     public string Id { get; set; }
     public int MMR { set; get; }
+    public int? RatingLowerBound { get; set; }
     public double RankingPoints { get; set; }
     public int Rank { get; set; }
     public int LeagueId { get; set; }
@@ -50,7 +51,7 @@ public class PlayerGameModeStatPerGateway : WinLoss, IIdentifiable
         }
     }
 
-    public void RecordRanking(in int mmr, in double rankingPoints)
+    public void RecordRanking(in int mmr, in double rankingPoints, in int? ratingLowerBound = null)
     {
         if (RankProgressionStart == null || LastGameWasBefore8Hours())
         {
@@ -58,6 +59,7 @@ public class PlayerGameModeStatPerGateway : WinLoss, IIdentifiable
         }
 
         MMR = mmr;
+        RatingLowerBound = ratingLowerBound;
         RankingPoints = rankingPoints;
     }
 

--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGatewayHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGatewayHandler.cs
@@ -71,11 +71,12 @@ public class PlayerGameModeStatPerGatewayHandler(IPlayerRepository playerReposit
 
         loser.RecordWin(false);
 
-        var firstLooser = losingTeam.First();
+        var firstLoser = losingTeam.First();
 
         loser.RecordRanking(
-            (int?)firstLooser.updatedMmr?.rating ?? (int?)firstLooser.mmr?.rating ?? 0,
-            firstLooser.updatedRanking?.rp ?? firstLooser.ranking?.rp ?? 0);
+            (int?)firstLoser.updatedMmr?.rating ?? (int?)firstLoser.mmr?.rating ?? 0,
+            firstLoser.updatedRanking?.rp ?? firstLoser.ranking?.rp ?? 0,
+            GetRatingLowerBound(firstLoser));
 
         await _playerRepository.UpsertPlayerGameModeStatPerGateway(loser);
     }
@@ -110,7 +111,8 @@ public class PlayerGameModeStatPerGatewayHandler(IPlayerRepository playerReposit
         winner.RecordWin(true);
         winner.RecordRanking(
             (int?)winners.First().updatedMmr?.rating ?? (int?)winners.First().mmr?.rating ?? 0,
-            winners.First().updatedRanking?.rp ?? winners.First().ranking?.rp ?? 0);
+            winners.First().updatedRanking?.rp ?? winners.First().ranking?.rp ?? 0,
+            GetRatingLowerBound(winners.First()));
 
         await _playerRepository.UpsertPlayerGameModeStatPerGateway(winner);
     }
@@ -154,5 +156,22 @@ public class PlayerGameModeStatPerGatewayHandler(IPlayerRepository playerReposit
         }
 
         return gameMode;
+    }
+
+    [NoTrace]
+    private static int? GetRatingLowerBound(PlayerMMrChange player)
+    {
+        var lowerBound = player.updatedMmr?.rating_lower_bound;
+        if (lowerBound == null)
+        {
+            lowerBound = player.mmr?.rating_lower_bound;
+        }
+
+        if (lowerBound == null)
+        {
+            return null;
+        }
+
+        return (int)lowerBound.Value;
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Player/PlayerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Player/PlayerTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using W3C.Contracts.GameObjects;
@@ -157,6 +158,31 @@ public class PlayerTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task PlayerStatsMapping_IncludesRatingLowerBound()
+    {
+        var playerRepository = new PlayerRepository(MongoClient);
+
+        var battleTagIdCombined = new BattleTagIdCombined(new List<PlayerId>
+            {
+                PlayerId.Create("peter#123")
+            },
+            GateWay.Europe,
+            GameMode.GM_1v1,
+            2,
+            null);
+        var player = PlayerGameModeStatPerGateway.Create(battleTagIdCombined);
+        player.RecordRanking(234, 123, 222);
+
+        await playerRepository.UpsertPlayerGameModeStatPerGateway(player);
+
+        var playerLoadedAgain = await playerRepository.LoadGameModeStatPerGateway("peter#123", GateWay.Europe, 2);
+        var serialized = JsonSerializer.Serialize(playerLoadedAgain.Single(), new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.AreEqual(222, playerLoadedAgain.Single().RatingLowerBound);
+        StringAssert.Contains("\"ratingLowerBound\":222", serialized);
+    }
+
+    [Test]
     public async Task PlayerIdMappedRight()
     {
         var playerRepository = new PlayerRepository(MongoClient);
@@ -218,9 +244,11 @@ public class PlayerTests : IntegrationTestBase
 
         ev.match.players[0].battleTag = "peter#123";
         ev.match.players[0].won = true;
+        ev.match.players[0].updatedMmr.rating_lower_bound = 1700;
 
         ev.match.players[1].battleTag = "wolf#456";
         ev.match.players[1].won = false;
+        ev.match.players[1].updatedMmr.rating_lower_bound = 1600;
 
         await handler.Update(ev);
 
@@ -228,9 +256,11 @@ public class PlayerTests : IntegrationTestBase
         var loser = await playerRepository.LoadGameModeStatPerGateway("wolf#456", GateWay.Europe, 1);
 
         Assert.AreEqual(1, winnerStatGateWay.First(x => x.GameMode == GameMode.GM_1v1).Wins);
+        Assert.AreEqual(1700, winnerStatGateWay.First(x => x.GameMode == GameMode.GM_1v1).RatingLowerBound);
 
         Assert.AreEqual(1, loser.First(x => x.GameMode == GameMode.GM_1v1).Losses);
         Assert.AreEqual(0, loser.First(x => x.GameMode == GameMode.GM_1v1).Wins);
+        Assert.AreEqual(1600, loser.First(x => x.GameMode == GameMode.GM_1v1).RatingLowerBound);
     }
 
     [Test]


### PR DESCRIPTION
Currently, profiles in W3C launcher shows "Highest MMR", but only for "themselves" (when a player is looking at their own profile). This is because it's only being sent down to the launcher via the MM service instead of coming from the backend. The backend wasn't storing it when the MMR is updated. I think this is something useful we should store because it's an interesting stat. 

Of course we shouldn't show it when RD is still high (or I think the simpler condition is just "if rating_lower_bound is lower than the current MMR, just hide it", which has the same meaning effectively? I think? right...?)

I don't think this is really secret or "internal" info based on prior conversations, so I don't think there's much harm in doing this.