### PR TITLE
Add map metadata backfill tool

### DIFF
--- a/W3ChampionsStatisticService.Tools/MapMetadataBackfill/CsvReportWriter.cs
+++ b/W3ChampionsStatisticService.Tools/MapMetadataBackfill/CsvReportWriter.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace W3ChampionsStatisticService.Tools.MapMetadataBackfill;
+
+public static class CsvReportWriter
+{
+    public static async Task WriteAsync(string path, IReadOnlyCollection<MapMetadataBackfillReportRow> rows)
+    {
+        await using var stream = File.Create(path);
+        await using var writer = new StreamWriter(stream, new UTF8Encoding(false));
+
+        await writer.WriteLineAsync(string.Join(",", Header.Select(Escape)));
+        foreach (var row in rows)
+        {
+            var fields = new[]
+            {
+                row.Action,
+                row.TargetMap,
+                row.MatchCount.ToString(),
+                string.Join("|", row.Seasons.OrderBy(s => s)),
+                string.Join("|", row.GameModes.OrderBy(g => g)),
+                row.ProposedMapName,
+                row.ProposedMapId?.ToString() ?? string.Empty,
+                row.Confidence,
+                row.Status,
+                row.ModifiedCount.ToString(),
+                string.Join("|", row.SampleIds),
+                string.Join("|", row.SourceMaps),
+                row.Notes
+            };
+
+            await writer.WriteLineAsync(string.Join(",", fields.Select(Escape)));
+        }
+    }
+
+    private static readonly string[] Header =
+    {
+        "action",
+        "target_map",
+        "match_count",
+        "seasons",
+        "game_modes",
+        "proposed_map_name",
+        "proposed_map_id",
+        "confidence",
+        "status",
+        "modified_count",
+        "sample_ids",
+        "source_maps",
+        "notes"
+    };
+
+    private static string Escape(string value)
+    {
+        value ??= string.Empty;
+        if (!value.Contains(',') && !value.Contains('"') && !value.Contains('\n') && !value.Contains('\r'))
+        {
+            return value;
+        }
+
+        return $"\"{value.Replace("\"", "\"\"")}\"";
+    }
+}
+
+public sealed record MapMetadataBackfillReportRow(
+    string TargetMap,
+    long MatchCount,
+    IReadOnlyCollection<int> Seasons,
+    IReadOnlyCollection<int> GameModes,
+    string ProposedMapName,
+    int? ProposedMapId,
+    string Confidence,
+    string Status,
+    string Action,
+    long ModifiedCount,
+    IReadOnlyCollection<string> SampleIds,
+    IReadOnlyCollection<string> SourceMaps,
+    string Notes);

--- a/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataBackfillCommand.cs
+++ b/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataBackfillCommand.cs
@@ -1,0 +1,459 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace W3ChampionsStatisticService.Tools.MapMetadataBackfill;
+
+public static class MapMetadataBackfillCommand
+{
+    public static async Task<int> RunAsync(string[] args)
+    {
+        MapMetadataBackfillOptions options;
+        try
+        {
+            options = MapMetadataBackfillOptions.Parse(args);
+        }
+        catch (HelpRequestedException)
+        {
+            Console.WriteLine(MapMetadataBackfillOptions.Usage);
+            return 0;
+        }
+        catch (ArgumentException ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            Console.Error.WriteLine();
+            Console.Error.WriteLine(MapMetadataBackfillOptions.Usage);
+            return 2;
+        }
+
+        try
+        {
+            await RunBackfillAsync(options);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex);
+            return 1;
+        }
+    }
+
+    private static async Task RunBackfillAsync(MapMetadataBackfillOptions options)
+    {
+        Console.WriteLine(options.Apply ? "Running map metadata backfill in APPLY mode." : "Running map metadata backfill in dry-run mode.");
+        Console.WriteLine($"Database: {options.DatabaseName}, collection: {options.CollectionName}");
+        Console.WriteLine($"Target seasons: {options.TargetMinSeason}-{options.TargetMaxSeason}; source seasons: {options.SourceMinSeason}-{(options.SourceMaxSeason?.ToString() ?? "latest")}");
+        Console.WriteLine(options.HasGameModeFilter
+            ? $"Game modes: {string.Join(", ", options.GameModes.OrderBy(g => g))}"
+            : "Game modes: all");
+
+        var mongoSettings = MongoClientSettings.FromConnectionString(options.ConnectionString.Replace("'", string.Empty));
+        mongoSettings.ServerSelectionTimeout = TimeSpan.FromSeconds(10);
+        mongoSettings.ConnectTimeout = TimeSpan.FromSeconds(10);
+
+        var client = new MongoClient(mongoSettings);
+        var collection = client.GetDatabase(options.DatabaseName).GetCollection<BsonDocument>(options.CollectionName);
+
+        var sourceMetadata = await LoadSourceMetadataAsync(collection, options);
+        var targetGroups = await LoadTargetGroupsAsync(collection, options);
+        var manualMetadata = MapMetadataResolver.LoadManualMetadata(options.ManualMapPath);
+        var resolver = new MapMetadataResolver(sourceMetadata, manualMetadata);
+
+        Console.WriteLine($"Loaded {sourceMetadata.Count} source map metadata rows.");
+        Console.WriteLine($"Found {targetGroups.Count} target map groups with missing metadata.");
+
+        var reportRows = new List<MapMetadataBackfillReportRow>();
+        foreach (var target in targetGroups.OrderBy(t => t.Map, StringComparer.OrdinalIgnoreCase))
+        {
+            var resolution = resolver.Resolve(target.Map);
+            var action = GetAction(resolution, options, target);
+            long modifiedCount = 0;
+
+            if (options.Apply && action == "update")
+            {
+                modifiedCount = await ApplyMapMetadataAsync(collection, options, target, resolution);
+            }
+
+            reportRows.Add(new MapMetadataBackfillReportRow(
+                target.Map,
+                target.Count,
+                target.Seasons,
+                target.GameModes,
+                resolution.MapName,
+                resolution.MapId,
+                resolution.Confidence,
+                resolution.Status.ToString(),
+                options.Apply ? action : $"dry-run:{action}",
+                modifiedCount,
+                target.SampleIds,
+                resolution.SourceMaps,
+                AppendActionNote(resolution, options, target, action)));
+        }
+
+        await CsvReportWriter.WriteAsync(options.ReportPath, reportRows);
+
+        var readyCount = reportRows.Count(r => r.Action.EndsWith(":update", StringComparison.OrdinalIgnoreCase) || r.Action == "update");
+        var ambiguousCount = reportRows.Count(r => r.Status == MapMetadataResolutionStatus.Ambiguous.ToString());
+        var missingCount = reportRows.Count(r => r.Status == MapMetadataResolutionStatus.Missing.ToString());
+        var skippedNoMapIdCount = reportRows.Count(r => r.Action.EndsWith(":skip-no-map-id", StringComparison.OrdinalIgnoreCase) || r.Action == "skip-no-map-id");
+        var modifiedTotal = reportRows.Sum(r => r.ModifiedCount);
+
+        Console.WriteLine($"Report written to {options.ReportPath}");
+        Console.WriteLine($"Ready: {readyCount}, ambiguous: {ambiguousCount}, missing: {missingCount}, skipped without map id: {skippedNoMapIdCount}");
+        PrintPreview(reportRows, options);
+        if (options.Apply)
+        {
+            Console.WriteLine($"Modified documents: {modifiedTotal}");
+        }
+    }
+
+    private static void PrintPreview(IReadOnlyCollection<MapMetadataBackfillReportRow> reportRows, MapMetadataBackfillOptions options)
+    {
+        if (options.PreviewLimit == 0 || reportRows.Count == 0)
+        {
+            return;
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(options.Apply ? "Applied changes:" : "Dry-run preview:");
+
+        foreach (var row in reportRows.Take(options.PreviewLimit))
+        {
+            var seasonText = RangeLabel(row.Seasons);
+            var modeText = row.GameModes.Count > 0 ? $" modes {string.Join("/", row.GameModes.OrderBy(g => g))}" : string.Empty;
+            var mapIdText = row.ProposedMapId.HasValue ? $" (id {row.ProposedMapId.Value})" : string.Empty;
+
+            if (row.Action.EndsWith(":update", StringComparison.OrdinalIgnoreCase) || row.Action == "update")
+            {
+                var verb = options.Apply ? "updated" : "would update";
+                Console.WriteLine($"  {verb} {row.TargetMap} -> {row.ProposedMapName}{mapIdText}: {row.MatchCount} matches, seasons {seasonText}{modeText}");
+                continue;
+            }
+
+            var reason = row.Status.Equals(MapMetadataResolutionStatus.Ambiguous.ToString(), StringComparison.OrdinalIgnoreCase)
+                ? "ambiguous"
+                : row.Status.Equals(MapMetadataResolutionStatus.Missing.ToString(), StringComparison.OrdinalIgnoreCase)
+                    ? "missing mapping"
+                    : row.Action.Replace("dry-run:", string.Empty);
+
+            Console.WriteLine($"  skip {row.TargetMap}: {reason}, {row.MatchCount} matches, seasons {seasonText}{modeText}");
+        }
+
+        if (reportRows.Count > options.PreviewLimit)
+        {
+            Console.WriteLine($"  ... {reportRows.Count - options.PreviewLimit} more rows in the CSV report");
+        }
+    }
+
+    private static string RangeLabel(IReadOnlyCollection<int> values)
+    {
+        if (values.Count == 0)
+        {
+            return "unknown";
+        }
+
+        var sorted = values.OrderBy(v => v).ToList();
+        return sorted.Count == 1 ? sorted[0].ToString() : $"{sorted.First()}-{sorted.Last()}";
+    }
+
+    private static string GetAction(
+        MapMetadataResolution resolution,
+        MapMetadataBackfillOptions options,
+        TargetMapGroup target)
+    {
+        if (!resolution.CanApply)
+        {
+            return resolution.Status == MapMetadataResolutionStatus.Ambiguous ? "skip-ambiguous" : "skip-missing";
+        }
+
+        if (options.RequireMapId && !resolution.MapId.HasValue)
+        {
+            return "skip-no-map-id";
+        }
+
+        if (target.MissingMapNameCount > 0)
+        {
+            return "update";
+        }
+
+        if (target.MissingMapIdCount > 0 && resolution.MapId.HasValue)
+        {
+            return "update";
+        }
+
+        if (target.MissingMapIdCount > 0)
+        {
+            return "skip-no-map-id";
+        }
+
+        return "skip-no-change";
+    }
+
+    private static string AppendRequireMapIdNote(MapMetadataResolution resolution, MapMetadataBackfillOptions options)
+    {
+        if (options.RequireMapId && resolution.CanApply && !resolution.MapId.HasValue)
+        {
+            return $"{resolution.Notes} Skipped because --require-map-id is set.";
+        }
+
+        return resolution.Notes;
+    }
+
+    private static string AppendActionNote(
+        MapMetadataResolution resolution,
+        MapMetadataBackfillOptions options,
+        TargetMapGroup target,
+        string action)
+    {
+        var notes = AppendRequireMapIdNote(resolution, options);
+        if (action == "skip-no-map-id" && target.MissingMapNameCount == 0)
+        {
+            return $"{notes} MapName is already set; MapId is still unknown.";
+        }
+
+        if (action == "skip-no-change")
+        {
+            return $"{notes} Nothing to update.";
+        }
+
+        return notes;
+    }
+
+    private static async Task<IReadOnlyCollection<SourceMapMetadata>> LoadSourceMetadataAsync(
+        IMongoCollection<BsonDocument> collection,
+        MapMetadataBackfillOptions options)
+    {
+        var filter = BuildSeasonFilter(options.SourceMinSeason, options.SourceMaxSeason, options)
+            & Builders<BsonDocument>.Filter.Exists("Map", true)
+            & Builders<BsonDocument>.Filter.Ne("Map", BsonNull.Value)
+            & Builders<BsonDocument>.Filter.Ne("Map", string.Empty)
+            & Builders<BsonDocument>.Filter.Exists("MapName", true)
+            & Builders<BsonDocument>.Filter.Ne("MapName", BsonNull.Value)
+            & Builders<BsonDocument>.Filter.Ne("MapName", string.Empty);
+
+        var group = new BsonDocument
+        {
+            ["_id"] = new BsonDocument
+            {
+                ["Map"] = "$Map",
+                ["MapName"] = "$MapName",
+                ["MapId"] = "$MapId"
+            },
+            ["Count"] = new BsonDocument("$sum", 1),
+            ["MinSeason"] = new BsonDocument("$min", "$Season"),
+            ["MaxSeason"] = new BsonDocument("$max", "$Season"),
+            ["GameModes"] = new BsonDocument("$addToSet", "$GameMode")
+        };
+
+        var docs = await collection.Aggregate()
+            .Match(filter)
+            .Group(group)
+            .ToListAsync();
+
+        return docs
+            .Select(doc =>
+            {
+                var id = doc["_id"].AsBsonDocument;
+                return new SourceMapMetadata(
+                    id.GetValue("Map").AsString,
+                    id.GetValue("MapName").AsString,
+                    ReadNullableInt(id, "MapId"),
+                    ReadInt(doc, "MinSeason"),
+                    ReadInt(doc, "MaxSeason"),
+                    ReadIntArray(doc, "GameModes"),
+                    ReadLong(doc, "Count"));
+            })
+            .ToList();
+    }
+
+    private static async Task<IReadOnlyCollection<TargetMapGroup>> LoadTargetGroupsAsync(
+        IMongoCollection<BsonDocument> collection,
+        MapMetadataBackfillOptions options)
+    {
+        var filter = BuildSeasonFilter(options.TargetMinSeason, options.TargetMaxSeason, options)
+            & Builders<BsonDocument>.Filter.Exists("Map", true)
+            & Builders<BsonDocument>.Filter.Ne("Map", BsonNull.Value)
+            & Builders<BsonDocument>.Filter.Ne("Map", string.Empty)
+            & Builders<BsonDocument>.Filter.Or(
+                Builders<BsonDocument>.Filter.Exists("MapName", false),
+                Builders<BsonDocument>.Filter.Eq("MapName", BsonNull.Value),
+                Builders<BsonDocument>.Filter.Eq("MapName", string.Empty),
+                Builders<BsonDocument>.Filter.Exists("MapId", false),
+                Builders<BsonDocument>.Filter.Eq("MapId", BsonNull.Value));
+
+        var group = new BsonDocument
+        {
+            ["_id"] = "$Map",
+            ["Count"] = new BsonDocument("$sum", 1),
+            ["MissingMapNameCount"] = CountMissingOrEmptyExpression("$MapName"),
+            ["MissingMapIdCount"] = CountMissingExpression("$MapId"),
+            ["Seasons"] = new BsonDocument("$addToSet", "$Season"),
+            ["GameModes"] = new BsonDocument("$addToSet", "$GameMode"),
+            ["SampleIds"] = new BsonDocument("$addToSet", "$_id")
+        };
+
+        var docs = await collection.Aggregate()
+            .Match(filter)
+            .Group(group)
+            .ToListAsync();
+
+        return docs
+            .Select(doc => new TargetMapGroup(
+                doc.GetValue("_id").AsString,
+                ReadLong(doc, "Count"),
+                ReadLong(doc, "MissingMapNameCount"),
+                ReadLong(doc, "MissingMapIdCount"),
+                ReadIntArray(doc, "Seasons"),
+                ReadIntArray(doc, "GameModes"),
+                ReadObjectIds(doc, "SampleIds", options.SampleIdsPerMap)))
+            .ToList();
+    }
+
+    private static BsonDocument CountMissingExpression(string fieldName)
+    {
+        return new BsonDocument("$sum", new BsonDocument("$cond", new BsonArray
+        {
+            new BsonDocument("$eq", new BsonArray { fieldName, BsonNull.Value }),
+            1,
+            0
+        }));
+    }
+
+    private static BsonDocument CountMissingOrEmptyExpression(string fieldName)
+    {
+        return new BsonDocument("$sum", new BsonDocument("$cond", new BsonArray
+        {
+            new BsonDocument("$or", new BsonArray
+            {
+                new BsonDocument("$eq", new BsonArray { fieldName, BsonNull.Value }),
+                new BsonDocument("$eq", new BsonArray { fieldName, string.Empty })
+            }),
+            1,
+            0
+        }));
+    }
+
+    private static FilterDefinition<BsonDocument> BuildSeasonFilter(int minSeason, int? maxSeason, MapMetadataBackfillOptions options)
+    {
+        var builder = Builders<BsonDocument>.Filter;
+        var filter = builder.Gte("Season", minSeason);
+        if (maxSeason.HasValue)
+        {
+            filter &= builder.Lte("Season", maxSeason.Value);
+        }
+
+        if (options.HasGameModeFilter)
+        {
+            filter &= builder.In("GameMode", options.GameModes);
+        }
+
+        return filter;
+    }
+
+    private static FilterDefinition<BsonDocument> BuildTargetMapFilter(
+        MapMetadataBackfillOptions options,
+        TargetMapGroup target)
+    {
+        return BuildSeasonFilter(options.TargetMinSeason, options.TargetMaxSeason, options)
+            & Builders<BsonDocument>.Filter.Eq("Map", target.Map);
+    }
+
+    private static async Task<long> ApplyMapMetadataAsync(
+        IMongoCollection<BsonDocument> collection,
+        MapMetadataBackfillOptions options,
+        TargetMapGroup target,
+        MapMetadataResolution resolution)
+    {
+        long modifiedCount = 0;
+        var targetMapFilter = BuildTargetMapFilter(options, target);
+
+        if (target.MissingMapNameCount > 0)
+        {
+            var updates = new List<UpdateDefinition<BsonDocument>>
+            {
+                Builders<BsonDocument>.Update.Set("MapName", resolution.MapName)
+            };
+
+            if (resolution.MapId.HasValue)
+            {
+                updates.Add(Builders<BsonDocument>.Update.Set("MapId", resolution.MapId.Value));
+            }
+
+            var result = await collection.UpdateManyAsync(
+                targetMapFilter & MissingMapNameFilter(),
+                Builders<BsonDocument>.Update.Combine(updates));
+            modifiedCount += result.ModifiedCount;
+        }
+
+        if (target.MissingMapIdCount > 0 && resolution.MapId.HasValue)
+        {
+            var result = await collection.UpdateManyAsync(
+                targetMapFilter & MissingMapIdFilter(),
+                Builders<BsonDocument>.Update.Set("MapId", resolution.MapId.Value));
+            modifiedCount += result.ModifiedCount;
+        }
+
+        return modifiedCount;
+    }
+
+    private static FilterDefinition<BsonDocument> MissingMapNameFilter()
+    {
+        return Builders<BsonDocument>.Filter.Or(
+            Builders<BsonDocument>.Filter.Exists("MapName", false),
+            Builders<BsonDocument>.Filter.Eq("MapName", BsonNull.Value),
+            Builders<BsonDocument>.Filter.Eq("MapName", string.Empty));
+    }
+
+    private static FilterDefinition<BsonDocument> MissingMapIdFilter()
+    {
+        return Builders<BsonDocument>.Filter.Or(
+            Builders<BsonDocument>.Filter.Exists("MapId", false),
+            Builders<BsonDocument>.Filter.Eq("MapId", BsonNull.Value));
+    }
+
+    private static int ReadInt(BsonDocument doc, string name)
+    {
+        return doc.GetValue(name).ToInt32();
+    }
+
+    private static long ReadLong(BsonDocument doc, string name)
+    {
+        return doc.GetValue(name).ToInt64();
+    }
+
+    private static int? ReadNullableInt(BsonDocument doc, string name)
+    {
+        var value = doc.GetValue(name, BsonNull.Value);
+        return value.IsBsonNull ? null : value.ToInt32();
+    }
+
+    private static IReadOnlyCollection<int> ReadIntArray(BsonDocument doc, string name)
+    {
+        return doc.GetValue(name, new BsonArray())
+            .AsBsonArray
+            .Where(v => !v.IsBsonNull)
+            .Select(v => v.ToInt32())
+            .ToList();
+    }
+
+    private static IReadOnlyCollection<string> ReadObjectIds(BsonDocument doc, string name, int maxCount)
+    {
+        return doc.GetValue(name, new BsonArray())
+            .AsBsonArray
+            .Take(maxCount)
+            .Select(v => v.IsObjectId ? v.AsObjectId.ToString() : v.ToString())
+            .ToList();
+    }
+
+    private sealed record TargetMapGroup(
+        string Map,
+        long Count,
+        long MissingMapNameCount,
+        long MissingMapIdCount,
+        IReadOnlyCollection<int> Seasons,
+        IReadOnlyCollection<int> GameModes,
+        IReadOnlyCollection<string> SampleIds);
+}

--- a/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataBackfillCommand.cs
+++ b/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataBackfillCommand.cs
@@ -317,7 +317,7 @@ public static class MapMetadataBackfillCommand
     {
         return new BsonDocument("$sum", new BsonDocument("$cond", new BsonArray
         {
-            new BsonDocument("$eq", new BsonArray { fieldName, BsonNull.Value }),
+            new BsonDocument("$eq", new BsonArray { NullIfMissingExpression(fieldName), BsonNull.Value }),
             1,
             0
         }));
@@ -327,14 +327,19 @@ public static class MapMetadataBackfillCommand
     {
         return new BsonDocument("$sum", new BsonDocument("$cond", new BsonArray
         {
-            new BsonDocument("$or", new BsonArray
+            new BsonDocument("$in", new BsonArray
             {
-                new BsonDocument("$eq", new BsonArray { fieldName, BsonNull.Value }),
-                new BsonDocument("$eq", new BsonArray { fieldName, string.Empty })
+                NullIfMissingExpression(fieldName),
+                new BsonArray { BsonNull.Value, string.Empty }
             }),
             1,
             0
         }));
+    }
+
+    private static BsonDocument NullIfMissingExpression(string fieldName)
+    {
+        return new BsonDocument("$ifNull", new BsonArray { fieldName, BsonNull.Value });
     }
 
     private static FilterDefinition<BsonDocument> BuildSeasonFilter(int minSeason, int? maxSeason, MapMetadataBackfillOptions options)

--- a/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataBackfillCommand.cs
+++ b/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataBackfillCommand.cs
@@ -46,6 +46,7 @@ public static class MapMetadataBackfillCommand
         Console.WriteLine(options.Apply ? "Running map metadata backfill in APPLY mode." : "Running map metadata backfill in dry-run mode.");
         Console.WriteLine($"Database: {options.DatabaseName}, collection: {options.CollectionName}");
         Console.WriteLine($"Target seasons: {options.TargetMinSeason}-{options.TargetMaxSeason}; source seasons: {options.SourceMinSeason}-{(options.SourceMaxSeason?.ToString() ?? "latest")}");
+        Console.WriteLine($"Preferred display-name source season: {options.PreferredNameSeason}");
         Console.WriteLine(options.HasGameModeFilter
             ? $"Game modes: {string.Join(", ", options.GameModes.OrderBy(g => g))}"
             : "Game modes: all");
@@ -60,7 +61,7 @@ public static class MapMetadataBackfillCommand
         var sourceMetadata = await LoadSourceMetadataAsync(collection, options);
         var targetGroups = await LoadTargetGroupsAsync(collection, options);
         var manualMetadata = MapMetadataResolver.LoadManualMetadata(options.ManualMapPath);
-        var resolver = new MapMetadataResolver(sourceMetadata, manualMetadata);
+        var resolver = new MapMetadataResolver(sourceMetadata, manualMetadata, options.PreferredNameSeason);
 
         Console.WriteLine($"Loaded {sourceMetadata.Count} source map metadata rows.");
         Console.WriteLine($"Found {targetGroups.Count} target map groups with missing metadata.");

--- a/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataBackfillOptions.cs
+++ b/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataBackfillOptions.cs
@@ -8,6 +8,7 @@ public sealed class MapMetadataBackfillOptions
 {
     public const string DefaultDatabaseName = "W3Champions-Statistic-Service";
     public const string DefaultCollectionName = "Matchup";
+    public const int DefaultPreferredNameSeason = 24;
 
     public string ConnectionString { get; init; }
     public string DatabaseName { get; init; } = DefaultDatabaseName;
@@ -16,6 +17,7 @@ public sealed class MapMetadataBackfillOptions
     public int TargetMaxSeason { get; init; } = 10;
     public int SourceMinSeason { get; init; } = 11;
     public int? SourceMaxSeason { get; init; }
+    public int PreferredNameSeason { get; init; } = DefaultPreferredNameSeason;
     public IReadOnlyCollection<int> GameModes { get; init; } = Array.Empty<int>();
     public bool Apply { get; init; }
     public bool RequireMapId { get; init; }
@@ -42,6 +44,7 @@ public sealed class MapMetadataBackfillOptions
           --target-max-season <number>         Defaults to 10.
           --source-min-season <number>         Defaults to 11.
           --source-max-season <number>         Optional upper bound for catalog rows.
+          --preferred-name-season <number>     Source season to prefer for display names. Defaults to 24.
           --game-mode <ids>                    Optional comma-separated list, for example 1 or 1,2,4.
           --report <path>                      CSV report path. Defaults to map-metadata-backfill-report.csv.
           --manual-map <path>                  Optional JSON file with extra legacy map mappings.
@@ -73,6 +76,7 @@ public sealed class MapMetadataBackfillOptions
         int? targetSeason = null;
         int sourceMinSeason = 11;
         int? sourceMaxSeason = null;
+        int preferredNameSeason = DefaultPreferredNameSeason;
         IReadOnlyCollection<int> gameModes = Array.Empty<int>();
         bool apply = false;
         bool requireMapId = false;
@@ -112,6 +116,9 @@ public sealed class MapMetadataBackfillOptions
                     break;
                 case "--source-max-season":
                     sourceMaxSeason = ReadInt(queue, arg);
+                    break;
+                case "--preferred-name-season":
+                    preferredNameSeason = ReadInt(queue, arg);
                     break;
                 case "--game-mode":
                 case "--game-modes":
@@ -162,6 +169,11 @@ public sealed class MapMetadataBackfillOptions
             throw new ArgumentException("--source-min-season must be less than or equal to --source-max-season.");
         }
 
+        if (preferredNameSeason < 0)
+        {
+            throw new ArgumentException("--preferred-name-season must be zero or greater.");
+        }
+
         if (sampleIdsPerMap < 0)
         {
             throw new ArgumentException("--sample-ids-per-map must be zero or greater.");
@@ -181,6 +193,7 @@ public sealed class MapMetadataBackfillOptions
             TargetMaxSeason = targetMaxSeason,
             SourceMinSeason = sourceMinSeason,
             SourceMaxSeason = sourceMaxSeason,
+            PreferredNameSeason = preferredNameSeason,
             GameModes = gameModes,
             Apply = apply,
             RequireMapId = requireMapId,

--- a/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataBackfillOptions.cs
+++ b/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataBackfillOptions.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace W3ChampionsStatisticService.Tools.MapMetadataBackfill;
+
+public sealed class MapMetadataBackfillOptions
+{
+    public const string DefaultDatabaseName = "W3Champions-Statistic-Service";
+    public const string DefaultCollectionName = "Matchup";
+
+    public string ConnectionString { get; init; }
+    public string DatabaseName { get; init; } = DefaultDatabaseName;
+    public string CollectionName { get; init; } = DefaultCollectionName;
+    public int TargetMinSeason { get; init; } = 1;
+    public int TargetMaxSeason { get; init; } = 10;
+    public int SourceMinSeason { get; init; } = 11;
+    public int? SourceMaxSeason { get; init; }
+    public IReadOnlyCollection<int> GameModes { get; init; } = Array.Empty<int>();
+    public bool Apply { get; init; }
+    public bool RequireMapId { get; init; }
+    public int SampleIdsPerMap { get; init; } = 3;
+    public int PreviewLimit { get; init; } = 25;
+    public string ReportPath { get; init; } = "map-metadata-backfill-report.csv";
+    public string ManualMapPath { get; init; }
+
+    public bool HasGameModeFilter => GameModes.Count > 0;
+
+    public static string Usage =>
+        """
+        Usage:
+          dotnet run --project W3ChampionsStatisticService.Tools -- backfill-map-metadata [options]
+
+        Required:
+          --connection-string <mongodb-uri>    MongoDB URI. If omitted, MONGO_CONNECTION_STRING is used.
+
+        Options:
+          --database <name>                    Defaults to W3Champions-Statistic-Service.
+          --collection <name>                  Defaults to Matchup.
+          --season <number>                    Backfill one target season. Equivalent to min/max season.
+          --target-min-season <number>         Defaults to 1.
+          --target-max-season <number>         Defaults to 10.
+          --source-min-season <number>         Defaults to 11.
+          --source-max-season <number>         Optional upper bound for catalog rows.
+          --game-mode <ids>                    Optional comma-separated list, for example 1 or 1,2,4.
+          --report <path>                      CSV report path. Defaults to map-metadata-backfill-report.csv.
+          --manual-map <path>                  Optional JSON file with extra legacy map mappings.
+          --sample-ids-per-map <number>        Defaults to 3.
+          --preview-limit <number>             Console preview rows. Defaults to 25. Use 0 to hide.
+          --require-map-id                     Skip rows where only MapName can be inferred.
+          --apply                              Write safe matches. Without this, the command is a dry run.
+          --help                               Show this help.
+
+        Manual map JSON shape:
+          {
+            "LegacyMapKey": { "mapName": "Display Name", "mapId": 123 }
+          }
+        """;
+
+    public static MapMetadataBackfillOptions Parse(string[] args)
+    {
+        var queue = new Queue<string>(args);
+        if (queue.Count > 0 && queue.Peek().Equals("backfill-map-metadata", StringComparison.OrdinalIgnoreCase))
+        {
+            queue.Dequeue();
+        }
+
+        string connectionString = null;
+        string databaseName = DefaultDatabaseName;
+        string collectionName = DefaultCollectionName;
+        int targetMinSeason = 1;
+        int targetMaxSeason = 10;
+        int? targetSeason = null;
+        int sourceMinSeason = 11;
+        int? sourceMaxSeason = null;
+        IReadOnlyCollection<int> gameModes = Array.Empty<int>();
+        bool apply = false;
+        bool requireMapId = false;
+        int sampleIdsPerMap = 3;
+        int previewLimit = 25;
+        string reportPath = "map-metadata-backfill-report.csv";
+        string manualMapPath = null;
+
+        while (queue.Count > 0)
+        {
+            var arg = queue.Dequeue();
+            switch (arg)
+            {
+                case "--help":
+                case "-h":
+                    throw new HelpRequestedException();
+                case "--connection-string":
+                    connectionString = ReadValue(queue, arg);
+                    break;
+                case "--database":
+                    databaseName = ReadValue(queue, arg);
+                    break;
+                case "--collection":
+                    collectionName = ReadValue(queue, arg);
+                    break;
+                case "--season":
+                    targetSeason = ReadInt(queue, arg);
+                    break;
+                case "--target-min-season":
+                    targetMinSeason = ReadInt(queue, arg);
+                    break;
+                case "--target-max-season":
+                    targetMaxSeason = ReadInt(queue, arg);
+                    break;
+                case "--source-min-season":
+                    sourceMinSeason = ReadInt(queue, arg);
+                    break;
+                case "--source-max-season":
+                    sourceMaxSeason = ReadInt(queue, arg);
+                    break;
+                case "--game-mode":
+                case "--game-modes":
+                    gameModes = ParseIntList(ReadValue(queue, arg), arg);
+                    break;
+                case "--report":
+                    reportPath = ReadValue(queue, arg);
+                    break;
+                case "--manual-map":
+                    manualMapPath = ReadValue(queue, arg);
+                    break;
+                case "--sample-ids-per-map":
+                    sampleIdsPerMap = ReadInt(queue, arg);
+                    break;
+                case "--preview-limit":
+                    previewLimit = ReadInt(queue, arg);
+                    break;
+                case "--require-map-id":
+                    requireMapId = true;
+                    break;
+                case "--apply":
+                    apply = true;
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown option '{arg}'.");
+            }
+        }
+
+        if (targetSeason.HasValue)
+        {
+            targetMinSeason = targetSeason.Value;
+            targetMaxSeason = targetSeason.Value;
+        }
+
+        connectionString ??= Environment.GetEnvironmentVariable("MONGO_CONNECTION_STRING");
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new ArgumentException("Missing MongoDB connection string. Pass --connection-string or set MONGO_CONNECTION_STRING.");
+        }
+
+        if (targetMinSeason > targetMaxSeason)
+        {
+            throw new ArgumentException("--target-min-season must be less than or equal to --target-max-season.");
+        }
+
+        if (sourceMaxSeason.HasValue && sourceMinSeason > sourceMaxSeason.Value)
+        {
+            throw new ArgumentException("--source-min-season must be less than or equal to --source-max-season.");
+        }
+
+        if (sampleIdsPerMap < 0)
+        {
+            throw new ArgumentException("--sample-ids-per-map must be zero or greater.");
+        }
+
+        if (previewLimit < 0)
+        {
+            throw new ArgumentException("--preview-limit must be zero or greater.");
+        }
+
+        return new MapMetadataBackfillOptions
+        {
+            ConnectionString = connectionString,
+            DatabaseName = databaseName,
+            CollectionName = collectionName,
+            TargetMinSeason = targetMinSeason,
+            TargetMaxSeason = targetMaxSeason,
+            SourceMinSeason = sourceMinSeason,
+            SourceMaxSeason = sourceMaxSeason,
+            GameModes = gameModes,
+            Apply = apply,
+            RequireMapId = requireMapId,
+            SampleIdsPerMap = sampleIdsPerMap,
+            PreviewLimit = previewLimit,
+            ReportPath = reportPath,
+            ManualMapPath = manualMapPath
+        };
+    }
+
+    private static string ReadValue(Queue<string> queue, string option)
+    {
+        if (queue.Count == 0)
+        {
+            throw new ArgumentException($"{option} requires a value.");
+        }
+
+        return queue.Dequeue();
+    }
+
+    private static int ReadInt(Queue<string> queue, string option)
+    {
+        var value = ReadValue(queue, option);
+        if (!int.TryParse(value, out var result))
+        {
+            throw new ArgumentException($"{option} requires a numeric value.");
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyCollection<int> ParseIntList(string value, string option)
+    {
+        var parsed = value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(v =>
+            {
+                if (!int.TryParse(v, out var id))
+                {
+                    throw new ArgumentException($"{option} contains a non-numeric value: '{v}'.");
+                }
+
+                return id;
+            })
+            .Distinct()
+            .ToArray();
+
+        if (parsed.Length == 0)
+        {
+            throw new ArgumentException($"{option} requires at least one value.");
+        }
+
+        return parsed;
+    }
+}
+
+public sealed class HelpRequestedException : Exception
+{
+}

--- a/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataResolver.cs
+++ b/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataResolver.cs
@@ -38,6 +38,7 @@ public enum MapMetadataResolutionStatus
 
 public sealed class MapMetadataResolver
 {
+    private readonly int _preferredNameSeason;
     private readonly Dictionary<string, List<SourceMapMetadata>> _exactSourceIndex;
     private readonly Dictionary<string, List<SourceMapMetadata>> _stableSourceIndex;
     private readonly Dictionary<string, List<SourceMapMetadata>> _familySourceIndex;
@@ -47,8 +48,10 @@ public sealed class MapMetadataResolver
 
     public MapMetadataResolver(
         IEnumerable<SourceMapMetadata> sourceMetadata,
-        IEnumerable<KeyValuePair<string, ManualMapMetadata>> manualMetadata = null)
+        IEnumerable<KeyValuePair<string, ManualMapMetadata>> manualMetadata = null,
+        int preferredNameSeason = MapMetadataBackfillOptions.DefaultPreferredNameSeason)
     {
+        _preferredNameSeason = preferredNameSeason;
         var source = sourceMetadata?.ToList() ?? new List<SourceMapMetadata>();
         _exactSourceIndex = BuildSourceIndex(source, MapKeyNormalizer.ExactKey);
         _stableSourceIndex = BuildSourceIndex(source, MapKeyNormalizer.StableKey);
@@ -151,7 +154,7 @@ public sealed class MapMetadataResolver
             "Matched built-in or supplied manual metadata.");
     }
 
-    private static MapMetadataResolution ResolveFromSource(
+    private MapMetadataResolution ResolveFromSource(
         IReadOnlyDictionary<string, List<SourceMapMetadata>> index,
         string key,
         string confidence)
@@ -183,11 +186,8 @@ public sealed class MapMetadataResolver
                 "Matched multiple map identities. Add a manual mapping before applying.");
         }
 
-        var selected = candidates
-            .OrderBy(c => c.MinSeason)
-            .ThenBy(c => c.MapName, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(c => c.Map, StringComparer.OrdinalIgnoreCase)
-            .First();
+        var selected = SelectPreferredNameCandidate(candidates);
+        var distinctNameCount = candidates.Select(c => c.MapName).Distinct(StringComparer.OrdinalIgnoreCase).Count();
 
         return new MapMetadataResolution(
             MapMetadataResolutionStatus.Resolved,
@@ -195,9 +195,35 @@ public sealed class MapMetadataResolver
             selected.MapName,
             selected.MapId,
             candidates.Select(SourceLabel).Distinct().OrderBy(s => s).ToList(),
-            candidates.Select(c => c.MapName).Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1
-                ? "Matched one map id with multiple display names; using earliest source-season name."
+            distinctNameCount > 1
+                ? PreferredNameNote(selected)
                 : "Matched source metadata.");
+    }
+
+    private SourceMapMetadata SelectPreferredNameCandidate(IReadOnlyCollection<SourceMapMetadata> candidates)
+    {
+        return candidates
+            .OrderByDescending(CoversPreferredNameSeason)
+            .ThenByDescending(c => c.MaxSeason)
+            .ThenByDescending(c => c.Count)
+            .ThenBy(c => c.MapName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(c => c.Map, StringComparer.OrdinalIgnoreCase)
+            .First();
+    }
+
+    private bool CoversPreferredNameSeason(SourceMapMetadata source)
+    {
+        return source.MinSeason <= _preferredNameSeason && source.MaxSeason >= _preferredNameSeason;
+    }
+
+    private string PreferredNameNote(SourceMapMetadata selected)
+    {
+        if (CoversPreferredNameSeason(selected))
+        {
+            return $"Matched one map id with multiple display names; using season {_preferredNameSeason} source-season name.";
+        }
+
+        return $"Matched one map id with multiple display names; no season {_preferredNameSeason} name found, using latest source-season name.";
     }
 
     private static string IdentityKey(SourceMapMetadata source)

--- a/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataResolver.cs
+++ b/W3ChampionsStatisticService.Tools/MapMetadataBackfill/MapMetadataResolver.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace W3ChampionsStatisticService.Tools.MapMetadataBackfill;
+
+public sealed record SourceMapMetadata(
+    string Map,
+    string MapName,
+    int? MapId,
+    int MinSeason,
+    int MaxSeason,
+    IReadOnlyCollection<int> GameModes,
+    long Count);
+
+public sealed record ManualMapMetadata(string MapName, int? MapId);
+
+public sealed record MapMetadataResolution(
+    MapMetadataResolutionStatus Status,
+    string Confidence,
+    string MapName,
+    int? MapId,
+    IReadOnlyCollection<string> SourceMaps,
+    string Notes)
+{
+    public bool CanApply => Status == MapMetadataResolutionStatus.Resolved;
+}
+
+public enum MapMetadataResolutionStatus
+{
+    Resolved,
+    Ambiguous,
+    Missing
+}
+
+public sealed class MapMetadataResolver
+{
+    private readonly Dictionary<string, List<SourceMapMetadata>> _exactSourceIndex;
+    private readonly Dictionary<string, List<SourceMapMetadata>> _stableSourceIndex;
+    private readonly Dictionary<string, List<SourceMapMetadata>> _familySourceIndex;
+    private readonly Dictionary<string, ManualMapMetadata> _manualExactIndex;
+    private readonly Dictionary<string, ManualMapMetadata> _manualStableIndex;
+    private readonly Dictionary<string, ManualMapMetadata> _manualFamilyIndex;
+
+    public MapMetadataResolver(
+        IEnumerable<SourceMapMetadata> sourceMetadata,
+        IEnumerable<KeyValuePair<string, ManualMapMetadata>> manualMetadata = null)
+    {
+        var source = sourceMetadata?.ToList() ?? new List<SourceMapMetadata>();
+        _exactSourceIndex = BuildSourceIndex(source, MapKeyNormalizer.ExactKey);
+        _stableSourceIndex = BuildSourceIndex(source, MapKeyNormalizer.StableKey);
+        _familySourceIndex = BuildSourceIndex(source, MapKeyNormalizer.FamilyKey);
+        var manual = BuiltInManualMetadata().Concat(manualMetadata ?? Array.Empty<KeyValuePair<string, ManualMapMetadata>>()).ToList();
+        _manualExactIndex = BuildManualIndex(manual, MapKeyNormalizer.ExactKey);
+        _manualStableIndex = BuildManualIndex(manual, MapKeyNormalizer.StableKey);
+        _manualFamilyIndex = BuildManualIndex(manual, MapKeyNormalizer.FamilyKey);
+    }
+
+    public MapMetadataResolution Resolve(string map)
+    {
+        if (string.IsNullOrWhiteSpace(map))
+        {
+            return Missing("Map is empty.");
+        }
+
+        var exact = ResolveFromSource(_exactSourceIndex, MapKeyNormalizer.ExactKey(map), "exact");
+        if (exact != null)
+        {
+            return exact;
+        }
+
+        var stable = ResolveFromSource(_stableSourceIndex, MapKeyNormalizer.StableKey(map), "normalized");
+        if (stable != null)
+        {
+            return stable;
+        }
+
+        var manual = ResolveManual(map);
+        if (manual != null)
+        {
+            return manual;
+        }
+
+        var family = ResolveFromSource(_familySourceIndex, MapKeyNormalizer.FamilyKey(map), "family");
+        if (family != null)
+        {
+            return family;
+        }
+
+        return Missing("No catalog or manual mapping matched.");
+    }
+
+    public static IReadOnlyCollection<KeyValuePair<string, ManualMapMetadata>> LoadManualMetadata(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return Array.Empty<KeyValuePair<string, ManualMapMetadata>>();
+        }
+
+        var json = File.ReadAllText(path);
+        var values = JsonSerializer.Deserialize<Dictionary<string, ManualMapMetadataFileEntry>>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        if (values == null)
+        {
+            return Array.Empty<KeyValuePair<string, ManualMapMetadata>>();
+        }
+
+        return values
+            .Where(v => !string.IsNullOrWhiteSpace(v.Key) && !string.IsNullOrWhiteSpace(v.Value?.MapName))
+            .Select(v => new KeyValuePair<string, ManualMapMetadata>(v.Key, new ManualMapMetadata(v.Value.MapName, v.Value.MapId)))
+            .ToList();
+    }
+
+    private MapMetadataResolution ResolveManual(string map)
+    {
+        var exactKey = MapKeyNormalizer.ExactKey(map);
+        if (_manualExactIndex.TryGetValue(exactKey, out var exactMetadata))
+        {
+            return ManualResolution(exactMetadata);
+        }
+
+        var stableKey = MapKeyNormalizer.StableKey(map);
+        if (_manualStableIndex.TryGetValue(stableKey, out var stableMetadata))
+        {
+            return ManualResolution(stableMetadata);
+        }
+
+        var familyKey = MapKeyNormalizer.FamilyKey(map);
+        if (_manualFamilyIndex.TryGetValue(familyKey, out var familyMetadata))
+        {
+            return ManualResolution(familyMetadata);
+        }
+
+        return null;
+    }
+
+    private static MapMetadataResolution ManualResolution(ManualMapMetadata metadata)
+    {
+        return new MapMetadataResolution(
+            MapMetadataResolutionStatus.Resolved,
+            "manual",
+            metadata.MapName,
+            metadata.MapId,
+            Array.Empty<string>(),
+            "Matched built-in or supplied manual metadata.");
+    }
+
+    private static MapMetadataResolution ResolveFromSource(
+        IReadOnlyDictionary<string, List<SourceMapMetadata>> index,
+        string key,
+        string confidence)
+    {
+        if (string.IsNullOrWhiteSpace(key) || !index.TryGetValue(key, out var candidates) || candidates.Count == 0)
+        {
+            return null;
+        }
+
+        var groupedByIdentity = candidates
+            .GroupBy(IdentityKey)
+            .ToList();
+
+        if (groupedByIdentity.Count > 1)
+        {
+            var sources = candidates
+                .OrderBy(c => c.MinSeason)
+                .ThenBy(c => c.Map)
+                .Select(SourceLabel)
+                .Distinct()
+                .ToList();
+
+            return new MapMetadataResolution(
+                MapMetadataResolutionStatus.Ambiguous,
+                confidence,
+                null,
+                null,
+                sources,
+                "Matched multiple map identities. Add a manual mapping before applying.");
+        }
+
+        var selected = candidates
+            .OrderBy(c => c.MinSeason)
+            .ThenBy(c => c.MapName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(c => c.Map, StringComparer.OrdinalIgnoreCase)
+            .First();
+
+        return new MapMetadataResolution(
+            MapMetadataResolutionStatus.Resolved,
+            confidence,
+            selected.MapName,
+            selected.MapId,
+            candidates.Select(SourceLabel).Distinct().OrderBy(s => s).ToList(),
+            candidates.Select(c => c.MapName).Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1
+                ? "Matched one map id with multiple display names; using earliest source-season name."
+                : "Matched source metadata.");
+    }
+
+    private static string IdentityKey(SourceMapMetadata source)
+    {
+        if (source.MapId.HasValue)
+        {
+            return $"id:{source.MapId.Value}";
+        }
+
+        return $"name:{MapKeyNormalizer.StableKey(source.MapName)}";
+    }
+
+    private static string SourceLabel(SourceMapMetadata source)
+    {
+        var mapId = source.MapId.HasValue ? source.MapId.Value.ToString() : "null";
+        return $"{source.Map} -> {source.MapName} (id {mapId}, s{source.MinSeason}-{source.MaxSeason})";
+    }
+
+    private static MapMetadataResolution Missing(string notes)
+    {
+        return new MapMetadataResolution(
+            MapMetadataResolutionStatus.Missing,
+            "none",
+            null,
+            null,
+            Array.Empty<string>(),
+            notes);
+    }
+
+    private static Dictionary<string, List<SourceMapMetadata>> BuildSourceIndex(
+        IEnumerable<SourceMapMetadata> source,
+        Func<string, string> keySelector)
+    {
+        var result = new Dictionary<string, List<SourceMapMetadata>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in source)
+        {
+            var key = keySelector(item.Map);
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                continue;
+            }
+
+            if (!result.TryGetValue(key, out var bucket))
+            {
+                bucket = new List<SourceMapMetadata>();
+                result[key] = bucket;
+            }
+
+            bucket.Add(item);
+        }
+
+        return result;
+    }
+
+    private static Dictionary<string, ManualMapMetadata> BuildManualIndex(
+        IEnumerable<KeyValuePair<string, ManualMapMetadata>> manualMetadata,
+        Func<string, string> keySelector)
+    {
+        var result = new Dictionary<string, ManualMapMetadata>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in manualMetadata)
+        {
+            var key = keySelector(item.Key);
+            if (!string.IsNullOrWhiteSpace(key))
+            {
+                result[key] = item.Value;
+            }
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyCollection<KeyValuePair<string, ManualMapMetadata>> BuiltInManualMetadata()
+    {
+        return new Dictionary<string, ManualMapMetadata>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["amazonia"] = new("Amazonia", 0),
+            ["Amazonia"] = new("Amazonia", 0),
+            ["concealedhill"] = new("Concealed Hill", 1),
+            ["ConcealedHill"] = new("Concealed Hill", 1),
+            ["echoisles"] = new("Echo Isles", 2),
+            ["EchoIsles"] = new("Echo Isles", 2),
+            ["lastrefuge"] = new("Last Refuge", 3),
+            ["LastRefuge"] = new("Last Refuge", 3),
+            ["northernisles"] = new("Northern Isles", 4),
+            ["NorthernIsles"] = new("Northern Isles", 4),
+            ["terenasstand"] = new("Terenas Stand LV", 5),
+            ["TerenasStand"] = new("Terenas Stand LV", 5),
+            ["TerenasStandLV"] = new("Terenas Stand LV", 5),
+            ["twistedmeadows"] = new("Twisted Meadows", 6),
+            ["TwistedMeadows"] = new("Twisted Meadows", 6),
+            ["turtlerock"] = new("Turtle Rock", 12),
+            ["TurtleRock"] = new("Turtle Rock", 12),
+            ["autumnleaves"] = new("Autumn Leaves", 44),
+            ["AutumnLeaves"] = new("Autumn Leaves", 44),
+            ["autumnleaves201016"] = new("Autumn Leaves", 44),
+            ["AutumnLeavesv2-0"] = new("Autumn Leaves", 44),
+            ["tidehunters"] = new("Tidehunters", 54),
+            ["Tidehunters"] = new("Tidehunters", 54),
+            ["ShatteredExile"] = new("Shattered Exile", 59),
+            ["ShatteredExilev2_06"] = new("Shattered Exile", 59),
+            ["ShatteredExilev2-07"] = new("Shattered Exile", 59),
+            ["ShallowGrave"] = new("Shallow Grave", 61),
+            ["ShallowGravev1_4"] = new("Shallow Grave", 61),
+            ["ruinsofazshara"] = new("Ruins of Azshara", null),
+            ["RuinsOfAzshara"] = new("Ruins of Azshara", null),
+            ["ruinsofazshara201016"] = new("Ruins of Azshara LV", null)
+        };
+    }
+
+    private sealed class ManualMapMetadataFileEntry
+    {
+        public string MapName { get; set; }
+        public int? MapId { get; set; }
+    }
+}
+
+public static class MapKeyNormalizer
+{
+    public static string ExactKey(string value)
+    {
+        return value?.Trim().ToLowerInvariant() ?? string.Empty;
+    }
+
+    public static string StableKey(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var key = Path.GetFileName(value.Trim()).ToLowerInvariant();
+        key = Regex.Replace(key, @"\.(w3x|w3m)$", string.Empty, RegexOptions.IgnoreCase);
+        key = Regex.Replace(key, @"^s\d+[_-]?\d*", string.Empty, RegexOptions.IgnoreCase);
+        key = Regex.Replace(key, @"^\d{10}", string.Empty, RegexOptions.IgnoreCase);
+        key = Regex.Replace(key, @"^\d?c\d{10}", string.Empty, RegexOptions.IgnoreCase);
+        key = Regex.Replace(key, @"^\d?w3c\d{10}", string.Empty, RegexOptions.IgnoreCase);
+        key = Regex.Replace(key, @"w3c\d{10,}$", string.Empty, RegexOptions.IgnoreCase);
+        return Regex.Replace(key, @"[^a-z0-9]", string.Empty, RegexOptions.IgnoreCase);
+    }
+
+    public static string FamilyKey(string value)
+    {
+        var key = StableKey(value);
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return key;
+        }
+
+        key = Regex.Replace(key, @"20\d{4}$", string.Empty, RegexOptions.IgnoreCase);
+        key = Regex.Replace(key, @"v\d+[a-z0-9]*$", string.Empty, RegexOptions.IgnoreCase);
+        key = Regex.Replace(key, @"lv$", string.Empty, RegexOptions.IgnoreCase);
+        return key;
+    }
+
+}

--- a/W3ChampionsStatisticService.Tools/Program.cs
+++ b/W3ChampionsStatisticService.Tools/Program.cs
@@ -1,0 +1,3 @@
+using W3ChampionsStatisticService.Tools.MapMetadataBackfill;
+
+return await MapMetadataBackfillCommand.RunAsync(args);

--- a/W3ChampionsStatisticService.Tools/README.md
+++ b/W3ChampionsStatisticService.Tools/README.md
@@ -45,6 +45,7 @@ MONGO_CONNECTION_STRING="mongodb://..." dotnet run \
 ```
 
 The resolver uses newer `Matchup` rows as the source catalog, plus a small built-in mapping for old-only map keys. Ambiguous or missing matches are reported and skipped.
+When one map id has had multiple display names, the resolver prefers the name from season 24 by default. Use `--preferred-name-season <season>` to choose a different source season for display names.
 
 Dry runs print a short human-readable preview and write the full CSV report. Use `--preview-limit 0` to hide the console preview or increase the limit when reviewing a small dataset.
 

--- a/W3ChampionsStatisticService.Tools/README.md
+++ b/W3ChampionsStatisticService.Tools/README.md
@@ -1,0 +1,63 @@
+# W3ChampionsStatisticService.Tools
+
+Small operational tools for the statistic service.
+
+## Map metadata backfill
+
+Backfills missing `MapName` and `MapId` fields on historical `Matchup` documents. The command is dry-run by default and writes a CSV report before any production run should be applied.
+
+Dry run:
+
+```bash
+MONGO_CONNECTION_STRING="mongodb://..." dotnet run \
+  --project W3ChampionsStatisticService.Tools \
+  -- backfill-map-metadata \
+  --target-min-season 1 \
+  --target-max-season 10 \
+  --source-min-season 11 \
+  --preview-limit 50 \
+  --report map-metadata-backfill-report.csv
+```
+
+To review or apply one season at a time, use `--season`:
+
+```bash
+MONGO_CONNECTION_STRING="mongodb://..." dotnet run \
+  --project W3ChampionsStatisticService.Tools \
+  -- backfill-map-metadata \
+  --season 1 \
+  --source-min-season 11 \
+  --preview-limit 50 \
+  --report map-metadata-backfill-season-1.csv
+```
+
+Apply only the safe, resolved rows:
+
+```bash
+MONGO_CONNECTION_STRING="mongodb://..." dotnet run \
+  --project W3ChampionsStatisticService.Tools \
+  -- backfill-map-metadata \
+  --target-min-season 1 \
+  --target-max-season 10 \
+  --source-min-season 11 \
+  --report map-metadata-backfill-report.csv \
+  --apply
+```
+
+The resolver uses newer `Matchup` rows as the source catalog, plus a small built-in mapping for old-only map keys. Ambiguous or missing matches are reported and skipped.
+
+Dry runs print a short human-readable preview and write the full CSV report. Use `--preview-limit 0` to hide the console preview or increase the limit when reviewing a small dataset.
+
+Optional manual mappings can be supplied when the dry-run report shows gaps:
+
+```json
+{
+  "LegacyMapKey": { "mapName": "Display Name", "mapId": 123 }
+}
+```
+
+Then run with:
+
+```bash
+--manual-map manual-map-metadata.json
+```

--- a/W3ChampionsStatisticService.Tools/W3ChampionsStatisticService.Tools.csproj
+++ b/W3ChampionsStatisticService.Tools/W3ChampionsStatisticService.Tools.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MongoDB.Driver" />
+  </ItemGroup>
+</Project>

--- a/W3ChampionsStatisticService.sln
+++ b/W3ChampionsStatisticService.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "W3C.Domain", "W3C.Domain\W3
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "W3C.Contracts", "W3C.Contracts\W3C.Contracts.csproj", "{4634CE7A-D4EB-4E26-A0FC-1D7252FD260C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "W3ChampionsStatisticService.Tools", "W3ChampionsStatisticService.Tools\W3ChampionsStatisticService.Tools.csproj", "{4C14E6E6-4212-4C31-AB14-392382FAADF7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{4634CE7A-D4EB-4E26-A0FC-1D7252FD260C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4634CE7A-D4EB-4E26-A0FC-1D7252FD260C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4634CE7A-D4EB-4E26-A0FC-1D7252FD260C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C14E6E6-4212-4C31-AB14-392382FAADF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C14E6E6-4212-4C31-AB14-392382FAADF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C14E6E6-4212-4C31-AB14-392382FAADF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C14E6E6-4212-4C31-AB14-392382FAADF7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WC3ChampionsStatisticService.UnitTests/Tools/MapMetadataBackfillTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Tools/MapMetadataBackfillTests.cs
@@ -24,7 +24,24 @@ public class MapMetadataBackfillTests
     }
 
     [Test]
-    public void Resolve_UsesEarliestNameWhenOneMapIdHasLaterDisplayName()
+    public void Resolve_UsesSeason24NameWhenOneMapIdHasLaterDisplayName()
+    {
+        var resolver = new MapMetadataResolver(new[]
+        {
+            new SourceMapMetadata("AutumnLeavesv2-0", "Autumn Leaves", 44, 11, 11, new[] { 1 }, 10),
+            new SourceMapMetadata("2404091839AutumnLeavesv2_0", "Autumn Leaves v2", 44, 24, 24, new[] { 1 }, 10)
+        });
+
+        var resolution = resolver.Resolve("AutumnLeavesv2_0");
+
+        Assert.AreEqual(MapMetadataResolutionStatus.Resolved, resolution.Status);
+        Assert.AreEqual("Autumn Leaves v2", resolution.MapName);
+        Assert.AreEqual(44, resolution.MapId);
+        StringAssert.Contains("season 24", resolution.Notes);
+    }
+
+    [Test]
+    public void Resolve_UsesLatestNameWhenPreferredNameSeasonIsUnavailable()
     {
         var resolver = new MapMetadataResolver(new[]
         {
@@ -35,8 +52,9 @@ public class MapMetadataBackfillTests
         var resolution = resolver.Resolve("AutumnLeavesv2_0");
 
         Assert.AreEqual(MapMetadataResolutionStatus.Resolved, resolution.Status);
-        Assert.AreEqual("Autumn Leaves", resolution.MapName);
+        Assert.AreEqual("Autumn Leaves v2", resolution.MapName);
         Assert.AreEqual(44, resolution.MapId);
+        StringAssert.Contains("latest source-season", resolution.Notes);
     }
 
     [Test]
@@ -82,6 +100,21 @@ public class MapMetadataBackfillTests
 
         Assert.IsFalse(options.Apply);
         Assert.AreEqual(25, options.PreviewLimit);
+        Assert.AreEqual(24, options.PreferredNameSeason);
+    }
+
+    [Test]
+    public void Parse_AllowsPreferredNameSeasonOverride()
+    {
+        var options = MapMetadataBackfillOptions.Parse(new[]
+        {
+            "--connection-string",
+            "mongodb://localhost:27017",
+            "--preferred-name-season",
+            "23"
+        });
+
+        Assert.AreEqual(23, options.PreferredNameSeason);
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/Tools/MapMetadataBackfillTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Tools/MapMetadataBackfillTests.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using W3ChampionsStatisticService.Tools.MapMetadataBackfill;
+
+namespace WC3ChampionsStatisticService.Tests.Tools;
+
+public class MapMetadataBackfillTests
+{
+    [Test]
+    public void Resolve_PrefersExactLegacyEchoIslesOverV2Family()
+    {
+        var resolver = new MapMetadataResolver(new[]
+        {
+            new SourceMapMetadata("EchoIsles", "Echo Isles", 2, 11, 11, new[] { 1 }, 10),
+            new SourceMapMetadata("EchoIslesv2_2", "Echo Isles 2.0", 1051, 12, 12, new[] { 1 }, 10)
+        });
+
+        var resolution = resolver.Resolve("EchoIsles");
+
+        Assert.AreEqual(MapMetadataResolutionStatus.Resolved, resolution.Status);
+        Assert.AreEqual("exact", resolution.Confidence);
+        Assert.AreEqual("Echo Isles", resolution.MapName);
+        Assert.AreEqual(2, resolution.MapId);
+    }
+
+    [Test]
+    public void Resolve_UsesEarliestNameWhenOneMapIdHasLaterDisplayName()
+    {
+        var resolver = new MapMetadataResolver(new[]
+        {
+            new SourceMapMetadata("AutumnLeavesv2-0", "Autumn Leaves", 44, 11, 11, new[] { 1 }, 10),
+            new SourceMapMetadata("2404091839AutumnLeavesv2_0", "Autumn Leaves v2", 44, 20, 20, new[] { 1 }, 10)
+        });
+
+        var resolution = resolver.Resolve("AutumnLeavesv2_0");
+
+        Assert.AreEqual(MapMetadataResolutionStatus.Resolved, resolution.Status);
+        Assert.AreEqual("Autumn Leaves", resolution.MapName);
+        Assert.AreEqual(44, resolution.MapId);
+    }
+
+    [Test]
+    public void Resolve_ReportsAmbiguousFamilyWhenMultipleMapIdsMatch()
+    {
+        var resolver = new MapMetadataResolver(new[]
+        {
+            new SourceMapMetadata("SomeMapv1_0", "Some Map", 10, 11, 11, new[] { 1 }, 10),
+            new SourceMapMetadata("SomeMapv2_0", "Some Map v2", 11, 12, 12, new[] { 1 }, 10)
+        }, new Dictionary<string, ManualMapMetadata>());
+
+        var resolution = resolver.Resolve("SomeMap");
+
+        Assert.AreEqual(MapMetadataResolutionStatus.Ambiguous, resolution.Status);
+    }
+
+    [Test]
+    public void Resolve_UsesManualMetadataForOldOnlyMap()
+    {
+        var resolver = new MapMetadataResolver(new SourceMapMetadata[] { });
+
+        var resolution = resolver.Resolve("RuinsOfAzshara");
+
+        Assert.AreEqual(MapMetadataResolutionStatus.Resolved, resolution.Status);
+        Assert.AreEqual("manual", resolution.Confidence);
+        Assert.AreEqual("Ruins of Azshara", resolution.MapName);
+        Assert.IsNull(resolution.MapId);
+    }
+
+    [TestCase("3c2511040950LastRefugev1_5", "lastrefugev15")]
+    [TestCase("s13_1LastRefugev1_5", "lastrefugev15")]
+    [TestCase("EchoIslesv2_2w3c26012513571051", "echoislesv22")]
+    [TestCase("AutumnLeavesv2-0", "autumnleavesv20")]
+    public void StableKey_RemovesUploadNoiseButKeepsVersionSignal(string input, string expected)
+    {
+        Assert.AreEqual(expected, MapKeyNormalizer.StableKey(input));
+    }
+
+    [Test]
+    public void Parse_DefaultsToDryRunWithConsolePreview()
+    {
+        var options = MapMetadataBackfillOptions.Parse(new[] { "--connection-string", "mongodb://localhost:27017" });
+
+        Assert.IsFalse(options.Apply);
+        Assert.AreEqual(25, options.PreviewLimit);
+    }
+
+    [Test]
+    public void Parse_AllowsPreviewToBeHidden()
+    {
+        var options = MapMetadataBackfillOptions.Parse(new[] { "--connection-string", "mongodb://localhost:27017", "--preview-limit", "0" });
+
+        Assert.AreEqual(0, options.PreviewLimit);
+    }
+
+    [Test]
+    public void Parse_SeasonSetsSingleTargetSeason()
+    {
+        var options = MapMetadataBackfillOptions.Parse(new[]
+        {
+            "--connection-string",
+            "mongodb://localhost:27017",
+            "--season",
+            "3"
+        });
+
+        Assert.AreEqual(3, options.TargetMinSeason);
+        Assert.AreEqual(3, options.TargetMaxSeason);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Tools/MapMetadataBackfillTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Tools/MapMetadataBackfillTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Reflection;
+using MongoDB.Bson;
 using NUnit.Framework;
 using W3ChampionsStatisticService.Tools.MapMetadataBackfill;
 
@@ -138,5 +140,22 @@ public class MapMetadataBackfillTests
 
         Assert.AreEqual(3, options.TargetMinSeason);
         Assert.AreEqual(3, options.TargetMaxSeason);
+    }
+
+    [Test]
+    public void MissingCountExpressions_TreatAbsentFieldsAsNull()
+    {
+        var mapIdExpression = InvokePrivateBsonDocument("CountMissingExpression", "$MapId").ToString();
+        var mapNameExpression = InvokePrivateBsonDocument("CountMissingOrEmptyExpression", "$MapName").ToString();
+
+        StringAssert.Contains("$ifNull", mapIdExpression);
+        StringAssert.Contains("$ifNull", mapNameExpression);
+        StringAssert.Contains("$in", mapNameExpression);
+    }
+
+    private static BsonDocument InvokePrivateBsonDocument(string methodName, string fieldName)
+    {
+        var method = typeof(MapMetadataBackfillCommand).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+        return (BsonDocument)method.Invoke(null, new object[] { fieldName });
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/WC3ChampionsStatisticService.Tests.csproj
+++ b/WC3ChampionsStatisticService.UnitTests/WC3ChampionsStatisticService.Tests.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\W3C.Domain\W3C.Domain.csproj" />
     <ProjectReference Include="..\W3ChampionsStatisticService\W3ChampionsStatisticService.csproj" />
+    <ProjectReference Include="..\W3ChampionsStatisticService.Tools\W3ChampionsStatisticService.Tools.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What changed

Adds a small backend console tool for backfilling missing `MapName` and `MapId` metadata on historical `Matchup` documents.

The tool is intentionally dry-run by default. It builds a source catalog from newer `Matchup` rows, applies known legacy map fallbacks, writes a CSV report, and skips ambiguous or missing mappings instead of guessing.

## Why

Older seasons can have only the normalized `Map` key, which leaves map filters/stat views with ugly or missing names. This gives maintainers a reviewable way to fill historical `MapName` / `MapId` data without making deploy-time database changes.

## How to run a dry run

One season at a time:

```bash
MONGO_CONNECTION_STRING="mongodb://REAL_CONNECTION" dotnet run \
  --project W3ChampionsStatisticService.Tools \
  -- backfill-map-metadata \
  --season 1 \
  --source-min-season 11 \
  --preview-limit 50 \
  --report map-metadata-backfill-season-1.csv
```

Or a range of seasons:

```bash
MONGO_CONNECTION_STRING="mongodb://REAL_CONNECTION" dotnet run \
  --project W3ChampionsStatisticService.Tools \
  -- backfill-map-metadata \
  --target-min-season 1 \
  --target-max-season 10 \
  --source-min-season 11 \
  --preview-limit 50 \
  --report map-metadata-backfill-report.csv
```

This prints a short human-readable preview and writes the full CSV report. No data is changed without `--apply`.

## How to apply after reviewing the report

```bash
MONGO_CONNECTION_STRING="mongodb://REAL_CONNECTION" dotnet run \
  --project W3ChampionsStatisticService.Tools \
  -- backfill-map-metadata \
  --season 1 \
  --source-min-season 11 \
  --preview-limit 50 \
  --report map-metadata-backfill-season-1-apply.csv \
  --apply
```

For a range, use `--target-min-season` and `--target-max-season` instead of `--season`. Ambiguous or missing mappings are still skipped in apply mode.

## Checks

- `DOTNET_ROLL_FORWARD=Major /opt/homebrew/bin/dotnet build W3ChampionsStatisticService.sln --no-restore`
- `DOTNET_ROLL_FORWARD=Major /opt/homebrew/bin/dotnet test W3ChampionsStatisticService.sln --filter MapMetadataBackfillTests`
- Local disposable MongoDB seeded with 11,200 prod-shaped `Matchup` rows from public API samples:
  - dry-run resolved 29/29 old map groups
  - apply updated 7,000 season 1-10 rows
  - post-apply dry-run reported no further writable changes, only name-only rows with unknown map ids skipped
