### PR TITLE
Carry progressionStartSeason on ActiveGameMode

### DIFF
--- a/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
+++ b/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
@@ -674,6 +674,7 @@ public class ActiveGameMode
     public string Type { get; set; }
     public int TeamCount { get; set; }
     public int TeamSize { get; set; }
+    public int? ProgressionStartSeason { get; set; }
 }
 
 public class MapShortInfo

--- a/WC3ChampionsStatisticService.UnitTests/MatchmakingService/ActiveGameModeTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/MatchmakingService/ActiveGameModeTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using W3C.Domain.MatchmakingService;
+
+namespace WC3ChampionsStatisticService.Tests.MatchmakingService;
+
+[TestFixture]
+public class ActiveGameModeTests
+{
+    [Test]
+    public void Deserializes_progressionStartSeason_from_matchmaking_payload()
+    {
+        var json = @"[{""id"":1,""name"":""1v1"",""type"":""1on1"",""teamCount"":2,""teamSize"":1,""progressionStartSeason"":42,""maps"":[]}]";
+
+        var modes = JsonConvert.DeserializeObject<List<ActiveGameMode>>(json);
+
+        modes.Should().HaveCount(1);
+        modes[0].ProgressionStartSeason.Should().Be(42);
+    }
+
+    [Test]
+    public void ProgressionStartSeason_is_null_when_absent()
+    {
+        var json = @"[{""id"":1,""name"":""1v1"",""type"":""1on1"",""teamCount"":2,""teamSize"":1,""maps"":[]}]";
+
+        var modes = JsonConvert.DeserializeObject<List<ActiveGameMode>>(json);
+
+        modes[0].ProgressionStartSeason.Should().BeNull();
+    }
+
+    [Test]
+    public void ProgressionStartSeason_is_null_when_explicitly_null()
+    {
+        var json = @"[{""id"":1,""name"":""1v1"",""type"":""1on1"",""teamCount"":2,""teamSize"":1,""progressionStartSeason"":null,""maps"":[]}]";
+
+        var modes = JsonConvert.DeserializeObject<List<ActiveGameMode>>(json);
+
+        modes[0].ProgressionStartSeason.Should().BeNull();
+    }
+}

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -1,0 +1,26 @@
+# Progression ranking — website-backend
+
+website-backend serves the ranking data the website and launcher render; it does not compute rank. A new
+progression ranking system runs alongside the legacy "RP" ladder. Each game mode uses exactly one of the
+two, selected per mode by a season flag sourced from matchmaking-service.
+
+## `ActiveGameMode.ProgressionStartSeason`
+
+`api/ladder/active-modes` (`Ladder/LadderController.cs`) returns the active game modes. Each carries
+`ProgressionStartSeason` (`int?`) on the `ActiveGameMode` DTO
+(`W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs`):
+
+- `null` / absent — the mode uses the legacy RP ladder.
+- a number `N` — the mode uses the new progression system from season `N` onward.
+
+The endpoint forwards the raw season value unchanged; the client decides which system to render for the
+season it is viewing (a past season keeps whatever it used, so a current-season-resolved label would be
+wrong for history). The field is additive — clients that ignore it keep rendering RP.
+
+## File reference
+
+| Concern | Path |
+|---|---|
+| `ActiveGameMode` DTO | `W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs` |
+| `active-modes` endpoint | `W3ChampionsStatisticService/Ladder/LadderController.cs` |
+| Contract test | `WC3ChampionsStatisticService.UnitTests/MatchmakingService/ActiveGameModeTests.cs` |


### PR DESCRIPTION
Additive: adds `ProgressionStartSeason` (`int?`) to the `ActiveGameMode` DTO so `api/ladder/active-modes`
forwards the matchmaking-service per-mode flag to clients. Pure pass-through — no controller or fetch change.
Clients that ignore the field keep their current behavior.

- Deserialized from the upstream camelCase `progressionStartSeason` via Newtonsoft's default case-insensitive
  matching (same mechanism as the existing `TeamCount`/`TeamSize`); re-emitted camelCase to clients.
- Tests: `ActiveGameModeTests` — value / absent / explicit-null (3/3).
- `dotnet build` ✓ · `dotnet format --verify-no-changes` ✓.

Targets `prj/new-ranking-system`.
