### PR TITLE
P8-2: Ingest + season-keyed progression read-model

### DIFF
--- a/W3C.Domain/GameModes/GameModesHelper.cs
+++ b/W3C.Domain/GameModes/GameModesHelper.cs
@@ -16,6 +16,19 @@ public class GameModesHelper
         GameMode.GM_4v4_AT,
     ];
 
+    public const int RaceSplitStartSeason = 2;
+
+    private static readonly Dictionary<GameMode, GameMode> ArrangedTeamVariants = new()
+    {
+        { GameMode.GM_2v2, GameMode.GM_2v2_AT },
+        { GameMode.GM_4v4, GameMode.GM_4v4_AT },
+        { GameMode.GM_LEGION_4v4_x20, GameMode.GM_LEGION_4v4_x20_AT },
+        { GameMode.GM_DOTA_5ON5, GameMode.GM_DOTA_5ON5_AT },
+        { GameMode.GM_DS, GameMode.GM_DS_AT },
+        { GameMode.GM_CF, GameMode.GM_CF_AT },
+        { GameMode.GM_MINIDOTA_3ON3, GameMode.GM_MINIDOTA_3ON3_AT },
+    };
+
     public static bool IsFfaGameMode(GameMode gameMode)
     {
         return FfaGameModes.Contains(gameMode);
@@ -25,4 +38,12 @@ public class GameModesHelper
     {
         return MeleeGameModes.Contains(gameMode);
     }
+
+    // The arranged-team (AT) variant of a base mode for an AT player; the mode unchanged otherwise.
+    public static GameMode ToArrangedTeamVariant(GameMode gameMode, bool isAt)
+        => isAt && ArrangedTeamVariants.TryGetValue(gameMode, out var atVariant) ? atVariant : gameMode;
+
+    // 1v1 ladders are keyed per race from RaceSplitStartSeason onward; other modes/seasons are not.
+    public static bool UsesRaceInLadderKey(GameMode gameMode, int season)
+        => gameMode == GameMode.GM_1v1 && season >= RaceSplitStartSeason;
 }

--- a/W3C.Domain/MatchmakingService/MatchEventDtos.cs
+++ b/W3C.Domain/MatchmakingService/MatchEventDtos.cs
@@ -27,6 +27,7 @@ public class PlayerMMrChange : UnfinishedMatchPlayer
     public int? matchRanking { get; set; }
     public Mmr updatedMmr { get; set; }
     public Ranking updatedRanking { get; set; }
+    public UpdatedProgression updatedProgression { get; set; }
     public string atTeamId { get; set; }
     public Race? rndRace { get; set; }
 
@@ -64,6 +65,15 @@ public class Ranking
     public int? leagueId { get; set; }
     public int? leagueOrder { get; set; }
     public double? progress { get; set; }
+}
+
+[BsonIgnoreExtraElements]
+public class UpdatedProgression
+{
+    public int? league { get; set; }
+    public int? division { get; set; }
+    public int? points { get; set; }
+    public int? apexPoints { get; set; }
 }
 
 [BsonIgnoreExtraElements]

--- a/W3ChampionsStatisticService/Ladder/PlayOverviewHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/PlayOverviewHandler.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using W3C.Contracts.GameObjects;
 using W3C.Domain.CommonValueObjects;
+using W3C.Domain.GameModes;
 using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
@@ -63,9 +64,9 @@ public class PlayOverviewHandler(IPlayerRepository playerRepository) : IMatchFin
         var playerIds = players.Select(w => PlayerId.Create(w.battleTag)).ToList();
 
         var match = nextEvent.match;
-        var playerRaceIfSingle = match.gameMode == GameMode.GM_1v1 && match.season >= 2 ? (Race?)players.Single().race : null;
+        var playerRaceIfSingle = GameModesHelper.UsesRaceInLadderKey(match.gameMode, match.season) ? (Race?)players.Single().race : null;
 
-        var gameMode = GetOverviewGameMode(match.gameMode, players[0]);
+        var gameMode = GameModesHelper.ToArrangedTeamVariant(match.gameMode, players[0].IsAt);
 
         var winnerIdCombined = new BattleTagIdCombined(
             players.Select(p =>
@@ -90,44 +91,4 @@ public class PlayOverviewHandler(IPlayerRepository playerRepository) : IMatchFin
         return winner;
     }
 
-    [NoTrace]
-    private GameMode GetOverviewGameMode(GameMode gameMode, PlayerMMrChange player)
-    {
-        if (gameMode == GameMode.GM_2v2 && player.IsAt)
-        {
-            return GameMode.GM_2v2_AT;
-        }
-
-        if (gameMode == GameMode.GM_4v4 && player.IsAt)
-        {
-            return GameMode.GM_4v4_AT;
-        }
-
-        if (gameMode == GameMode.GM_LEGION_4v4_x20 && player.IsAt)
-        {
-            return GameMode.GM_LEGION_4v4_x20_AT;
-        }
-
-        if (gameMode == GameMode.GM_DOTA_5ON5 && player.IsAt)
-        {
-            return GameMode.GM_DOTA_5ON5_AT;
-        }
-
-        if (gameMode == GameMode.GM_DS && player.IsAt)
-        {
-            return GameMode.GM_DS_AT;
-        }
-
-        if (gameMode == GameMode.GM_CF && player.IsAt)
-        {
-            return GameMode.GM_CF_AT;
-        }
-
-        if (gameMode == GameMode.GM_MINIDOTA_3ON3 && player.IsAt)
-        {
-            return GameMode.GM_MINIDOTA_3ON3_AT;
-        }
-
-        return gameMode;
-    }
 }

--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGatewayHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGatewayHandler.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using W3C.Contracts.GameObjects;
 using W3C.Domain.CommonValueObjects;
+using W3C.Domain.GameModes;
 using W3C.Domain.MatchmakingService;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.ReadModelBase;
@@ -58,14 +59,14 @@ public class PlayerGameModeStatPerGatewayHandler(IPlayerRepository playerReposit
 
     private async Task RecordLoss(Match match, List<PlayerMMrChange> losingTeam)
     {
-        var gameMode = GetGameModeStatGameMode(match.gameMode, losingTeam[0]);
+        var gameMode = GameModesHelper.ToArrangedTeamVariant(match.gameMode, losingTeam[0].IsAt);
 
         var loserId = new BattleTagIdCombined(
             losingTeam.Select(w => PlayerId.Create(w.battleTag)).ToList(),
             match.gateway,
             gameMode,
             match.season,
-            match.gameMode == GameMode.GM_1v1 && match.season >= 2 ? (Race?)losingTeam.Single().race : null);
+            GameModesHelper.UsesRaceInLadderKey(match.gameMode, match.season) ? (Race?)losingTeam.Single().race : null);
 
         var loser = await _playerRepository.LoadGameModeStatPerGateway(loserId.Id) ?? PlayerGameModeStatPerGateway.Create(loserId);
 
@@ -97,14 +98,14 @@ public class PlayerGameModeStatPerGatewayHandler(IPlayerRepository playerReposit
 
     private async Task RecordWin(Match match, List<PlayerMMrChange> winners)
     {
-        var gameMode = GetGameModeStatGameMode(match.gameMode, winners[0]);
+        var gameMode = GameModesHelper.ToArrangedTeamVariant(match.gameMode, winners[0].IsAt);
 
         var winnerId = new BattleTagIdCombined(
             winners.Select(w => PlayerId.Create(w.battleTag)).ToList(),
             match.gateway,
             gameMode,
             match.season,
-            match.gameMode == GameMode.GM_1v1 && match.season >= 2 ? (Race?)winners.Single().race : null);
+            GameModesHelper.UsesRaceInLadderKey(match.gameMode, match.season) ? (Race?)winners.Single().race : null);
 
         var winner = await _playerRepository.LoadGameModeStatPerGateway(winnerId.Id) ?? PlayerGameModeStatPerGateway.Create(winnerId);
         winner.RecordWin(true);
@@ -115,44 +116,4 @@ public class PlayerGameModeStatPerGatewayHandler(IPlayerRepository playerReposit
         await _playerRepository.UpsertPlayerGameModeStatPerGateway(winner);
     }
 
-    [NoTrace]
-    private GameMode GetGameModeStatGameMode(GameMode gameMode, PlayerMMrChange player)
-    {
-        if (gameMode == GameMode.GM_2v2 && player.IsAt)
-        {
-            return GameMode.GM_2v2_AT;
-        }
-
-        if (gameMode == GameMode.GM_4v4 && player.IsAt)
-        {
-            return GameMode.GM_4v4_AT;
-        }
-
-        if (gameMode == GameMode.GM_LEGION_4v4_x20 && player.IsAt)
-        {
-            return GameMode.GM_LEGION_4v4_x20_AT;
-        }
-
-        if (gameMode == GameMode.GM_DOTA_5ON5 && player.IsAt)
-        {
-            return GameMode.GM_DOTA_5ON5_AT;
-        }
-
-        if (gameMode == GameMode.GM_DS && player.IsAt)
-        {
-            return GameMode.GM_DS_AT;
-        }
-
-        if (gameMode == GameMode.GM_CF && player.IsAt)
-        {
-            return GameMode.GM_CF_AT;
-        }
-
-        if (gameMode == GameMode.GM_MINIDOTA_3ON3 && player.IsAt)
-        {
-            return GameMode.GM_MINIDOTA_3ON3_AT;
-        }
-
-        return gameMode;
-    }
 }

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgression.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgression.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.CommonValueObjects;
+using W3C.Domain.Repositories;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+// Season-keyed downstream read-model of a player's / arranged-team's progression rank.
+// One document per entity (atTeamId ?? battleTag), keyed via BattleTagIdCombined so prior
+// seasons are retained automatically. Carries only the published rank fields below.
+public class PlayerProgression : IIdentifiable
+{
+    public string Id { get; set; }
+    public int Season { get; set; }
+    public GateWay GateWay { get; set; }
+    public GameMode GameMode { get; set; }
+    public Race? Race { get; set; }
+    public List<PlayerId> PlayerIds { get; set; }
+
+    public int? League { get; set; }
+    public int? Division { get; set; }
+    public int? Points { get; set; }
+    public int? ApexPoints { get; set; }
+
+    public static PlayerProgression Create(BattleTagIdCombined id)
+    {
+        return new PlayerProgression
+        {
+            Id = id.Id,
+            Season = id.Season,
+            GateWay = id.GateWay,
+            GameMode = id.GameMode,
+            Race = id.Race,
+            PlayerIds = id.BattleTags,
+        };
+    }
+
+    public void RecordRank(int? league, int? division, int? points, int? apexPoints)
+    {
+        League = league;
+        Division = division;
+        Points = points;
+        ApexPoints = apexPoints;
+    }
+}

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionHandler.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.CommonValueObjects;
+using W3C.Domain.GameModes;
 using W3C.Domain.MatchmakingService;
 using W3C.Domain.Tracing;
 using W3ChampionsStatisticService.Ports;
@@ -12,7 +13,7 @@ using W3ChampionsStatisticService.ReadModelBase;
 namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 
 // Ingests MatchFinishedEvent.match.players[].updatedProgression into the season-keyed
-// PlayerProgression read-model. One doc per entity: AT players grouped by team (shared
+// PlayerProgression read-model. One doc per entity: AT players grouped by atTeamId (shared
 // team rank), solo players individually. Keying mirrors PlayerGameModeStatPerGatewayHandler
 // (gameMode normalized to its AT variant; race in the key only for GM_1v1 season >= 2).
 [Trace]
@@ -25,10 +26,8 @@ public class PlayerProgressionHandler(IPlayerProgressionRepository progressionRe
         var match = nextEvent.match;
         var placed = match.players.Where(p => p.updatedProgression != null).ToList();
 
-        // AT players are grouped by team into one shared rank doc (mirrors
-        // PlayerGameModeStatPerGatewayHandler). Safe because a single match side carries at
-        // most one AT team per `team` number for every current AT mode (4-stacks, not 2+2).
-        foreach (var team in placed.Where(p => p.IsAt).GroupBy(p => p.team))
+        // Arranged-team players share one rank doc per team (keyed by atTeamId — multiple AT teams can share a game team number).
+        foreach (var team in placed.Where(p => p.IsAt).GroupBy(p => p.atTeamId))
         {
             await RecordRank(match, team.ToList());
         }
@@ -41,14 +40,14 @@ public class PlayerProgressionHandler(IPlayerProgressionRepository progressionRe
 
     private async Task RecordRank(Match match, List<PlayerMMrChange> entityPlayers)
     {
-        var gameMode = GetProgressionGameMode(match.gameMode, entityPlayers[0]);
+        var gameMode = GameModesHelper.ToArrangedTeamVariant(match.gameMode, entityPlayers[0].IsAt);
 
         var id = new BattleTagIdCombined(
             entityPlayers.Select(p => PlayerId.Create(p.battleTag)).ToList(),
             match.gateway,
             gameMode,
             match.season,
-            match.gameMode == GameMode.GM_1v1 && match.season >= 2 ? (Race?)entityPlayers.Single().race : null);
+            GameModesHelper.UsesRaceInLadderKey(match.gameMode, match.season) ? (Race?)entityPlayers.Single().race : null);
 
         // Every AT team member carries the same rank snapshot (MM emits a shared team rank),
         // so the first member's snapshot represents the whole entity.
@@ -58,46 +57,5 @@ public class PlayerProgressionHandler(IPlayerProgressionRepository progressionRe
         progression.RecordRank(snapshot.league, snapshot.division, snapshot.points, snapshot.apexPoints);
 
         await _progressionRepository.UpsertProgression(progression);
-    }
-
-    [NoTrace]
-    private GameMode GetProgressionGameMode(GameMode gameMode, PlayerMMrChange player)
-    {
-        if (gameMode == GameMode.GM_2v2 && player.IsAt)
-        {
-            return GameMode.GM_2v2_AT;
-        }
-
-        if (gameMode == GameMode.GM_4v4 && player.IsAt)
-        {
-            return GameMode.GM_4v4_AT;
-        }
-
-        if (gameMode == GameMode.GM_LEGION_4v4_x20 && player.IsAt)
-        {
-            return GameMode.GM_LEGION_4v4_x20_AT;
-        }
-
-        if (gameMode == GameMode.GM_DOTA_5ON5 && player.IsAt)
-        {
-            return GameMode.GM_DOTA_5ON5_AT;
-        }
-
-        if (gameMode == GameMode.GM_DS && player.IsAt)
-        {
-            return GameMode.GM_DS_AT;
-        }
-
-        if (gameMode == GameMode.GM_CF && player.IsAt)
-        {
-            return GameMode.GM_CF_AT;
-        }
-
-        if (gameMode == GameMode.GM_MINIDOTA_3ON3 && player.IsAt)
-        {
-            return GameMode.GM_MINIDOTA_3ON3_AT;
-        }
-
-        return gameMode;
     }
 }

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionHandler.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.CommonValueObjects;
+using W3C.Domain.MatchmakingService;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.ReadModelBase;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+// Ingests MatchFinishedEvent.match.players[].updatedProgression into the season-keyed
+// PlayerProgression read-model. One doc per entity: AT players grouped by team (shared
+// team rank), solo players individually. Keying mirrors PlayerGameModeStatPerGatewayHandler
+// (gameMode normalized to its AT variant; race in the key only for GM_1v1 season >= 2).
+[Trace]
+public class PlayerProgressionHandler(IPlayerProgressionRepository progressionRepository) : IMatchFinishedReadModelHandler
+{
+    private readonly IPlayerProgressionRepository _progressionRepository = progressionRepository;
+
+    public async Task Update(MatchFinishedEvent nextEvent)
+    {
+        var match = nextEvent.match;
+        var placed = match.players.Where(p => p.updatedProgression != null).ToList();
+
+        // AT players are grouped by team into one shared rank doc (mirrors
+        // PlayerGameModeStatPerGatewayHandler). Safe because a single match side carries at
+        // most one AT team per `team` number for every current AT mode (4-stacks, not 2+2).
+        foreach (var team in placed.Where(p => p.IsAt).GroupBy(p => p.team))
+        {
+            await RecordRank(match, team.ToList());
+        }
+
+        foreach (var soloPlayer in placed.Where(p => !p.IsAt))
+        {
+            await RecordRank(match, new List<PlayerMMrChange> { soloPlayer });
+        }
+    }
+
+    private async Task RecordRank(Match match, List<PlayerMMrChange> entityPlayers)
+    {
+        var gameMode = GetProgressionGameMode(match.gameMode, entityPlayers[0]);
+
+        var id = new BattleTagIdCombined(
+            entityPlayers.Select(p => PlayerId.Create(p.battleTag)).ToList(),
+            match.gateway,
+            gameMode,
+            match.season,
+            match.gameMode == GameMode.GM_1v1 && match.season >= 2 ? (Race?)entityPlayers.Single().race : null);
+
+        // Every AT team member carries the same rank snapshot (MM emits a shared team rank),
+        // so the first member's snapshot represents the whole entity.
+        var snapshot = entityPlayers[0].updatedProgression;
+
+        var progression = await _progressionRepository.LoadProgression(id.Id) ?? PlayerProgression.Create(id);
+        progression.RecordRank(snapshot.league, snapshot.division, snapshot.points, snapshot.apexPoints);
+
+        await _progressionRepository.UpsertProgression(progression);
+    }
+
+    [NoTrace]
+    private GameMode GetProgressionGameMode(GameMode gameMode, PlayerMMrChange player)
+    {
+        if (gameMode == GameMode.GM_2v2 && player.IsAt)
+        {
+            return GameMode.GM_2v2_AT;
+        }
+
+        if (gameMode == GameMode.GM_4v4 && player.IsAt)
+        {
+            return GameMode.GM_4v4_AT;
+        }
+
+        if (gameMode == GameMode.GM_LEGION_4v4_x20 && player.IsAt)
+        {
+            return GameMode.GM_LEGION_4v4_x20_AT;
+        }
+
+        if (gameMode == GameMode.GM_DOTA_5ON5 && player.IsAt)
+        {
+            return GameMode.GM_DOTA_5ON5_AT;
+        }
+
+        if (gameMode == GameMode.GM_DS && player.IsAt)
+        {
+            return GameMode.GM_DS_AT;
+        }
+
+        if (gameMode == GameMode.GM_CF && player.IsAt)
+        {
+            return GameMode.GM_CF_AT;
+        }
+
+        if (gameMode == GameMode.GM_MINIDOTA_3ON3 && player.IsAt)
+        {
+            return GameMode.GM_MINIDOTA_3ON3_AT;
+        }
+
+        return gameMode;
+    }
+}

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionHandler.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using W3C.Contracts.GameObjects;
-using W3C.Contracts.Matchmaking;
 using W3C.Domain.CommonValueObjects;
 using W3C.Domain.GameModes;
 using W3C.Domain.MatchmakingService;

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionRepository.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.Ports;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+[Trace]
+public class PlayerProgressionRepository(MongoClient mongoClient)
+    : MongoDbRepositoryBase(mongoClient), IPlayerProgressionRepository
+{
+    public Task<PlayerProgression> LoadProgression(string id)
+    {
+        return LoadFirst<PlayerProgression>(id);
+    }
+
+    public Task UpsertProgression(PlayerProgression progression)
+    {
+        return Upsert(progression);
+    }
+}

--- a/W3ChampionsStatisticService/Ports/IPlayerProgressionRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IPlayerProgressionRepository.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace W3ChampionsStatisticService.Ports;
+
+public interface IPlayerProgressionRepository
+{
+    Task<PlayerProgression> LoadProgression(string id);
+    Task UpsertProgression(PlayerProgression progression);
+}

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -32,6 +32,7 @@ using W3ChampionsStatisticService.PlayerProfiles;
 using W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
 using W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 using W3ChampionsStatisticService.PlayerProfiles.RaceStats;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 using W3ChampionsStatisticService.PlayerProfiles.War3InfoPlayerAkas;
 using W3ChampionsStatisticService.PlayerStats;
 using W3ChampionsStatisticService.PlayerStats.GameLengthForPlayerStatistics;
@@ -161,6 +162,7 @@ builder.Services.AddInterceptedTransient<IMatchRepository, MatchRepository>();
 // Ensure MatchRepository indexes are created at startup
 builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexes, MatchRepository>();
 builder.Services.AddInterceptedSingleton<IPlayerRepository, PlayerRepository>();
+builder.Services.AddInterceptedTransient<IPlayerProgressionRepository, PlayerProgressionRepository>();
 builder.Services.AddInterceptedTransient<IRankRepository, RankRepository>();
 builder.Services.AddInterceptedTransient<IPlayerStatsRepository, PlayerStatsRepository>();
 builder.Services.AddInterceptedTransient<IW3StatsRepo, W3StatsRepo>();
@@ -251,6 +253,7 @@ if (startHandlers == "true")
     builder.Services.AddMatchFinishedReadModelService<PlayerGameModeStatPerGatewayHandler>();
     builder.Services.AddMatchFinishedReadModelService<PlayerRaceStatPerGatewayHandler>();
     builder.Services.AddMatchFinishedReadModelService<PlayerMmrRpTimelineHandler>();
+    builder.Services.AddMatchFinishedReadModelService<PlayerProgressionHandler>();
     builder.Services.AddMatchFinishedReadModelService<GameLengthForPlayerStatisticsHandler>();
 
     // General Stats

--- a/WC3ChampionsStatisticService.UnitTests/GameModes/GameModesHelperTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/GameModes/GameModesHelperTests.cs
@@ -1,0 +1,68 @@
+using NUnit.Framework;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.GameModes;
+
+namespace WC3ChampionsStatisticService.UnitTests.GameModes;
+
+[TestFixture]
+public class GameModesHelperTests
+{
+    // ToArrangedTeamVariant
+
+    [Test]
+    public void ToArrangedTeamVariant_2v2_IsAt_Returns2v2AT()
+    {
+        Assert.AreEqual(GameMode.GM_2v2_AT, GameModesHelper.ToArrangedTeamVariant(GameMode.GM_2v2, true));
+    }
+
+    [Test]
+    public void ToArrangedTeamVariant_4v4_IsAt_Returns4v4AT()
+    {
+        Assert.AreEqual(GameMode.GM_4v4_AT, GameModesHelper.ToArrangedTeamVariant(GameMode.GM_4v4, true));
+    }
+
+    [Test]
+    public void ToArrangedTeamVariant_2v2_NotAt_ReturnsUnchanged()
+    {
+        Assert.AreEqual(GameMode.GM_2v2, GameModesHelper.ToArrangedTeamVariant(GameMode.GM_2v2, false));
+    }
+
+    [Test]
+    public void ToArrangedTeamVariant_1v1_IsAt_ReturnsUnchanged()
+    {
+        // GM_1v1 has no AT variant
+        Assert.AreEqual(GameMode.GM_1v1, GameModesHelper.ToArrangedTeamVariant(GameMode.GM_1v1, true));
+    }
+
+    [Test]
+    public void ToArrangedTeamVariant_Dota5on5_IsAt_ReturnsDota5on5AT()
+    {
+        Assert.AreEqual(GameMode.GM_DOTA_5ON5_AT, GameModesHelper.ToArrangedTeamVariant(GameMode.GM_DOTA_5ON5, true));
+    }
+
+    // UsesRaceInLadderKey
+
+    [Test]
+    public void UsesRaceInLadderKey_1v1_Season2_ReturnsTrue()
+    {
+        Assert.IsTrue(GameModesHelper.UsesRaceInLadderKey(GameMode.GM_1v1, 2));
+    }
+
+    [Test]
+    public void UsesRaceInLadderKey_1v1_Season3_ReturnsTrue()
+    {
+        Assert.IsTrue(GameModesHelper.UsesRaceInLadderKey(GameMode.GM_1v1, 3));
+    }
+
+    [Test]
+    public void UsesRaceInLadderKey_1v1_Season1_ReturnsFalse()
+    {
+        Assert.IsFalse(GameModesHelper.UsesRaceInLadderKey(GameMode.GM_1v1, 1));
+    }
+
+    [Test]
+    public void UsesRaceInLadderKey_2v2_Season5_ReturnsFalse()
+    {
+        Assert.IsFalse(GameModesHelper.UsesRaceInLadderKey(GameMode.GM_2v2, 5));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionDtoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionDtoTests.cs
@@ -1,0 +1,52 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using NUnit.Framework;
+using W3C.Domain.MatchmakingService;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class PlayerProgressionDtoTests
+{
+    [Test]
+    public void Deserializes_UpdatedProgression_FromInt32_Wire()
+    {
+        // The upstream serializer writes whole numbers as BSON Int32; these rank values are
+        // integer-or-null by construction, so int? is the correct C# type.
+        var doc = new BsonDocument
+        {
+            { "battleTag", "peter#123" },
+            { "won", true },
+            { "updatedProgression", new BsonDocument
+                {
+                    { "league", 3 },
+                    { "division", 2 },
+                    { "points", 50 },
+                    { "apexPoints", BsonNull.Value },
+                }
+            },
+        };
+
+        var player = BsonSerializer.Deserialize<PlayerMMrChange>(doc);
+
+        Assert.IsNotNull(player.updatedProgression);
+        Assert.AreEqual(3, player.updatedProgression.league);
+        Assert.AreEqual(2, player.updatedProgression.division);
+        Assert.AreEqual(50, player.updatedProgression.points);
+        Assert.IsNull(player.updatedProgression.apexPoints);
+    }
+
+    [Test]
+    public void UpdatedProgression_Absent_DeserializesToNull()
+    {
+        var doc = new BsonDocument
+        {
+            { "battleTag", "peter#123" },
+            { "won", false },
+        };
+
+        var player = BsonSerializer.Deserialize<PlayerMMrChange>(doc);
+
+        Assert.IsNull(player.updatedProgression);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionHandlerTests.cs
@@ -181,4 +181,29 @@ public class PlayerProgressionHandlerTests
         Assert.AreEqual(3, (await _repository.LoadProgression("1_p#1@20_GM_1v1")).League);
         Assert.AreEqual(4, (await _repository.LoadProgression("2_p#1@20_GM_1v1_HU")).League);
     }
+
+    [Test]
+    public async Task TwoAtTeamsOnSameGameTeam_WriteSeparateDocs()
+    {
+        // A 4v4-AT side (team 0) containing two distinct arranged teams of 2.
+        var teamX = new UpdatedProgression { league = 3, division = 1, points = 60 };
+        var teamY = new UpdatedProgression { league = 5, division = 4, points = 20 };
+        var ev = Event(GameMode.GM_4v4, 2, GateWay.Europe, new List<PlayerMMrChange>
+        {
+            Player("x1#1", 0, true, Race.HU, atTeamId: "team-X", progression: teamX),
+            Player("x2#2", 0, true, Race.OC, atTeamId: "team-X", progression: teamX),
+            Player("y1#3", 0, true, Race.NE, atTeamId: "team-Y", progression: teamY),
+            Player("y2#4", 0, true, Race.UD, atTeamId: "team-Y", progression: teamY),
+        });
+
+        await _handler.Update(ev);
+
+        Assert.AreEqual(2, await Count());
+        var x = await _repository.LoadProgression("2_x1#1@20_x2#2@20_GM_4v4_AT");
+        var y = await _repository.LoadProgression("2_y1#3@20_y2#4@20_GM_4v4_AT");
+        Assert.IsNotNull(x);
+        Assert.IsNotNull(y);
+        Assert.AreEqual(3, x.League);
+        Assert.AreEqual(5, y.League);
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionHandlerTests.cs
@@ -1,0 +1,184 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mongo2Go;
+using MongoDB.Driver;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.MatchmakingService;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class PlayerProgressionHandlerTests
+{
+    private MongoDbRunner _runner;
+    private MongoClient _mongoClient;
+    private PlayerProgressionRepository _repository;
+    private PlayerProgressionHandler _handler;
+
+    [SetUp]
+    public void Setup()
+    {
+        _runner = MongoDbRunner.Start();
+        _mongoClient = new MongoClient(_runner.ConnectionString);
+        _repository = new PlayerProgressionRepository(_mongoClient);
+        _handler = new PlayerProgressionHandler(_repository);
+    }
+
+    [TearDown]
+    public void TearDown() => _runner.Dispose();
+
+    private static PlayerMMrChange Player(string battleTag, int team, bool won, Race race,
+        string atTeamId = null, UpdatedProgression progression = null)
+    {
+        return new PlayerMMrChange
+        {
+            battleTag = battleTag,
+            team = team,
+            won = won,
+            race = race,
+            atTeamId = atTeamId,
+            mmr = new Mmr { rating = 1500 },
+            updatedMmr = new Mmr { rating = won ? 1520 : 1480 },
+            updatedProgression = progression,
+        };
+    }
+
+    private static MatchFinishedEvent Event(GameMode gameMode, int season, GateWay gateway, List<PlayerMMrChange> players)
+    {
+        return new MatchFinishedEvent
+        {
+            match = new Match
+            {
+                id = "match-1",
+                gameMode = gameMode,
+                gateway = gateway,
+                season = season,
+                players = players,
+            },
+        };
+    }
+
+    private IMongoCollection<PlayerProgression> Collection() =>
+        _mongoClient.GetDatabase("W3Champions-Statistic-Service").GetCollection<PlayerProgression>("PlayerProgression");
+
+    private Task<long> Count() => Collection().CountDocumentsAsync(FilterDefinition<PlayerProgression>.Empty);
+
+    [Test]
+    public async Task Solo1v1_Placed_WritesOneDocPerPlayer()
+    {
+        var ev = Event(GameMode.GM_1v1, 2, GateWay.Europe, new List<PlayerMMrChange>
+        {
+            Player("winner#1", 0, true, Race.HU, progression: new UpdatedProgression { league = 3, division = 2, points = 50, apexPoints = 120 }),
+            Player("loser#2", 1, false, Race.OC, progression: new UpdatedProgression { league = 3, division = 3, points = 40 }),
+        });
+
+        await _handler.Update(ev);
+
+        Assert.AreEqual(2, await Count());
+        var winner = await _repository.LoadProgression("2_winner#1@20_GM_1v1_HU");
+        Assert.IsNotNull(winner);
+        Assert.AreEqual(3, winner.League);
+        Assert.AreEqual(2, winner.Division);
+        Assert.AreEqual(50, winner.Points);
+        Assert.AreEqual(120, winner.ApexPoints);
+        Assert.AreEqual(Race.HU, winner.Race);
+    }
+
+    [Test]
+    public async Task AtTeam_WritesSingleSharedDoc_NormalizedGameMode_NoRace()
+    {
+        var teamRank = new UpdatedProgression { league = 4, division = 1, points = 75 };
+        var ev = Event(GameMode.GM_2v2, 2, GateWay.Europe, new List<PlayerMMrChange>
+        {
+            Player("a#1", 0, true, Race.HU, atTeamId: "team-A", progression: teamRank),
+            Player("b#2", 0, true, Race.OC, atTeamId: "team-A", progression: teamRank),
+            Player("c#3", 1, false, Race.NE, atTeamId: "team-B", progression: new UpdatedProgression { league = 4, division = 2, points = 30 }),
+            Player("d#4", 1, false, Race.UD, atTeamId: "team-B", progression: new UpdatedProgression { league = 4, division = 2, points = 30 }),
+        });
+
+        await _handler.Update(ev);
+
+        Assert.AreEqual(2, await Count()); // one doc per AT team
+        var teamA = await _repository.LoadProgression("2_a#1@20_b#2@20_GM_2v2_AT");
+        Assert.IsNotNull(teamA);
+        Assert.AreEqual(2, teamA.PlayerIds.Count);
+        Assert.AreEqual(4, teamA.League);
+        Assert.AreEqual(1, teamA.Division);
+        Assert.IsNull(teamA.Race);
+    }
+
+    [Test]
+    public async Task UnplacedPlayers_Skipped()
+    {
+        var ev = Event(GameMode.GM_1v1, 2, GateWay.Europe, new List<PlayerMMrChange>
+        {
+            Player("calibrating#1", 0, true, Race.HU, progression: null),
+            Player("calibrating#2", 1, false, Race.OC, progression: null),
+        });
+
+        await _handler.Update(ev);
+
+        Assert.AreEqual(0, await Count());
+    }
+
+    [Test]
+    public async Task Replay_IsIdempotent()
+    {
+        var ev = Event(GameMode.GM_1v1, 2, GateWay.Europe, new List<PlayerMMrChange>
+        {
+            Player("winner#1", 0, true, Race.HU, progression: new UpdatedProgression { league = 3, division = 2, points = 50 }),
+        });
+
+        await _handler.Update(ev);
+        await _handler.Update(ev);
+
+        Assert.AreEqual(1, await Count());
+        var doc = await _repository.LoadProgression("2_winner#1@20_GM_1v1_HU");
+        Assert.AreEqual(3, doc.League);
+        Assert.AreEqual(2, doc.Division);
+        Assert.AreEqual(50, doc.Points);
+    }
+
+    [Test]
+    public async Task AtTeam_Replay_IsIdempotent()
+    {
+        var teamRank = new UpdatedProgression { league = 4, division = 1, points = 75 };
+        var ev = Event(GameMode.GM_2v2, 2, GateWay.Europe, new List<PlayerMMrChange>
+        {
+            Player("a#1", 0, true, Race.HU, atTeamId: "team-A", progression: teamRank),
+            Player("b#2", 0, true, Race.OC, atTeamId: "team-A", progression: teamRank),
+        });
+
+        await _handler.Update(ev);
+        await _handler.Update(ev);
+
+        Assert.AreEqual(1, await Count());
+        var doc = await _repository.LoadProgression("2_a#1@20_b#2@20_GM_2v2_AT");
+        Assert.AreEqual(4, doc.League);
+        Assert.AreEqual(1, doc.Division);
+    }
+
+    [Test]
+    public async Task CrossSeason_RetainsBothDocs()
+    {
+        // season 1 -> BattleTagIdCombined omits the race suffix (race-split only for season >= 2).
+        var s1 = Event(GameMode.GM_1v1, 1, GateWay.Europe, new List<PlayerMMrChange>
+        {
+            Player("p#1", 0, true, Race.HU, progression: new UpdatedProgression { league = 3, division = 2, points = 50 }),
+        });
+        var s2 = Event(GameMode.GM_1v1, 2, GateWay.Europe, new List<PlayerMMrChange>
+        {
+            Player("p#1", 0, true, Race.HU, progression: new UpdatedProgression { league = 4, division = 1, points = 10 }),
+        });
+
+        await _handler.Update(s1);
+        await _handler.Update(s2);
+
+        Assert.AreEqual(2, await Count());
+        Assert.AreEqual(3, (await _repository.LoadProgression("1_p#1@20_GM_1v1")).League);
+        Assert.AreEqual(4, (await _repository.LoadProgression("2_p#1@20_GM_1v1_HU")).League);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionRepositoryTests.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mongo2Go;
+using MongoDB.Driver;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.CommonValueObjects;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class PlayerProgressionRepositoryTests
+{
+    private MongoDbRunner _runner;
+    private MongoClient _mongoClient;
+    private PlayerProgressionRepository _repository;
+
+    [SetUp]
+    public void Setup()
+    {
+        _runner = MongoDbRunner.Start();
+        _mongoClient = new MongoClient(_runner.ConnectionString);
+        _repository = new PlayerProgressionRepository(_mongoClient);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _runner.Dispose();
+    }
+
+    private static PlayerProgression Make(string battleTag, int season, int league, int division, int points)
+    {
+        var id = new BattleTagIdCombined(
+            new List<PlayerId> { PlayerId.Create(battleTag) },
+            GateWay.Europe, GameMode.GM_1v1, season, Race.HU);
+        var p = PlayerProgression.Create(id);
+        p.RecordRank(league, division, points, null);
+        return p;
+    }
+
+    private IMongoCollection<PlayerProgression> Collection() =>
+        _mongoClient
+            .GetDatabase("W3Champions-Statistic-Service")
+            .GetCollection<PlayerProgression>("PlayerProgression");
+
+    [Test]
+    public async Task Upsert_ThenLoad_RoundTrips()
+    {
+        var p = Make("peter#123", 2, 3, 2, 50);
+
+        await _repository.UpsertProgression(p);
+        var loaded = await _repository.LoadProgression(p.Id);
+
+        Assert.IsNotNull(loaded);
+        Assert.AreEqual(3, loaded.League);
+        Assert.AreEqual(2, loaded.Division);
+        Assert.AreEqual(50, loaded.Points);
+        Assert.AreEqual(GameMode.GM_1v1, loaded.GameMode);
+        Assert.AreEqual("peter#123", loaded.PlayerIds[0].BattleTag);
+    }
+
+    [Test]
+    public async Task Upsert_Twice_KeepsSingleDocWithLatest()
+    {
+        var p = Make("peter#123", 2, 3, 2, 50);
+        await _repository.UpsertProgression(p);
+
+        var updated = Make("peter#123", 2, 4, 1, 10);
+        await _repository.UpsertProgression(updated);
+
+        var loaded = await _repository.LoadProgression(p.Id);
+        Assert.AreEqual(4, loaded.League);
+        Assert.AreEqual(1, loaded.Division);
+        Assert.AreEqual(10, loaded.Points);
+        Assert.AreEqual(1, await Collection().CountDocumentsAsync(FilterDefinition<PlayerProgression>.Empty));
+    }
+
+    [Test]
+    public async Task LoadProgression_MissingId_ReturnsNull()
+    {
+        var loaded = await _repository.LoadProgression("nope");
+        Assert.IsNull(loaded);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionTests.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.CommonValueObjects;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class PlayerProgressionTests
+{
+    [Test]
+    public void Create_FromCombinedId_CopiesIdentityFields()
+    {
+        var id = new BattleTagIdCombined(
+            new List<PlayerId> { PlayerId.Create("peter#123") },
+            GateWay.Europe, GameMode.GM_1v1, 2, Race.HU);
+
+        var progression = PlayerProgression.Create(id);
+
+        Assert.AreEqual(id.Id, progression.Id);
+        Assert.AreEqual(2, progression.Season);
+        Assert.AreEqual(GateWay.Europe, progression.GateWay);
+        Assert.AreEqual(GameMode.GM_1v1, progression.GameMode);
+        Assert.AreEqual(Race.HU, progression.Race);
+        Assert.AreEqual(1, progression.PlayerIds.Count);
+        Assert.AreEqual("peter#123", progression.PlayerIds[0].BattleTag);
+    }
+
+    [Test]
+    public void Create_FromAtTeamId_HasNullRace()
+    {
+        var id = new BattleTagIdCombined(
+            new List<PlayerId> { PlayerId.Create("alice#1"), PlayerId.Create("bob#2") },
+            GateWay.Europe, GameMode.GM_2v2, 2, null);
+
+        var progression = PlayerProgression.Create(id);
+
+        Assert.IsNull(progression.Race);
+        Assert.AreEqual(2, progression.PlayerIds.Count);
+        Assert.AreEqual(id.Id, progression.Id);
+    }
+
+    [Test]
+    public void RecordRank_SetsRankFields()
+    {
+        var id = new BattleTagIdCombined(
+            new List<PlayerId> { PlayerId.Create("peter#123") },
+            GateWay.Europe, GameMode.GM_1v1, 2, Race.HU);
+        var progression = PlayerProgression.Create(id);
+
+        progression.RecordRank(3, 2, 50, null);
+
+        Assert.AreEqual(3, progression.League);
+        Assert.AreEqual(2, progression.Division);
+        Assert.AreEqual(50, progression.Points);
+        Assert.IsNull(progression.ApexPoints);
+    }
+
+    [Test]
+    public void RecordRank_OverwritesPreviousRank()
+    {
+        var id = new BattleTagIdCombined(
+            new List<PlayerId> { PlayerId.Create("peter#123") },
+            GateWay.Europe, GameMode.GM_1v1, 2, Race.HU);
+        var progression = PlayerProgression.Create(id);
+        progression.RecordRank(1, 0, 80, null);
+
+        progression.RecordRank(3, 2, 50, 10);
+
+        Assert.AreEqual(3, progression.League);
+        Assert.AreEqual(2, progression.Division);
+        Assert.AreEqual(50, progression.Points);
+        Assert.AreEqual(10, progression.ApexPoints);
+    }
+}

--- a/docs/ranking/README.md
+++ b/docs/ranking/README.md
@@ -1,0 +1,29 @@
+# Progression ranking — read-model (downstream)
+
+website-backend is **strictly downstream** for progression ranking: it ingests and retains the
+published rank, it never computes it.
+
+## Ingest path
+
+The matchmaking service publishes a per-player progression-rank snapshot on the existing
+`MatchFinishedEvent` (`match.players[].updatedProgression`), present only once a player has a
+placed rank. The snapshot carries the published rank fields only:
+`{ league, division, points, apexPoints }`.
+
+- **DTO:** `UpdatedProgression` on `PlayerMMrChange` (`W3C.Domain/MatchmakingService/MatchEventDtos.cs`).
+  All fields are `int?` — every value is integer-or-null by construction. Additive
+  (`[BsonIgnoreExtraElements]`): events without the field deserialize it as `null`.
+- **Read-model:** `PlayerProgression` (collection `PlayerProgression`) — one document per entity
+  (a single player, or an arranged team), keyed via `BattleTagIdCombined`
+  (`"{season}_{tags@gateway}_{gameMode}[_race]"`). Season is part of the `_id`, so prior seasons are
+  retained automatically (no reset handler).
+- **Handler:** `PlayerProgressionHandler : IMatchFinishedReadModelHandler` — mirrors
+  `PlayerGameModeStatPerGatewayHandler` (arranged-team players grouped into one shared rank document;
+  gameMode normalized to its AT variant; race in the key only for `GM_1v1` from season 2 on).
+  Registered via `AddMatchFinishedReadModelService<PlayerProgressionHandler>()`.
+- **Idempotency / retention:** a deterministic `_id` + `FindOneAndReplace(IsUpsert)` make replays a
+  no-op overwrite; the read-model framework cursor (`HandlerVersions`) provides at-least-once delivery
+  and skips stale-season events.
+
+Read-model handlers are off by default locally (`IS_DEVELOPMENT`) — do not enable them against shared
+data.


### PR DESCRIPTION
## P8-2 — Ingest + season-keyed progression read-model (downstream)

Downstream ingest for the progression ranking system. The matchmaking service publishes a per-player progression-rank snapshot `{ league, division, points, apexPoints }` on the existing `MatchFinishedEvent` (`match.players[].updatedProgression`), present only once a player has a placed rank. This PR ingests it into a new season-keyed read-model. Fully additive.

### What's here
- **DTO** — `UpdatedProgression` (4 × `int?`) on `PlayerMMrChange` (`W3C.Domain/MatchmakingService/MatchEventDtos.cs`). Additive (`[BsonIgnoreExtraElements]`): events without the field deserialize it as `null`.
- **Read-model** — `PlayerProgression : IIdentifiable` (collection `PlayerProgression`): one document per entity (a single player or an arranged team), season-keyed `_id` via `BattleTagIdCombined`, so prior seasons are retained automatically (no reset handler).
- **Repository** — dedicated `IPlayerProgressionRepository` / `PlayerProgressionRepository` (`MongoDbRepositoryBase`, `AddInterceptedTransient`).
- **Handler** — `PlayerProgressionHandler : IMatchFinishedReadModelHandler`, registered via `AddMatchFinishedReadModelService<T>`. Mirrors `PlayerGameModeStatPerGatewayHandler`: arranged-team players grouped into one shared rank document, single players individually; gameMode normalized to its AT variant; race in the key only for `GM_1v1` from season 2 on. Load-or-create then upsert (idempotent).
- **Doc** — seeds `docs/ranking/README.md`.

### Notes
- **Field types `int?`** — the published rank values are integer-or-null by construction; mirrors the existing `Ranking` DTO. (A `double?` would fail to deserialize the BSON Int32 the upstream serializer emits.)
- **Idempotency / retention** — a deterministic `_id` + `FindOneAndReplace(IsUpsert)` make replays a no-op overwrite; the read-model framework cursor (`HandlerVersions`) provides at-least-once delivery and skips stale-season events; season in the `_id` retains prior seasons.
- **Additive** — the only edits to existing files are the new DTO field + two DI registrations in `Program.cs`; nothing existing changed.

### Test plan
NUnit + Mongo2Go, TDD throughout. 15 new tests under `WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/`:
- DTO: Int32-wire round-trip; absent field → null.
- Read-model: `Create` (single + arranged-team/null-race), `RecordRank`, overwrite semantics.
- Repo: upsert/load round-trip, re-upsert keeps one doc, missing id → null.
- Handler: single-player placement, arranged team → single shared doc (normalized gameMode, no race), unplaced skip, replay idempotency (single + team), cross-season retention, apexPoints pass-through.

**Gate (local):** `dotnet build` → 0 errors · `dotnet test` (full suite) → **586 passed / 0 failed / 9 skipped** · `dotnet format --verify-no-changes` → clean.

### Checklist
- [x] Targets `prj/new-ranking-system` (not master/main/develop)
- [x] Tests added (NUnit + Mongo2Go) — TDD
- [x] Gate output green (build + full suite + format)
- [x] Additive only — legacy ladder read-models (`Rank`/`PlayerGameModeStatPerGateway`) untouched; read-model handlers off by default locally (`IS_DEVELOPMENT`)
