### PR TITLE
Proxy player warning admin actions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,13 +21,13 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="nunit" Version="3.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />

--- a/W3C.Contracts/Admin/Permission/Permission.cs
+++ b/W3C.Contracts/Admin/Permission/Permission.cs
@@ -11,16 +11,16 @@ public class Permission
 
 public enum EPermission
 {
-    Permissions,
-    Moderation,
-    Queue,
-    Logs,
-    Maps,
-    Tournaments,
-    Content,
-    Proxies,
-    Warnings,
-    SmurfCheckerQuery,
-    SmurfCheckerQueryExplanation,
-    SmurfCheckerAdministration,
+    Permissions = 0,
+    Moderation = 1,
+    Queue = 2,
+    Logs = 3,
+    Maps = 4,
+    Tournaments = 5,
+    Content = 6,
+    Proxies = 7,
+    SmurfCheckerQuery = 8,
+    SmurfCheckerQueryExplanation = 9,
+    SmurfCheckerAdministration = 10,
+    Warnings = 11,
 }

--- a/W3C.Contracts/Admin/Permission/Permission.cs
+++ b/W3C.Contracts/Admin/Permission/Permission.cs
@@ -19,6 +19,7 @@ public enum EPermission
     Tournaments,
     Content,
     Proxies,
+    Warnings,
     SmurfCheckerQuery,
     SmurfCheckerQueryExplanation,
     SmurfCheckerAdministration,

--- a/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
+++ b/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
@@ -114,6 +114,22 @@ public class MatchmakingServiceClient
         return null;
     }
 
+    public async Task<List<PlayerWarningDefinition>> GetPlayerWarningDefinitions()
+    {
+        var url = $"{MatchmakingApiUrl}/admin/warning-definitions";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("x-admin-secret", AdminSecret);
+        var response = await _httpClient.SendAsync(request);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return await GetResult<List<PlayerWarningDefinition>>(response);
+        }
+
+        await HandleMMError(response);
+        return null;
+    }
+
     public async Task<CreatePlayerWarningResponse> CreatePlayerWarning(CreatePlayerWarningRequest warningRequest)
     {
         var url = $"{MatchmakingApiUrl}/admin/warnings";
@@ -704,8 +720,7 @@ public class CreatePlayerWarningRequest
 {
     public string targetBattleTag { get; set; }
     public string issuedByBattleTag { get; set; }
-    public string rule { get; set; }
-    public string category { get; set; }
+    public string warningDefinitionId { get; set; }
     public string severity { get; set; }
     public Dictionary<string, string> title { get; set; }
     public Dictionary<string, string> body { get; set; }
@@ -721,6 +736,7 @@ public class PlayerWarning
     public string _id { get; set; }
     public string targetBattleTag { get; set; }
     public string issuedByBattleTag { get; set; }
+    public string warningDefinitionId { get; set; }
     public string rule { get; set; }
     public string category { get; set; }
     public string severity { get; set; }
@@ -733,6 +749,16 @@ public class PlayerWarning
     public DateTime? cancelledAt { get; set; }
     public string cancelledByBattleTag { get; set; }
     public List<PlayerWarningDeliveryAttempt> deliveryAttempts { get; set; }
+}
+
+public class PlayerWarningDefinition
+{
+    public string _id { get; set; }
+    public string severity { get; set; }
+    public Dictionary<string, string> title { get; set; }
+    public Dictionary<string, string> body { get; set; }
+    public bool enabled { get; set; }
+    public int sortOrder { get; set; }
 }
 
 public class PlayerWarningDeliveryAttempt

--- a/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
+++ b/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
@@ -87,6 +87,69 @@ public class MatchmakingServiceClient
         return null;
     }
 
+    public async Task<PlayerWarningsResponse> GetPlayerWarnings(PlayerWarningsGetRequest req)
+    {
+        var url = $"{MatchmakingApiUrl}/admin/warnings?page={req.Page}&itemsPerPage={req.ItemsPerPage}";
+
+        if (!string.IsNullOrEmpty(req.BattleTag))
+        {
+            url += $"&battleTag={HttpUtility.UrlEncode(req.BattleTag)}";
+        }
+
+        if (!string.IsNullOrEmpty(req.Status))
+        {
+            url += $"&status={HttpUtility.UrlEncode(req.Status)}";
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("x-admin-secret", AdminSecret);
+        var response = await _httpClient.SendAsync(request);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return await GetResult<PlayerWarningsResponse>(response);
+        }
+
+        await HandleMMError(response);
+        return null;
+    }
+
+    public async Task<CreatePlayerWarningResponse> CreatePlayerWarning(CreatePlayerWarningRequest warningRequest)
+    {
+        var url = $"{MatchmakingApiUrl}/admin/warnings";
+        var httpcontent = new StringContent(SerializeData(warningRequest), Encoding.UTF8, "application/json");
+        var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Headers.Add("x-admin-secret", AdminSecret);
+        request.Content = httpcontent;
+        var response = await _httpClient.SendAsync(request);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return await GetResult<CreatePlayerWarningResponse>(response);
+        }
+
+        await HandleMMError(response);
+        return null;
+    }
+
+    public async Task<PlayerWarning> CancelPlayerWarning(string id, CancelPlayerWarningRequest cancelRequest)
+    {
+        var url = $"{MatchmakingApiUrl}/admin/warnings/{HttpUtility.UrlEncode(id)}/cancel";
+        var httpcontent = new StringContent(SerializeData(cancelRequest), Encoding.UTF8, "application/json");
+        var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Headers.Add("x-admin-secret", AdminSecret);
+        request.Content = httpcontent;
+        var response = await _httpClient.SendAsync(request);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return await GetResult<PlayerWarning>(response);
+        }
+
+        await HandleMMError(response);
+        return null;
+    }
+
     public async Task<List<MappedQueue>> GetLiveQueueData()
     {
         var url = $"{MatchmakingApiUrl}/queue/snapshots";
@@ -615,6 +678,66 @@ public class BannedPlayerResponse
 {
     public int total { get; set; }
     public List<BannedPlayerReadmodel> players { get; set; }
+}
+
+public class PlayerWarningsGetRequest
+{
+    public int Page { get; set; } = 1;
+    public int ItemsPerPage { get; set; } = 25;
+    public string BattleTag { get; set; }
+    public string Status { get; set; }
+}
+
+public class PlayerWarningsResponse
+{
+    public int total { get; set; }
+    public List<PlayerWarning> warnings { get; set; }
+}
+
+public class CreatePlayerWarningResponse
+{
+    public PlayerWarning warning { get; set; }
+    public bool delivered { get; set; }
+}
+
+public class CreatePlayerWarningRequest
+{
+    public string targetBattleTag { get; set; }
+    public string issuedByBattleTag { get; set; }
+    public string rule { get; set; }
+    public string category { get; set; }
+    public string severity { get; set; }
+    public Dictionary<string, string> title { get; set; }
+    public Dictionary<string, string> body { get; set; }
+}
+
+public class CancelPlayerWarningRequest
+{
+    public string cancelledByBattleTag { get; set; }
+}
+
+public class PlayerWarning
+{
+    public string _id { get; set; }
+    public string targetBattleTag { get; set; }
+    public string issuedByBattleTag { get; set; }
+    public string rule { get; set; }
+    public string category { get; set; }
+    public string severity { get; set; }
+    public Dictionary<string, string> title { get; set; }
+    public Dictionary<string, string> body { get; set; }
+    public string status { get; set; }
+    public DateTime createdAt { get; set; }
+    public DateTime? sentAt { get; set; }
+    public DateTime? acknowledgedAt { get; set; }
+    public DateTime? cancelledAt { get; set; }
+    public string cancelledByBattleTag { get; set; }
+    public List<PlayerWarningDeliveryAttempt> deliveryAttempts { get; set; }
+}
+
+public class PlayerWarningDeliveryAttempt
+{
+    public DateTime attemptedAt { get; set; }
 }
 
 public class UserVisibleBanReason

--- a/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
+++ b/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
@@ -805,6 +805,8 @@ public class PlayerWarning
     public DateTime? acknowledgedAt { get; set; }
     public DateTime? cancelledAt { get; set; }
     public string cancelledByBattleTag { get; set; }
+    public DateTime? undeliverableAt { get; set; }
+    public string undeliverableReason { get; set; }
     public List<PlayerWarningDeliveryAttempt> deliveryAttempts { get; set; }
 }
 

--- a/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
+++ b/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
@@ -114,9 +114,14 @@ public class MatchmakingServiceClient
         return null;
     }
 
-    public async Task<List<PlayerWarningDefinition>> GetPlayerWarningDefinitions()
+    public async Task<List<PlayerWarningDefinition>> GetPlayerWarningDefinitions(bool includeDisabled = false)
     {
         var url = $"{MatchmakingApiUrl}/admin/warning-definitions";
+        if (includeDisabled)
+        {
+            url += "?includeDisabled=true";
+        }
+
         var request = new HttpRequestMessage(HttpMethod.Get, url);
         request.Headers.Add("x-admin-secret", AdminSecret);
         var response = await _httpClient.SendAsync(request);
@@ -124,6 +129,60 @@ public class MatchmakingServiceClient
         if (response.IsSuccessStatusCode)
         {
             return await GetResult<List<PlayerWarningDefinition>>(response);
+        }
+
+        await HandleMMError(response);
+        return null;
+    }
+
+    public async Task<PlayerWarningDefinition> CreatePlayerWarningDefinition(PlayerWarningDefinitionRequest warningDefinitionRequest)
+    {
+        var url = $"{MatchmakingApiUrl}/admin/warning-definitions";
+        var httpcontent = new StringContent(SerializeData(warningDefinitionRequest), Encoding.UTF8, "application/json");
+        var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Headers.Add("x-admin-secret", AdminSecret);
+        request.Content = httpcontent;
+        var response = await _httpClient.SendAsync(request);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return await GetResult<PlayerWarningDefinition>(response);
+        }
+
+        await HandleMMError(response);
+        return null;
+    }
+
+    public async Task<PlayerWarningDefinition> UpdatePlayerWarningDefinition(string id, PlayerWarningDefinitionRequest warningDefinitionRequest)
+    {
+        var url = $"{MatchmakingApiUrl}/admin/warning-definitions/{HttpUtility.UrlEncode(id)}";
+        var httpcontent = new StringContent(SerializeData(warningDefinitionRequest), Encoding.UTF8, "application/json");
+        var request = new HttpRequestMessage(HttpMethod.Put, url);
+        request.Headers.Add("x-admin-secret", AdminSecret);
+        request.Content = httpcontent;
+        var response = await _httpClient.SendAsync(request);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return await GetResult<PlayerWarningDefinition>(response);
+        }
+
+        await HandleMMError(response);
+        return null;
+    }
+
+    public async Task<PlayerWarningDefinition> DisablePlayerWarningDefinition(string id, DisablePlayerWarningDefinitionRequest disableRequest)
+    {
+        var url = $"{MatchmakingApiUrl}/admin/warning-definitions/{HttpUtility.UrlEncode(id)}";
+        var httpcontent = new StringContent(SerializeData(disableRequest), Encoding.UTF8, "application/json");
+        var request = new HttpRequestMessage(HttpMethod.Delete, url);
+        request.Headers.Add("x-admin-secret", AdminSecret);
+        request.Content = httpcontent;
+        var response = await _httpClient.SendAsync(request);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return await GetResult<PlayerWarningDefinition>(response);
         }
 
         await HandleMMError(response);
@@ -737,8 +796,6 @@ public class PlayerWarning
     public string targetBattleTag { get; set; }
     public string issuedByBattleTag { get; set; }
     public string warningDefinitionId { get; set; }
-    public string rule { get; set; }
-    public string category { get; set; }
     public string severity { get; set; }
     public Dictionary<string, string> title { get; set; }
     public Dictionary<string, string> body { get; set; }
@@ -759,6 +816,24 @@ public class PlayerWarningDefinition
     public Dictionary<string, string> body { get; set; }
     public bool enabled { get; set; }
     public int sortOrder { get; set; }
+    public string createdByBattleTag { get; set; }
+    public string updatedByBattleTag { get; set; }
+}
+
+public class PlayerWarningDefinitionRequest
+{
+    public string severity { get; set; }
+    public Dictionary<string, string> title { get; set; }
+    public Dictionary<string, string> body { get; set; }
+    public bool? enabled { get; set; }
+    public int? sortOrder { get; set; }
+    public string createdByBattleTag { get; set; }
+    public string updatedByBattleTag { get; set; }
+}
+
+public class DisablePlayerWarningDefinitionRequest
+{
+    public string updatedByBattleTag { get; set; }
 }
 
 public class PlayerWarningDeliveryAttempt

--- a/W3ChampionsStatisticService/Admin/AdminController.cs
+++ b/W3ChampionsStatisticService/Admin/AdminController.cs
@@ -94,10 +94,45 @@ public class AdminController(
 
     [HttpGet("warning-definitions")]
     [BearerHasPermissionFilter(Permission = EPermission.Warnings)]
-    public async Task<IActionResult> GetWarningDefinitions()
+    public async Task<IActionResult> GetWarningDefinitions([FromQuery] bool includeDisabled = false)
     {
-        var definitions = await _matchmakingServiceRepository.GetPlayerWarningDefinitions();
+        var definitions = await _matchmakingServiceRepository.GetPlayerWarningDefinitions(includeDisabled);
         return Ok(definitions);
+    }
+
+    [HttpPost("warning-definitions")]
+    [BearerHasPermissionFilter(Permission = EPermission.Warnings)]
+    public async Task<IActionResult> CreateWarningDefinition([FromBody] PlayerWarningDefinitionRequest request, [NoTrace] string battleTag)
+    {
+        if (request == null)
+            return BadRequest(new { error = "invalid_request" });
+
+        request.createdByBattleTag = battleTag;
+        var definition = await _matchmakingServiceRepository.CreatePlayerWarningDefinition(request);
+        return Ok(definition);
+    }
+
+    [HttpPut("warning-definitions/{id}")]
+    [BearerHasPermissionFilter(Permission = EPermission.Warnings)]
+    public async Task<IActionResult> UpdateWarningDefinition([FromRoute] string id, [FromBody] PlayerWarningDefinitionRequest request, [NoTrace] string battleTag)
+    {
+        if (request == null)
+            return BadRequest(new { error = "invalid_request" });
+
+        request.updatedByBattleTag = battleTag;
+        var definition = await _matchmakingServiceRepository.UpdatePlayerWarningDefinition(id, request);
+        return Ok(definition);
+    }
+
+    [HttpDelete("warning-definitions/{id}")]
+    [BearerHasPermissionFilter(Permission = EPermission.Warnings)]
+    public async Task<IActionResult> DeleteWarningDefinition([FromRoute] string id, [NoTrace] string battleTag)
+    {
+        var definition = await _matchmakingServiceRepository.DisablePlayerWarningDefinition(id, new DisablePlayerWarningDefinitionRequest
+        {
+            updatedByBattleTag = battleTag
+        });
+        return Ok(definition);
     }
 
     [HttpPost("warnings")]

--- a/W3ChampionsStatisticService/Admin/AdminController.cs
+++ b/W3ChampionsStatisticService/Admin/AdminController.cs
@@ -73,6 +73,56 @@ public class AdminController(
         return Ok();
     }
 
+    [HttpGet("warnings")]
+    [BearerHasPermissionFilter(Permission = EPermission.Warnings)]
+    public async Task<IActionResult> GetWarnings([FromQuery] PlayerWarningsGetRequest req)
+    {
+        if (!string.IsNullOrWhiteSpace(req.BattleTag))
+        {
+            var canonical = await _battleTagResolver.ResolveCanonical(req.BattleTag);
+            if (canonical == null)
+                return BadRequest(new { error = "user_not_found", input = req.BattleTag });
+
+            req.BattleTag = canonical;
+        }
+
+        req.Page = req.Page <= 0 ? 1 : req.Page;
+        req.ItemsPerPage = req.ItemsPerPage <= 0 ? 25 : req.ItemsPerPage;
+        var warnings = await _matchmakingServiceRepository.GetPlayerWarnings(req);
+        return Ok(warnings);
+    }
+
+    [HttpPost("warnings")]
+    [BearerHasPermissionFilter(Permission = EPermission.Warnings)]
+    public async Task<IActionResult> CreateWarning([FromBody] CreatePlayerWarningRequest request, [NoTrace] string battleTag)
+    {
+        if (request == null)
+            return BadRequest(new { error = "invalid_request" });
+
+        var canonical = await _battleTagResolver.ResolveCanonical(request.targetBattleTag);
+        if (canonical == null)
+            return BadRequest(new { error = "user_not_found", input = request.targetBattleTag });
+
+        request.targetBattleTag = canonical;
+        request.issuedByBattleTag = battleTag;
+        request.severity = string.IsNullOrWhiteSpace(request.severity) ? "Warning" : request.severity;
+
+        var warning = await _matchmakingServiceRepository.CreatePlayerWarning(request);
+        return Ok(warning);
+    }
+
+    [HttpPost("warnings/{id}/cancel")]
+    [BearerHasPermissionFilter(Permission = EPermission.Warnings)]
+    public async Task<IActionResult> CancelWarning([FromRoute] string id, [NoTrace] string battleTag)
+    {
+        var warning = await _matchmakingServiceRepository.CancelPlayerWarning(id, new CancelPlayerWarningRequest
+        {
+            cancelledByBattleTag = battleTag
+        });
+
+        return Ok(warning);
+    }
+
     [HttpGet("ban-reason-translations")]
     [BearerHasPermissionFilter(Permission = EPermission.Moderation)]
     public async Task<IActionResult> GetBanReasonTranslations()

--- a/W3ChampionsStatisticService/Admin/AdminController.cs
+++ b/W3ChampionsStatisticService/Admin/AdminController.cs
@@ -92,6 +92,14 @@ public class AdminController(
         return Ok(warnings);
     }
 
+    [HttpGet("warning-definitions")]
+    [BearerHasPermissionFilter(Permission = EPermission.Warnings)]
+    public async Task<IActionResult> GetWarningDefinitions()
+    {
+        var definitions = await _matchmakingServiceRepository.GetPlayerWarningDefinitions();
+        return Ok(definitions);
+    }
+
     [HttpPost("warnings")]
     [BearerHasPermissionFilter(Permission = EPermission.Warnings)]
     public async Task<IActionResult> CreateWarning([FromBody] CreatePlayerWarningRequest request, [NoTrace] string battleTag)
@@ -105,7 +113,6 @@ public class AdminController(
 
         request.targetBattleTag = canonical;
         request.issuedByBattleTag = battleTag;
-        request.severity = string.IsNullOrWhiteSpace(request.severity) ? "Warning" : request.severity;
 
         var warning = await _matchmakingServiceRepository.CreatePlayerWarning(request);
         return Ok(warning);

--- a/WC3ChampionsStatisticService.UnitTests/Admin/AdminWarningsControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/AdminWarningsControllerTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;

--- a/WC3ChampionsStatisticService.UnitTests/Admin/AdminWarningsControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/AdminWarningsControllerTests.cs
@@ -27,8 +27,23 @@ public class AdminWarningsControllerTests
     public void WarningEndpointsRequireWarningsPermission()
     {
         AssertWarningsPermission(nameof(AdminController.GetWarnings));
+        AssertWarningsPermission(nameof(AdminController.GetWarningDefinitions));
         AssertWarningsPermission(nameof(AdminController.CreateWarning));
         AssertWarningsPermission(nameof(AdminController.CancelWarning));
+    }
+
+    [Test]
+    public async Task GetWarningDefinitionsForwardsAdminSecret()
+    {
+        var handler = new CapturingHandler("[{\"_id\":\"chat-conduct\",\"severity\":\"Warning\",\"title\":{\"en\":\"Chat conduct reminder\"},\"body\":{\"en\":\"Please keep chat respectful.\"},\"enabled\":true,\"sortOrder\":10}]");
+        var controller = CreateController(handler, Mock.Of<IBattleTagResolver>());
+
+        var result = await controller.GetWarningDefinitions();
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        Assert.That(handler.Requests[0].Headers.Contains("x-admin-secret"), Is.True);
+        Assert.That(handler.Requests[0].RequestUri!.AbsolutePath, Does.EndWith("/admin/warning-definitions"));
     }
 
     [Test]
@@ -42,9 +57,7 @@ public class AdminWarningsControllerTests
         var result = await controller.CreateWarning(new CreatePlayerWarningRequest
         {
             targetBattleTag = "grubby#1234",
-            severity = "",
-            title = new Dictionary<string, string> { ["en"] = "Careful" },
-            body = new Dictionary<string, string> { ["en"] = "Please mind rule 2." },
+            warningDefinitionId = "chat-conduct",
         }, "Admin#1");
 
         Assert.That(result, Is.InstanceOf<OkObjectResult>());
@@ -54,9 +67,10 @@ public class AdminWarningsControllerTests
         var body = JObject.Parse(handler.RequestBodies[0]);
         Assert.That(body["targetBattleTag"]!.Value<string>(), Is.EqualTo("Grubby#1234"));
         Assert.That(body["issuedByBattleTag"]!.Value<string>(), Is.EqualTo("Admin#1"));
-        Assert.That(body["rule"], Is.Null);
-        Assert.That(body["category"], Is.Null);
-        Assert.That(body["severity"]!.Value<string>(), Is.EqualTo("Warning"));
+        Assert.That(body["warningDefinitionId"]!.Value<string>(), Is.EqualTo("chat-conduct"));
+        Assert.That(body["severity"], Is.Null);
+        Assert.That(body["title"], Is.Null);
+        Assert.That(body["body"], Is.Null);
     }
 
     [Test]
@@ -99,6 +113,34 @@ public class AdminWarningsControllerTests
     }
 
     [Test]
+    public async Task CreateCustomWarningCanonicalizesTargetAndForwardsCustomSnapshot()
+    {
+        var handler = new CapturingHandler();
+        var resolver = new Mock<IBattleTagResolver>();
+        resolver.Setup(r => r.ResolveCanonical("grubby#1234")).ReturnsAsync("Grubby#1234");
+        var controller = CreateController(handler, resolver.Object);
+
+        var result = await controller.CreateWarning(new CreatePlayerWarningRequest
+        {
+            targetBattleTag = "grubby#1234",
+            severity = "Critical",
+            title = new Dictionary<string, string> { ["en"] = "Custom title" },
+            body = new Dictionary<string, string> { ["en"] = "Custom body" },
+        }, "Admin#1");
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+
+        var body = JObject.Parse(handler.RequestBodies[0]);
+        Assert.That(body["targetBattleTag"]!.Value<string>(), Is.EqualTo("Grubby#1234"));
+        Assert.That(body["issuedByBattleTag"]!.Value<string>(), Is.EqualTo("Admin#1"));
+        Assert.That(body["warningDefinitionId"], Is.Null);
+        Assert.That(body["severity"]!.Value<string>(), Is.EqualTo("Critical"));
+        Assert.That(body["title"]!["en"]!.Value<string>(), Is.EqualTo("Custom title"));
+        Assert.That(body["body"]!["en"]!.Value<string>(), Is.EqualTo("Custom body"));
+    }
+
+    [Test]
     public async Task CreateWarningRejectsUnknownTargetBeforeProxying()
     {
         var handler = new CapturingHandler();
@@ -109,9 +151,7 @@ public class AdminWarningsControllerTests
         var result = await controller.CreateWarning(new CreatePlayerWarningRequest
         {
             targetBattleTag = "missing#1",
-            severity = "Warning",
-            title = new Dictionary<string, string> { ["en"] = "Careful" },
-            body = new Dictionary<string, string> { ["en"] = "Please mind rule 2." },
+            warningDefinitionId = "chat-conduct",
         }, "Admin#1");
 
         Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
@@ -163,7 +203,7 @@ public class AdminWarningsControllerTests
         public HttpClient CreateClient(string name) => client;
     }
 
-    private class CapturingHandler(string responseBody = "{\"warning\":{\"_id\":\"warning-1\",\"targetBattleTag\":\"Grubby#1234\",\"issuedByBattleTag\":\"Admin#1\",\"rule\":\"Rule 2\",\"severity\":\"Warning\",\"title\":{\"en\":\"Careful\"},\"body\":{\"en\":\"Please mind rule 2.\"},\"status\":\"Pending\",\"createdAt\":\"2026-06-06T20:00:00Z\"},\"delivered\":false}") : HttpMessageHandler
+    private class CapturingHandler(string responseBody = "{\"warning\":{\"_id\":\"warning-1\",\"targetBattleTag\":\"Grubby#1234\",\"issuedByBattleTag\":\"Admin#1\",\"warningDefinitionId\":\"chat-conduct\",\"severity\":\"Warning\",\"title\":{\"en\":\"Careful\"},\"body\":{\"en\":\"Please mind rule 2.\"},\"status\":\"Pending\",\"createdAt\":\"2026-06-06T20:00:00Z\"},\"delivered\":false}") : HttpMessageHandler
     {
         public List<HttpRequestMessage> Requests { get; } = [];
         public List<string> RequestBodies { get; } = [];

--- a/WC3ChampionsStatisticService.UnitTests/Admin/AdminWarningsControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/AdminWarningsControllerTests.cs
@@ -28,6 +28,9 @@ public class AdminWarningsControllerTests
     {
         AssertWarningsPermission(nameof(AdminController.GetWarnings));
         AssertWarningsPermission(nameof(AdminController.GetWarningDefinitions));
+        AssertWarningsPermission(nameof(AdminController.CreateWarningDefinition));
+        AssertWarningsPermission(nameof(AdminController.UpdateWarningDefinition));
+        AssertWarningsPermission(nameof(AdminController.DeleteWarningDefinition));
         AssertWarningsPermission(nameof(AdminController.CreateWarning));
         AssertWarningsPermission(nameof(AdminController.CancelWarning));
     }
@@ -44,6 +47,90 @@ public class AdminWarningsControllerTests
         Assert.That(handler.Requests, Has.Count.EqualTo(1));
         Assert.That(handler.Requests[0].Headers.Contains("x-admin-secret"), Is.True);
         Assert.That(handler.Requests[0].RequestUri!.AbsolutePath, Does.EndWith("/admin/warning-definitions"));
+    }
+
+    [Test]
+    public async Task GetWarningDefinitionsCanIncludeDisabledDefinitions()
+    {
+        var handler = new CapturingHandler("[{\"_id\":\"chat-conduct\",\"severity\":\"Warning\",\"title\":{\"en\":\"Chat conduct reminder\"},\"body\":{\"en\":\"Please keep chat respectful.\"},\"enabled\":false,\"sortOrder\":10}]");
+        var controller = CreateController(handler, Mock.Of<IBattleTagResolver>());
+
+        var result = await controller.GetWarningDefinitions(true);
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        Assert.That(handler.Requests[0].RequestUri!.Query, Does.Contain("includeDisabled=true"));
+    }
+
+    [Test]
+    public async Task CreateWarningDefinitionInjectsAdminBattleTagAndForwardsAdminSecret()
+    {
+        var handler = new CapturingHandler("{\"_id\":\"warning-template-1\",\"severity\":\"Info\",\"title\":{\"en\":\"Notice\"},\"body\":{\"en\":\"Message\"},\"enabled\":true,\"sortOrder\":20}");
+        var controller = CreateController(handler, Mock.Of<IBattleTagResolver>());
+
+        var result = await controller.CreateWarningDefinition(new PlayerWarningDefinitionRequest
+        {
+            severity = "Info",
+            title = new Dictionary<string, string> { ["en"] = "Notice" },
+            body = new Dictionary<string, string> { ["en"] = "Message" },
+            enabled = true,
+            sortOrder = 20,
+        }, "Admin#1");
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        Assert.That(handler.Requests[0].Headers.Contains("x-admin-secret"), Is.True);
+        Assert.That(handler.Requests[0].RequestUri!.AbsolutePath, Does.EndWith("/admin/warning-definitions"));
+
+        var body = JObject.Parse(handler.RequestBodies[0]);
+        Assert.That(body["createdByBattleTag"]!.Value<string>(), Is.EqualTo("Admin#1"));
+        Assert.That(body["updatedByBattleTag"], Is.Null);
+        Assert.That(body["severity"]!.Value<string>(), Is.EqualTo("Info"));
+        Assert.That(body["title"]!["en"]!.Value<string>(), Is.EqualTo("Notice"));
+    }
+
+    [Test]
+    public async Task UpdateWarningDefinitionInjectsAdminBattleTagAndForwardsAdminSecret()
+    {
+        var handler = new CapturingHandler("{\"_id\":\"chat-conduct\",\"severity\":\"Critical\",\"title\":{\"en\":\"Updated\"},\"body\":{\"en\":\"Updated body\"},\"enabled\":false,\"sortOrder\":5}");
+        var controller = CreateController(handler, Mock.Of<IBattleTagResolver>());
+
+        var result = await controller.UpdateWarningDefinition("chat-conduct", new PlayerWarningDefinitionRequest
+        {
+            severity = "Critical",
+            title = new Dictionary<string, string> { ["en"] = "Updated" },
+            body = new Dictionary<string, string> { ["en"] = "Updated body" },
+            enabled = false,
+            sortOrder = 5,
+        }, "Admin#1");
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        Assert.That(handler.Requests[0].Headers.Contains("x-admin-secret"), Is.True);
+        Assert.That(handler.Requests[0].RequestUri!.AbsolutePath, Does.EndWith("/admin/warning-definitions/chat-conduct"));
+
+        var body = JObject.Parse(handler.RequestBodies[0]);
+        Assert.That(body["updatedByBattleTag"]!.Value<string>(), Is.EqualTo("Admin#1"));
+        Assert.That(body["createdByBattleTag"], Is.Null);
+        Assert.That(body["enabled"]!.Value<bool>(), Is.False);
+    }
+
+    [Test]
+    public async Task DeleteWarningDefinitionSoftDisablesThroughMatchmaking()
+    {
+        var handler = new CapturingHandler("{\"_id\":\"chat-conduct\",\"severity\":\"Warning\",\"title\":{\"en\":\"Chat conduct reminder\"},\"body\":{\"en\":\"Please keep chat respectful.\"},\"enabled\":false,\"sortOrder\":10}");
+        var controller = CreateController(handler, Mock.Of<IBattleTagResolver>());
+
+        var result = await controller.DeleteWarningDefinition("chat-conduct", "Admin#1");
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        Assert.That(handler.Requests[0].Method, Is.EqualTo(HttpMethod.Delete));
+        Assert.That(handler.Requests[0].Headers.Contains("x-admin-secret"), Is.True);
+        Assert.That(handler.Requests[0].RequestUri!.AbsolutePath, Does.EndWith("/admin/warning-definitions/chat-conduct"));
+
+        var body = JObject.Parse(handler.RequestBodies[0]);
+        Assert.That(body["updatedByBattleTag"]!.Value<string>(), Is.EqualTo("Admin#1"));
     }
 
     [Test]
@@ -161,7 +248,7 @@ public class AdminWarningsControllerTests
     [Test]
     public async Task CancelWarningInjectsAdminBattleTagAndForwardsAdminSecret()
     {
-        var handler = new CapturingHandler("{\"_id\":\"warning-1\",\"targetBattleTag\":\"Grubby#1234\",\"issuedByBattleTag\":\"Admin#1\",\"rule\":\"Rule 2\",\"severity\":\"Warning\",\"title\":{\"en\":\"Careful\"},\"body\":{\"en\":\"Please mind rule 2.\"},\"status\":\"Cancelled\",\"createdAt\":\"2026-06-06T20:00:00Z\"}");
+        var handler = new CapturingHandler("{\"_id\":\"warning-1\",\"targetBattleTag\":\"Grubby#1234\",\"issuedByBattleTag\":\"Admin#1\",\"severity\":\"Warning\",\"title\":{\"en\":\"Careful\"},\"body\":{\"en\":\"Please mind rule 2.\"},\"status\":\"Cancelled\",\"createdAt\":\"2026-06-06T20:00:00Z\"}");
         var controller = CreateController(handler, Mock.Of<IBattleTagResolver>());
 
         var result = await controller.CancelWarning("warning-1", "Admin#1");

--- a/WC3ChampionsStatisticService.UnitTests/Admin/AdminWarningsControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/AdminWarningsControllerTests.cs
@@ -1,0 +1,182 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using W3C.Contracts.Admin.Permission;
+using W3C.Domain.MatchmakingService;
+using W3C.Domain.Repositories;
+using W3ChampionsStatisticService.Admin;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.Services;
+using W3ChampionsStatisticService.WebApi.ActionFilters;
+
+namespace WC3ChampionsStatisticService.Tests.Admin;
+
+[TestFixture]
+public class AdminWarningsControllerTests
+{
+    [Test]
+    public void WarningEndpointsRequireWarningsPermission()
+    {
+        AssertWarningsPermission(nameof(AdminController.GetWarnings));
+        AssertWarningsPermission(nameof(AdminController.CreateWarning));
+        AssertWarningsPermission(nameof(AdminController.CancelWarning));
+    }
+
+    [Test]
+    public async Task CreateWarningCanonicalizesTargetInjectsIssuerAndForwardsAdminSecret()
+    {
+        var handler = new CapturingHandler();
+        var resolver = new Mock<IBattleTagResolver>();
+        resolver.Setup(r => r.ResolveCanonical("grubby#1234")).ReturnsAsync("Grubby#1234");
+        var controller = CreateController(handler, resolver.Object);
+
+        var result = await controller.CreateWarning(new CreatePlayerWarningRequest
+        {
+            targetBattleTag = "grubby#1234",
+            severity = "",
+            title = new Dictionary<string, string> { ["en"] = "Careful" },
+            body = new Dictionary<string, string> { ["en"] = "Please mind rule 2." },
+        }, "Admin#1");
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        Assert.That(handler.Requests[0].Headers.Contains("x-admin-secret"), Is.True);
+
+        var body = JObject.Parse(handler.RequestBodies[0]);
+        Assert.That(body["targetBattleTag"]!.Value<string>(), Is.EqualTo("Grubby#1234"));
+        Assert.That(body["issuedByBattleTag"]!.Value<string>(), Is.EqualTo("Admin#1"));
+        Assert.That(body["rule"], Is.Null);
+        Assert.That(body["category"], Is.Null);
+        Assert.That(body["severity"]!.Value<string>(), Is.EqualTo("Warning"));
+    }
+
+    [Test]
+    public async Task GetWarningsCanonicalizesBattleTagFilter()
+    {
+        var handler = new CapturingHandler("{\"total\":0,\"warnings\":[]}");
+        var resolver = new Mock<IBattleTagResolver>();
+        resolver.Setup(r => r.ResolveCanonical("grubby#1234")).ReturnsAsync("Grubby#1234");
+        var controller = CreateController(handler, resolver.Object);
+
+        var result = await controller.GetWarnings(new PlayerWarningsGetRequest
+        {
+            BattleTag = "grubby#1234",
+            Page = 1,
+            ItemsPerPage = 10,
+        });
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        Assert.That(handler.Requests[0].RequestUri!.Query, Does.Contain("battleTag=Grubby%231234"));
+    }
+
+    [Test]
+    public async Task GetWarningsRejectsUnknownBattleTagFilterBeforeProxying()
+    {
+        var handler = new CapturingHandler();
+        var resolver = new Mock<IBattleTagResolver>();
+        resolver.Setup(r => r.ResolveCanonical("missing#1")).ReturnsAsync((string)null);
+        var controller = CreateController(handler, resolver.Object);
+
+        var result = await controller.GetWarnings(new PlayerWarningsGetRequest
+        {
+            BattleTag = "missing#1",
+            Page = 1,
+            ItemsPerPage = 10,
+        });
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        Assert.That(handler.Requests, Is.Empty);
+    }
+
+    [Test]
+    public async Task CreateWarningRejectsUnknownTargetBeforeProxying()
+    {
+        var handler = new CapturingHandler();
+        var resolver = new Mock<IBattleTagResolver>();
+        resolver.Setup(r => r.ResolveCanonical("missing#1")).ReturnsAsync((string)null);
+        var controller = CreateController(handler, resolver.Object);
+
+        var result = await controller.CreateWarning(new CreatePlayerWarningRequest
+        {
+            targetBattleTag = "missing#1",
+            severity = "Warning",
+            title = new Dictionary<string, string> { ["en"] = "Careful" },
+            body = new Dictionary<string, string> { ["en"] = "Please mind rule 2." },
+        }, "Admin#1");
+
+        Assert.That(result, Is.InstanceOf<BadRequestObjectResult>());
+        Assert.That(handler.Requests, Is.Empty);
+    }
+
+    [Test]
+    public async Task CancelWarningInjectsAdminBattleTagAndForwardsAdminSecret()
+    {
+        var handler = new CapturingHandler("{\"_id\":\"warning-1\",\"targetBattleTag\":\"Grubby#1234\",\"issuedByBattleTag\":\"Admin#1\",\"rule\":\"Rule 2\",\"severity\":\"Warning\",\"title\":{\"en\":\"Careful\"},\"body\":{\"en\":\"Please mind rule 2.\"},\"status\":\"Cancelled\",\"createdAt\":\"2026-06-06T20:00:00Z\"}");
+        var controller = CreateController(handler, Mock.Of<IBattleTagResolver>());
+
+        var result = await controller.CancelWarning("warning-1", "Admin#1");
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        Assert.That(handler.Requests[0].Headers.Contains("x-admin-secret"), Is.True);
+        Assert.That(handler.Requests[0].RequestUri!.AbsolutePath, Does.EndWith("/admin/warnings/warning-1/cancel"));
+
+        var body = JObject.Parse(handler.RequestBodies[0]);
+        Assert.That(body["cancelledByBattleTag"]!.Value<string>(), Is.EqualTo("Admin#1"));
+    }
+
+    private static void AssertWarningsPermission(string methodName)
+    {
+        var method = typeof(AdminController).GetMethod(methodName)!;
+        var attribute = method.GetCustomAttribute<BearerHasPermissionFilter>();
+
+        Assert.That(attribute, Is.Not.Null);
+        Assert.That(attribute!.Permission, Is.EqualTo(EPermission.Warnings));
+    }
+
+    private static AdminController CreateController(CapturingHandler handler, IBattleTagResolver resolver)
+    {
+        var client = new MatchmakingServiceClient(new TestHttpClientFactory(new HttpClient(handler)));
+
+        return new AdminController(
+            Mock.Of<IMatchRepository>(),
+            client,
+            Mock.Of<INewsRepository>(),
+            Mock.Of<IInformationMessagesRepository>(),
+            Mock.Of<IAdminRepository>(),
+            Mock.Of<IRankRepository>(),
+            resolver);
+    }
+
+    private class TestHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+
+    private class CapturingHandler(string responseBody = "{\"warning\":{\"_id\":\"warning-1\",\"targetBattleTag\":\"Grubby#1234\",\"issuedByBattleTag\":\"Admin#1\",\"rule\":\"Rule 2\",\"severity\":\"Warning\",\"title\":{\"en\":\"Careful\"},\"body\":{\"en\":\"Please mind rule 2.\"},\"status\":\"Pending\",\"createdAt\":\"2026-06-06T20:00:00Z\"},\"delivered\":false}") : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+        public List<string> RequestBodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            RequestBodies.Add(request.Content == null ? "" : await request.Content.ReadAsStringAsync(cancellationToken));
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+}


### PR DESCRIPTION
Adds warning admin endpoints behind the Warnings permission and proxies them to matchmaking with the admin secret.

The backend canonicalizes target BattleTags and fills in the acting admin BattleTag before creating, updating, cancelling, or disabling warning data.

Try it from the website admin warnings pages after granting the Warnings permission.
