### PR TITLE
perf(lag-reports): make /api/lag-reports fast (14s → sub-second)

### DIFF
--- a/W3ChampionsStatisticService/LagReports/LagReport.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReport.cs
@@ -24,11 +24,18 @@ public class LagReport : IIdentifiable
     public int FloGameId { get; set; }
 
     public string GameName { get; set; }
+
+    /// <summary>Lowercased copy of GameName for index-backed case-insensitive prefix search.</summary>
+    public string GameNameSearch { get; set; }
+
     public string MapPath { get; set; }
 
     /// <summary>The flo-node that hosted this game.</summary>
     public int ServerNodeId { get; set; }
     public string ServerNodeName { get; set; }
+
+    /// <summary>Lowercased copy of ServerNodeName for index-backed case-insensitive prefix search.</summary>
+    public string ServerNodeNameSearch { get; set; }
 
     /// <summary>True if at least one player explicitly submitted (clicked Submit).</summary>
     public bool HasExplicitReport { get; set; }
@@ -53,6 +60,9 @@ public class LagReportPlayer
 {
     public string BattleTag { get; set; }
 
+    /// <summary>Lowercased copy of BattleTag for index-backed case-insensitive prefix search.</summary>
+    public string BattleTagSearch { get; set; }
+
     /// <summary>Player's public IP at time of game (self-reported by launcher).</summary>
     public string ClientIp { get; set; }
 
@@ -69,8 +79,14 @@ public class LagReportPlayer
     /// <summary>Name of the proxy node (null if direct).</summary>
     public string ProxyName { get; set; }
 
+    /// <summary>Lowercased copy of ProxyName for index-backed case-insensitive prefix search.</summary>
+    public string ProxyNameSearch { get; set; }
+
     /// <summary>IP of the proxy node (null if direct). Split from proxy_address for filtering.</summary>
     public string ProxyIp { get; set; }
+
+    /// <summary>Lowercased copy of ProxyIp for index-backed case-insensitive prefix search.</summary>
+    public string ProxyIpSearch { get; set; }
 
     /// <summary>Port of the proxy node (null if direct).</summary>
     public int? ProxyPort { get; set; }

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -31,20 +32,14 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
             // Server filter
             new(Builders<LagReport>.IndexKeys.Ascending(r => r.ServerNodeId)),
 
-            // Server name filter (partial match)
-            new(Builders<LagReport>.IndexKeys.Ascending(r => r.ServerNodeName)),
-
-            // Game name filter (partial match)
-            new(Builders<LagReport>.IndexKeys.Ascending(r => r.GameName)),
-
-            // Player battle tag filter (inside nested array)
-            new(Builders<LagReport>.IndexKeys.Ascending("Players.BattleTag")),
-
-            // Proxy name filter (inside nested array)
-            new(Builders<LagReport>.IndexKeys.Ascending("Players.ProxyName")),
-
-            // Proxy IP filter (inside nested array)
-            new(Builders<LagReport>.IndexKeys.Ascending("Players.ProxyIp")),
+            // Case-insensitive prefix search: the admin list filters on lowercased shadow
+            // fields with an anchored /^.../ regex so the index can bound the scan. A
+            // case-insensitive regex on the raw field cannot, and fetches every document.
+            new(Builders<LagReport>.IndexKeys.Ascending(r => r.GameNameSearch)),
+            new(Builders<LagReport>.IndexKeys.Ascending(r => r.ServerNodeNameSearch)),
+            new(Builders<LagReport>.IndexKeys.Ascending("Players.BattleTagSearch")),
+            new(Builders<LagReport>.IndexKeys.Ascending("Players.ProxyNameSearch")),
+            new(Builders<LagReport>.IndexKeys.Ascending("Players.ProxyIpSearch")),
 
             // Issue category filter (inside nested array)
             new(Builders<LagReport>.IndexKeys.Ascending("Players.IssueCategories")),
@@ -61,6 +56,25 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
         };
 
         await collection.Indexes.CreateManyAsync(indexes);
+
+        // Drop the raw-field text indexes superseded by the lowercased *Search indexes above:
+        // the list view now filters on the prefix-searchable shadow fields, so these are dead
+        // write overhead. Tolerate "already dropped" so this stays idempotent across restarts.
+        var obsoleteIndexes = new[]
+        {
+            "ServerNodeName_1", "GameName_1", "Players.BattleTag_1", "Players.ProxyName_1", "Players.ProxyIp_1",
+        };
+        foreach (var name in obsoleteIndexes)
+        {
+            try
+            {
+                await collection.Indexes.DropOneAsync(name);
+            }
+            catch (MongoCommandException ex) when (ex.Code == 27 || ex.CodeName == "IndexNotFound")
+            {
+                // Index doesn't exist (fresh DB or already dropped) — nothing to do.
+            }
+        }
     }
 
     /// <summary>
@@ -75,6 +89,12 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
 
         var filter = Builders<LagReport>.Filter.Eq(r => r.FloGameId, floGameId);
 
+        // Maintain lowercased search fields so the admin list can do index-backed
+        // case-insensitive prefix search (see BuildFilters / EnsureIndexesAsync).
+        playerData.BattleTagSearch = playerData.BattleTag?.ToLowerInvariant();
+        playerData.ProxyNameSearch = playerData.ProxyName?.ToLowerInvariant();
+        playerData.ProxyIpSearch = playerData.ProxyIp?.ToLowerInvariant();
+
         // Atomic upsert: push the player and set UpdatedAt on every call,
         // $setOnInsert the template fields only when creating a new document.
         var update = Builders<LagReport>.Update
@@ -84,9 +104,11 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
             .SetOnInsert(r => r.GameId, template.GameId)
             .SetOnInsert(r => r.FloGameId, template.FloGameId)
             .SetOnInsert(r => r.GameName, template.GameName)
+            .SetOnInsert(r => r.GameNameSearch, template.GameName?.ToLowerInvariant())
             .SetOnInsert(r => r.MapPath, template.MapPath)
             .SetOnInsert(r => r.ServerNodeId, template.ServerNodeId)
             .SetOnInsert(r => r.ServerNodeName, template.ServerNodeName)
+            .SetOnInsert(r => r.ServerNodeNameSearch, template.ServerNodeName?.ToLowerInvariant())
             .SetOnInsert(r => r.CreatedAt, DateTime.UtcNow);
 
         if (playerData.IsExplicit)
@@ -131,31 +153,51 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
     public async Task<(List<LagReport> Items, long Total)> GetReports(LagReportQueryRequest req)
     {
         var collection = CreateCollection<LagReport>();
-        var filter = BuildFilter(req);
+        var filters = BuildFilters(req);
+        var hasFilter = filters.Count > 0;
+        var filter = hasFilter ? Builders<LagReport>.Filter.And(filters) : Builders<LagReport>.Filter.Empty;
 
-        var total = await collection.CountDocumentsAsync(filter);
+        // CountDocuments on an empty filter forces a full collection scan: the driver
+        // runs it as a {$group} aggregation rather than the O(1) metadata count, which
+        // dominates the response time of the common unfiltered list view. Use the fast
+        // metadata count when nothing is filtered; filtered counts are index-assisted.
+        var totalTask = hasFilter
+            ? collection.CountDocumentsAsync(filter)
+            : collection.EstimatedDocumentCountAsync();
 
         var sort = Builders<LagReport>.Sort.Descending(r => r.CreatedAt);
 
-        var items = await collection.Find(filter)
+        // The list view only needs the LagEvents/ConnectionEvents counts, never the
+        // heavy per-player MTR/ping arrays. Excluding them avoids deserializing (and
+        // then discarding) multi-megabyte diagnostics payloads on every page.
+        var projection = Builders<LagReport>.Projection
+            .Exclude("Players.Diagnostics.TargetMtr")
+            .Exclude("Players.Diagnostics.AllServerBaselines")
+            .Exclude("Players.Diagnostics.ReverseMtr")
+            .Exclude("Players.Diagnostics.PingHistory")
+            .Exclude(r => r.ServerSidePing);
+
+        var itemsTask = collection.Find(filter)
+            .Project<LagReport>(projection)
             .Sort(sort)
             .Skip(req.Page * req.PageSize)
             .Limit(req.PageSize)
             .ToListAsync();
 
-        return (items, total);
+        // Run the count and the page fetch concurrently rather than serially.
+        await Task.WhenAll(totalTask, itemsTask);
+
+        return (itemsTask.Result, totalTask.Result);
     }
 
-    private static FilterDefinition<LagReport> BuildFilter(LagReportQueryRequest req)
+    private static List<FilterDefinition<LagReport>> BuildFilters(LagReportQueryRequest req)
     {
         var builder = Builders<LagReport>.Filter;
         var filters = new List<FilterDefinition<LagReport>>();
 
         if (!string.IsNullOrEmpty(req.BattleTag))
         {
-            var pattern = new BsonRegularExpression(Regex.Escape(req.BattleTag), "i");
-            filters.Add(builder.ElemMatch(r => r.Players,
-                Builders<LagReportPlayer>.Filter.Regex(p => p.BattleTag, pattern)));
+            filters.Add(builder.Regex("Players.BattleTagSearch", PrefixPattern(req.BattleTag)));
         }
 
         if (!string.IsNullOrEmpty(req.GameSearch))
@@ -169,31 +211,25 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
                 gameFilters.Add(builder.Eq(r => r.FloGameId, gameIdNum));
             }
 
-            // Always also match GameName as partial (case-insensitive)
-            var namePattern = new BsonRegularExpression(Regex.Escape(req.GameSearch), "i");
-            gameFilters.Add(builder.Regex(r => r.GameName, namePattern));
+            // Always also match GameName as a case-insensitive prefix
+            gameFilters.Add(builder.Regex(r => r.GameNameSearch, PrefixPattern(req.GameSearch)));
 
             filters.Add(builder.Or(gameFilters));
         }
 
         if (!string.IsNullOrEmpty(req.ServerName))
         {
-            var pattern = new BsonRegularExpression(Regex.Escape(req.ServerName), "i");
-            filters.Add(builder.Regex(r => r.ServerNodeName, pattern));
+            filters.Add(builder.Regex(r => r.ServerNodeNameSearch, PrefixPattern(req.ServerName)));
         }
 
         if (!string.IsNullOrEmpty(req.ProxyName))
         {
-            var pattern = new BsonRegularExpression(Regex.Escape(req.ProxyName), "i");
-            filters.Add(builder.ElemMatch(r => r.Players,
-                Builders<LagReportPlayer>.Filter.Regex(p => p.ProxyName, pattern)));
+            filters.Add(builder.Regex("Players.ProxyNameSearch", PrefixPattern(req.ProxyName)));
         }
 
         if (!string.IsNullOrEmpty(req.ProxyIp))
         {
-            var pattern = new BsonRegularExpression(Regex.Escape(req.ProxyIp), "i");
-            filters.Add(builder.ElemMatch(r => r.Players,
-                Builders<LagReportPlayer>.Filter.Regex(p => p.ProxyIp, pattern)));
+            filters.Add(builder.Regex("Players.ProxyIpSearch", PrefixPattern(req.ProxyIp)));
         }
 
         if (!string.IsNullOrEmpty(req.DateFrom) && DateTimeOffset.TryParse(req.DateFrom, out var dateFrom))
@@ -216,6 +252,66 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
             filters.Add(builder.Eq(r => r.HasExplicitReport, true));
         }
 
-        return filters.Count > 0 ? builder.And(filters) : builder.Empty;
+        return filters;
+    }
+
+    /// <summary>
+    /// Anchored, case-sensitive regex against a lowercased *Search field — index-backed
+    /// case-insensitive PREFIX matching. A case-insensitive regex on the raw field cannot
+    /// use the index and scans the whole collection.
+    /// </summary>
+    private static BsonRegularExpression PrefixPattern(string value) =>
+        new("^" + Regex.Escape(value.ToLowerInvariant()));
+
+    /// <summary>
+    /// One-shot backfill of the lowercased *Search fields onto documents written before the
+    /// fields existed. Idempotent via the {GameNameSearch exists:false} guard; runs entirely
+    /// server-side as a single aggregation-pipeline UpdateMany. Returns documents updated.
+    /// </summary>
+    public async Task<long> BackfillSearchFields(CancellationToken ct = default)
+    {
+        var collection = CreateCollection<LagReport>();
+
+        var filter = Builders<LagReport>.Filter.Exists(r => r.GameNameSearch, false);
+
+        // $toLower yields "" for null/missing; keep null instead so backfilled values match the
+        // write path (BattleTag?.ToLowerInvariant()) and direct-connection players stay null.
+        static BsonValue Lower(string field) => new BsonDocument("$cond", new BsonArray
+        {
+            new BsonDocument("$ne", new BsonArray { field, BsonNull.Value }),
+            new BsonDocument("$toLower", field),
+            BsonNull.Value,
+        });
+
+        var setStage = new BsonDocument("$set", new BsonDocument
+        {
+            { "GameNameSearch", Lower("$GameName") },
+            { "ServerNodeNameSearch", Lower("$ServerNodeName") },
+            {
+                "Players",
+                new BsonDocument("$map", new BsonDocument
+                {
+                    { "input", "$Players" },
+                    { "as", "p" },
+                    {
+                        "in",
+                        new BsonDocument("$mergeObjects", new BsonArray
+                        {
+                            "$$p",
+                            new BsonDocument
+                            {
+                                { "BattleTagSearch", Lower("$$p.BattleTag") },
+                                { "ProxyNameSearch", Lower("$$p.ProxyName") },
+                                { "ProxyIpSearch", Lower("$$p.ProxyIp") },
+                            },
+                        })
+                    },
+                })
+            },
+        });
+
+        var pipeline = new BsonDocumentStagePipelineDefinition<LagReport, LagReport>(new[] { setStage });
+        var result = await collection.UpdateManyAsync(filter, pipeline, cancellationToken: ct);
+        return result.ModifiedCount;
     }
 }

--- a/W3ChampionsStatisticService/LagReports/LagReportSearchBackfillService.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportSearchBackfillService.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using W3ChampionsStatisticService.Ports;
+
+namespace W3ChampionsStatisticService.LagReports;
+
+/// <summary>
+/// One-shot startup backfill of the LagReport lowercased *Search fields onto documents written
+/// before those fields existed, so the admin list's case-insensitive prefix search works on
+/// historical reports. Runs automatically once: a marker in the HandlerVersions store gates it,
+/// so later startups skip it with a single cheap lookup (no collection scan). The underlying
+/// UpdateMany is itself idempotent, so a crash before the marker is written just resumes next start.
+/// </summary>
+public class LagReportSearchBackfillService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<LagReportSearchBackfillService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            using var scope = scopeFactory.CreateScope();
+            var versions = scope.ServiceProvider.GetRequiredService<IVersionRepository>();
+
+            var marker = await versions.GetLastVersion<LagReportSearchBackfillService>();
+            if (marker.Version != ObjectId.Empty.ToString())
+            {
+                return; // Already backfilled.
+            }
+
+            var repository = scope.ServiceProvider.GetRequiredService<LagReportRepository>();
+            var updated = await repository.BackfillSearchFields(stoppingToken);
+            await versions.SaveLastVersion<LagReportSearchBackfillService>(ObjectId.GenerateNewId().ToString());
+
+            logger.LogInformation("LagReport search-field backfill complete: {Count} document(s) updated", updated);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "LagReport search-field backfill failed");
+        }
+    }
+}

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -289,6 +289,10 @@ if (runBackfill == "true")
     builder.Services.AddUnversionedReadModelService<MatchupHeroBackfillService>();
 }
 
+// One-shot, self-gating backfill of the LagReport lowercased *Search fields onto pre-existing
+// documents. Runs automatically once (marker in HandlerVersions); a cheap no-op on later startups.
+builder.Services.AddHostedService<W3ChampionsStatisticService.LagReports.LagReportSearchBackfillService>();
+
 var app = builder.Build();
 
 app.UseForwardedHeaders(new ForwardedHeadersOptions

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
 using NUnit.Framework;
 using W3ChampionsStatisticService.LagReports;
 
@@ -247,5 +249,111 @@ public class LagReportRepositoryTests : IntegrationTestBase
 
         var (items, _) = await _repo.GetReports(new LagReportQueryRequest());
         Assert.IsTrue(items[0].CreatedAt >= items[1].CreatedAt);
+    }
+
+    [Test]
+    public async Task GetReports_ExcludesHeavyDiagnosticsArraysButKeepsEventCounts()
+    {
+        // CreatePlayer populates LagEvents (needed by the list view) AND PingHistory
+        // (one of the heavy arrays the list projection drops). UpdateServerSidePing
+        // adds the top-level ServerSidePing array, which the list view also drops.
+        var template = CreateTemplate(floGameId: 9101, gameId: 13101);
+        var reportId = await _repo.UpsertPlayerData(template.FloGameId, CreatePlayer("Heavy#1"), template);
+        await _repo.UpdateServerSidePing(reportId, new List<ServerSidePingData>
+        {
+            new() { PlayerId = 1, PlayerName = "Heavy#1", Samples = [new ServerPingSample { Time = 60, Avg = 22 }] }
+        });
+
+        var (items, total) = await _repo.GetReports(new LagReportQueryRequest());
+
+        Assert.AreEqual(1, total); // unfiltered total comes from the fast metadata count
+        Assert.AreEqual(1, items.Count);
+
+        var diag = items[0].Players[0].Diagnostics;
+        Assert.AreEqual(1, diag.LagEvents.Count, "LagEvents must be kept — the list view reports their count");
+        Assert.That(diag.PingHistory, Is.Null.Or.Empty, "PingHistory is a heavy array and must be projected out");
+        Assert.That(diag.TargetMtr, Is.Null.Or.Empty, "TargetMtr is a heavy array and must be projected out");
+        Assert.IsNull(items[0].ServerSidePing, "ServerSidePing must be projected out of the list view");
+    }
+
+    [Test]
+    public async Task GetReports_BattleTagSearchIsCaseInsensitivePrefix()
+    {
+        var t = CreateTemplate(floGameId: 9201, gameId: 13201);
+        await _repo.UpsertPlayerData(t.FloGameId, CreatePlayer("Alice#1111"), t);
+
+        // Case-insensitive: different casing than stored still matches.
+        var (upper, _) = await _repo.GetReports(new LagReportQueryRequest { BattleTag = "ALICE" });
+        Assert.AreEqual(1, upper.Count);
+
+        // Prefix, not contains: a mid-string fragment must NOT match.
+        var (mid, _) = await _repo.GetReports(new LagReportQueryRequest { BattleTag = "lice" });
+        Assert.AreEqual(0, mid.Count);
+    }
+
+    [Test]
+    public async Task BackfillSearchFields_PopulatesLegacyDocumentsForPrefixSearch()
+    {
+        // Simulate a document written before the *Search fields existed (fields absent, not null).
+        var collection = MongoClient
+            .GetDatabase("W3Champions-Statistic-Service")
+            .GetCollection<BsonDocument>("LagReport");
+        await collection.InsertOneAsync(new BsonDocument
+        {
+            { "_id", Guid.NewGuid().ToString() },
+            { "GameId", 99001 },
+            { "FloGameId", 99001 },
+            { "GameName", "Legacy Game" },
+            { "ServerNodeName", "EU Legacy" },
+            { "HasExplicitReport", false },
+            { "Players", new BsonArray { new BsonDocument { { "BattleTag", "Legacy#9999" } } } },
+            { "CreatedAt", DateTime.UtcNow },
+            { "UpdatedAt", DateTime.UtcNow },
+        });
+
+        // Before backfill: prefix search can't find it — there is no BattleTagSearch field.
+        var (before, _) = await _repo.GetReports(new LagReportQueryRequest { BattleTag = "Legacy" });
+        Assert.AreEqual(0, before.Count);
+
+        var updated = await _repo.BackfillSearchFields();
+        Assert.AreEqual(1, updated);
+
+        // After backfill: case-insensitive prefix search finds it.
+        var (after, _) = await _repo.GetReports(new LagReportQueryRequest { BattleTag = "legacy" });
+        Assert.AreEqual(1, after.Count);
+        Assert.AreEqual("Legacy#9999", after[0].Players[0].BattleTag);
+
+        // Re-running is a no-op (idempotent guard).
+        Assert.AreEqual(0, await _repo.BackfillSearchFields());
+    }
+
+    [Test]
+    public async Task EnsureIndexesAsync_DropsSupersededIndexesAndIsIdempotent()
+    {
+        var collection = MongoClient
+            .GetDatabase("W3Champions-Statistic-Service")
+            .GetCollection<BsonDocument>("LagReport");
+
+        // First run on a clean DB: the obsolete indexes don't exist, so the drops must be tolerated.
+        Assert.DoesNotThrowAsync(async () => await _repo.EnsureIndexesAsync());
+
+        // Simulate a legacy raw-field index left over from before the migration.
+        await collection.Indexes.CreateOneAsync(new CreateIndexModel<BsonDocument>(
+            Builders<BsonDocument>.IndexKeys.Ascending("Players.BattleTag")));
+
+        // Second run must drop the superseded index — and re-running stays idempotent.
+        Assert.DoesNotThrowAsync(async () => await _repo.EnsureIndexesAsync());
+
+        var names = new List<string>();
+        using (var cursor = await collection.Indexes.ListAsync())
+        {
+            foreach (var idx in await cursor.ToListAsync())
+            {
+                names.Add(idx["name"].AsString);
+            }
+        }
+
+        Assert.IsFalse(names.Contains("Players.BattleTag_1"), "superseded raw-field index should be dropped");
+        Assert.IsTrue(names.Contains("Players.BattleTagSearch_1"), "new shadow-field index should exist");
     }
 }


### PR DESCRIPTION
## Problem

The admin lag-reports list (`GET /api/lag-reports`) was very slow:

- **Unfiltered** (`?page=0&pageSize=25`): ~**14s** (reproduced via curl; TLS/connect ~90ms, so 100% server-side).
- **Filtered** (`?battleTag=BsK`): also multi-second.

## Root causes (confirmed via production `explain executionStats`, ~72k docs)

**Unfiltered** — the indexed `find` is ~1ms. The cost is the count: the C# driver's `CountDocumentsAsync({})` is translated into a `{$group}` aggregation that `COLLSCAN`s every document (**11.5s**). (The `count` command itself is `RECORD_STORE_FAST_COUNT` = 0ms — but `CountDocuments` doesn't use it.)

**Filtered** — the text filters used a **case-insensitive `$regex`** (`/BsK/i`). A btree index can't bound a case-insensitive regex, so MongoDB fetched every candidate document to test it:

| half | plan | time | docs fetched |
|---|---|---|---|
| `count` | scan all `Players.BattleTag` keys → FETCH all docs | **14.8s** | 71,892 |
| `find` | walk `CreatedAt`, FETCH + post-filter | 4.2s | 46,037 |

I verified the whole space on prod: case-insensitive contains, case-**sensitive** contains, and dropping `$elemMatch` **all** scan everything. Only a **prefix-anchored** regex `/^BsK/` gets tight index bounds (`["BsK","BsL")`) → **6ms find / 0ms count**.

## Changes

**Unfiltered list**
- Empty filter → `EstimatedDocumentCount` (O(1) metadata) instead of the scanning `CountDocuments`.
- Count and page-fetch run **concurrently** (`Task.WhenAll`).
- List query now **projects away** the heavy per-player diagnostics arrays (`TargetMtr`, `AllServerBaselines`, `ReverseMtr`, `PingHistory`, `ServerSidePing`) — the list view only needs `LagEvents`/`ConnectionEvents` counts.

**Filtered text search → index-backed case-insensitive prefix**
- New lowercased shadow fields: `Players.{BattleTagSearch,ProxyNameSearch,ProxyIpSearch}`, `GameNameSearch`, `ServerNodeNameSearch`, derived centrally in `UpsertPlayerData` and indexed in `EnsureIndexesAsync`.
- The 5 text filters now query the shadow fields with an anchored `/^<input.ToLowerInvariant()>/` regex.
- **One-shot, self-gating backfill** (`LagReportSearchBackfillService`) populates the shadow fields on pre-existing documents automatically on startup, gated by a `HandlerVersions` marker (cheap no-op on later startups; resumable since the `UpdateMany` is idempotent).
- **Drops** the 5 raw-field text indexes (`ServerNodeName_1`, `GameName_1`, `Players.BattleTag_1`, `Players.ProxyName_1`, `Players.ProxyIp_1`) now superseded by the shadow-field indexes.

## ⚠️ Behavior change

Filtered text search is now case-insensitive **"starts with"** rather than **"contains"**. Admins typing the start of a name/tag still work; a mid-string fragment (e.g. just the `#1234` discriminator) no longer matches. The frontend filter box (`website` repo, `AdminLagReports.vue`) may warrant a "starts with…" hint — separate PR.

## Deploy notes

Fully hands-off: on startup the new indexes are created, the 5 superseded ones dropped, and the backfill runs **once** automatically. No env vars or manual steps. Until the backfill completes, historical reports aren't searchable by the text filters (or self-heal within the existing 90-day TTL).

Minor: MongoDB `$toLower` (backfill) is ASCII-only vs C# `ToLowerInvariant` (write path, full Unicode) — a non-ASCII-uppercase battletag in *legacy* data wouldn't match until TTL refresh. Battletags are near-universally ASCII.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` LagReport repository suite — **17/17 pass**: existing filters still pass under prefix semantics; new tests cover case-insensitive-prefix (`ALICE` matches, mid-string `lice` doesn't), backfill of legacy docs + idempotency, superseded-index drop + idempotency, projection, and unfiltered count.
- [x] `dotnet format --verify-no-changes` — clean
- [ ] CI full suite
