### PR TITLE
P7-1: Lifetime win-milestone store

### DIFF
--- a/W3C.Domain/GameModes/GameModesHelper.cs
+++ b/W3C.Domain/GameModes/GameModesHelper.cs
@@ -43,7 +43,11 @@ public class GameModesHelper
     public static GameMode ToArrangedTeamVariant(GameMode gameMode, bool isAt)
         => isAt && ArrangedTeamVariants.TryGetValue(gameMode, out var atVariant) ? atVariant : gameMode;
 
+    // 1v1 is the only race-split game mode (its ladder/progression is tracked per race).
+    public static bool IsRaceSplitGameMode(GameMode gameMode)
+        => gameMode == GameMode.GM_1v1;
+
     // 1v1 ladders are keyed per race from RaceSplitStartSeason onward; other modes/seasons are not.
     public static bool UsesRaceInLadderKey(GameMode gameMode, int season)
-        => gameMode == GameMode.GM_1v1 && season >= RaceSplitStartSeason;
+        => IsRaceSplitGameMode(gameMode) && season >= RaceSplitStartSeason;
 }

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/MilestoneTargetCalculator.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/MilestoneTargetCalculator.cs
@@ -1,19 +1,25 @@
+using System;
+
 namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 
 // Pure, on-read next-milestone selection. Baseline granularity curve (the next round-number of
-// wins; the step coarsens as totals grow) plus a player-local catch-up that only ever NARROWS the
-// gap (a returning/low-volume player gets a nearer milestone; an active player gets the baseline —
-// never a widening gap). All thresholds are tunable constants; tests assert behaviour + invariants.
+// wins; the step coarsens as totals grow, capped at 100) plus a player-local catch-up that only
+// ever NARROWS the gap (a returning/low-volume player gets a nearer milestone; an active player
+// gets the baseline — never a widening gap). All thresholds are tunable constants; tests assert
+// behaviour + invariants.
 public static class MilestoneTargetCalculator
 {
-    // (upperBoundExclusive, step). Coarser steps are integer multiples of finer ones so a finer
-    // catch-up step never produces a farther target.
+    // (upperBoundExclusive, step). Step sizes are 5, 10, 25, 50, 100 — capped at 100. They are NOT
+    // all integer multiples of one another (25 is not a multiple of 10), so a finer catch-up step can
+    // occasionally land beyond the baseline milestone; Compute clamps the catch-up to the baseline so
+    // it can never widen the gap regardless of the step set.
     private static readonly (long UpperExclusive, long Step)[] Bands =
     {
         (50, 5),
+        (100, 10),
+        (250, 25),
         (500, 50),
-        (5000, 250),
-        (long.MaxValue, 1000),
+        (long.MaxValue, 100),
     };
 
     // Catch-up thresholds over the trailing recent-activity window (tunable).
@@ -23,12 +29,19 @@ public static class MilestoneTargetCalculator
 
     public static MilestoneTarget Compute(long totalWins, MilestoneActivity activity)
     {
-        var baseBand = BaselineBandIndex(totalWins);
-        var band = ApplyCatchUp(baseBand, activity);
-        var step = Bands[band].Step;
-        var next = ((totalWins / step) + 1) * step; // strictly greater multiple of step
+        var baselineTarget = NextMultiple(totalWins, Bands[BaselineBandIndex(totalWins)].Step);
+
+        var catchUpBand = ApplyCatchUp(BaselineBandIndex(totalWins), activity);
+        var catchUpTarget = NextMultiple(totalWins, Bands[catchUpBand].Step);
+
+        // Catch-up may only narrow. Because the step set is not fully nested, a finer step can land
+        // beyond the baseline milestone, so clamp to the baseline — never widen.
+        var next = Math.Min(baselineTarget, catchUpTarget);
         return new MilestoneTarget(next, next - totalWins);
     }
+
+    // The next multiple of step strictly greater than totalWins.
+    private static long NextMultiple(long totalWins, long step) => ((totalWins / step) + 1) * step;
 
     private static int BaselineBandIndex(long totalWins)
     {

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/MilestoneTargetCalculator.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/MilestoneTargetCalculator.cs
@@ -39,13 +39,14 @@ public static class MilestoneTargetCalculator
                 return i;
             }
         }
+        // Reached only when totalWins == long.MaxValue (loop's strict < misses the final band); returns the top band correctly.
         return Bands.Length - 1;
     }
 
     private static int ApplyCatchUp(int baseBand, MilestoneActivity activity)
     {
         var finer = 0;
-        if (activity.RecentGames <= DormantRecentGames)
+        if (activity.RecentGames <= DormantRecentGames) // <= also treats any negative as dormant (structurally impossible from ActivityIn, but Compute is public)
         {
             finer = baseBand; // drop all the way to the finest (band 0)
         }
@@ -57,5 +58,3 @@ public static class MilestoneTargetCalculator
         return band < 0 ? 0 : band;
     }
 }
-
-public readonly record struct MilestoneTarget(long NextTarget, long WinsToNext);

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/MilestoneTargetCalculator.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/MilestoneTargetCalculator.cs
@@ -1,0 +1,61 @@
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+// Pure, on-read next-milestone selection. Baseline granularity curve (the next round-number of
+// wins; the step coarsens as totals grow) plus a player-local catch-up that only ever NARROWS the
+// gap (a returning/low-volume player gets a nearer milestone; an active player gets the baseline —
+// never a widening gap). All thresholds are tunable constants; tests assert behaviour + invariants.
+public static class MilestoneTargetCalculator
+{
+    // (upperBoundExclusive, step). Coarser steps are integer multiples of finer ones so a finer
+    // catch-up step never produces a farther target.
+    private static readonly (long UpperExclusive, long Step)[] Bands =
+    {
+        (50, 5),
+        (500, 50),
+        (5000, 250),
+        (long.MaxValue, 1000),
+    };
+
+    // Catch-up thresholds over the trailing recent-activity window (tunable).
+    private const int DormantRecentGames = 0;       // no games in window → finest grid
+    private const int LowVolumeRecentGames = 10;    // few games in window → one band finer
+    private const int LowVolumeActiveWeeks = 3;     // …or active in few weeks
+
+    public static MilestoneTarget Compute(long totalWins, MilestoneActivity activity)
+    {
+        var baseBand = BaselineBandIndex(totalWins);
+        var band = ApplyCatchUp(baseBand, activity);
+        var step = Bands[band].Step;
+        var next = ((totalWins / step) + 1) * step; // strictly greater multiple of step
+        return new MilestoneTarget(next, next - totalWins);
+    }
+
+    private static int BaselineBandIndex(long totalWins)
+    {
+        for (var i = 0; i < Bands.Length; i++)
+        {
+            if (totalWins < Bands[i].UpperExclusive)
+            {
+                return i;
+            }
+        }
+        return Bands.Length - 1;
+    }
+
+    private static int ApplyCatchUp(int baseBand, MilestoneActivity activity)
+    {
+        var finer = 0;
+        if (activity.RecentGames <= DormantRecentGames)
+        {
+            finer = baseBand; // drop all the way to the finest (band 0)
+        }
+        else if (activity.RecentGames < LowVolumeRecentGames || activity.ActiveWeeks < LowVolumeActiveWeeks)
+        {
+            finer = 1;
+        }
+        var band = baseBand - finer;
+        return band < 0 ? 0 : band;
+    }
+}
+
+public readonly record struct MilestoneTarget(long NextTarget, long WinsToNext);

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestone.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestone.cs
@@ -35,6 +35,9 @@ public class ProgressionMilestone : IIdentifiable
     public long TotalWins { get; set; }
     public List<ActivityWeek> ActivityWeeks { get; set; } = new();
 
+    // Forward-looking: maintained on every game for a future read/display path (e.g. "last played").
+    // The target calculator does NOT consume it (it derives recency from the weekly buckets); kept
+    // here so it backfills for free during the historical replay rather than needing a reprocess later.
     [BsonRepresentation(BsonType.Array)]
     public DateTimeOffset LastPlayedAt { get; set; }
 

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestone.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestone.cs
@@ -13,12 +13,21 @@ namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 // Permanent, monotonic per-entity/mode/race lifetime win-milestone track. One document per
 // (entity, gateway, gameMode, race?) — season-less, so wins accumulate across all seasons.
 // totalWins counts wins only; activityWeeks counts every game (won or lost) in a rolling
-// ~90-day window, pre-computed on write so the on-read target calculator needs no history query.
+// recent window (see RecentWindowDays), pre-computed on write so the on-read target calculator
+// needs no history query.
 public class ProgressionMilestone : IIdentifiable
 {
+    // The recent-activity window, in days. Activity is bucketed and filtered at ISO-week
+    // granularity, so the effective window width is ~91–97 days depending on day-of-week —
+    // this is not an exact 90-day boundary. Week granularity is intended.
     public const int RecentWindowDays = 90;
 
-    public List<PlayerId> PlayerIds { get; set; }
+    // Keep a small buffer beyond the read window so the ISO-week-aligned lower bound used by
+    // ActivityIn is never pruned away (ActivityIn looks back up to ~7 days past RecentWindowDays
+    // due to week-alignment).
+    private const int ActivityPruneMarginDays = 7;
+
+    public List<PlayerId> PlayerIds { get; set; } = new();
     public GateWay GateWay { get; set; }
     public GameMode GameMode { get; set; }
     public Race? Race { get; set; }
@@ -76,6 +85,11 @@ public class ProgressionMilestone : IIdentifiable
         var cutoffWeek = StartOfIsoWeek(cutoff);
         ActivityWeeks.RemoveAll(w => w.WeekStartUtc < cutoffWeek);
     }
+
+    // Drop activity weeks older than the rolling window (+ alignment margin), measured from `reference`
+    // (typically the just-ingested game's timestamp). Bounds the stored array; ActivityIn re-filters on read.
+    public void PruneStaleActivity(DateTimeOffset reference)
+        => PruneActivityBefore(reference.AddDays(-(RecentWindowDays + ActivityPruneMarginDays)));
 
     public MilestoneActivity ActivityIn(DateTimeOffset now)
     {

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestone.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestone.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.CommonValueObjects;
+using W3C.Domain.Repositories;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+// Permanent, monotonic per-entity/mode/race lifetime win-milestone track. One document per
+// (entity, gateway, gameMode, race?) — season-less, so wins accumulate across all seasons.
+// totalWins counts wins only; activityWeeks counts every game (won or lost) in a rolling
+// ~90-day window, pre-computed on write so the on-read target calculator needs no history query.
+public class ProgressionMilestone : IIdentifiable
+{
+    public const int RecentWindowDays = 90;
+
+    public List<PlayerId> PlayerIds { get; set; }
+    public GateWay GateWay { get; set; }
+    public GameMode GameMode { get; set; }
+    public Race? Race { get; set; }
+
+    public long TotalWins { get; set; }
+    public List<ActivityWeek> ActivityWeeks { get; set; } = new();
+
+    [BsonRepresentation(BsonType.Array)]
+    public DateTimeOffset LastPlayedAt { get; set; }
+
+    public string Id => BuildId(PlayerIds, GateWay, GameMode, Race);
+
+    public static string BuildId(List<PlayerId> playerIds, GateWay gateWay, GameMode gameMode, Race? race)
+    {
+        var key = string.Join("_", playerIds.OrderBy(t => t.BattleTag).Select(b => $"{b.BattleTag}@{(int)gateWay}"));
+        var id = $"{key}_{gameMode}";
+        if (race != null)
+        {
+            id += $"_{race}";
+        }
+        return id;
+    }
+
+    public static ProgressionMilestone Create(List<PlayerId> playerIds, GateWay gateWay, GameMode gameMode, Race? race)
+    {
+        return new ProgressionMilestone
+        {
+            PlayerIds = playerIds,
+            GateWay = gateWay,
+            GameMode = gameMode,
+            Race = race,
+        };
+    }
+
+    public void RecordWin() => TotalWins++;
+
+    public void RecordActivity(DateTimeOffset playedAt)
+    {
+        var weekStart = StartOfIsoWeek(playedAt);
+        var bucket = ActivityWeeks.FirstOrDefault(w => w.WeekStartUtc == weekStart);
+        if (bucket == null)
+        {
+            bucket = new ActivityWeek { WeekStartUtc = weekStart };
+            ActivityWeeks.Add(bucket);
+        }
+        bucket.Games++;
+        if (playedAt > LastPlayedAt)
+        {
+            LastPlayedAt = playedAt;
+        }
+    }
+
+    public void PruneActivityBefore(DateTimeOffset cutoff)
+    {
+        var cutoffWeek = StartOfIsoWeek(cutoff);
+        ActivityWeeks.RemoveAll(w => w.WeekStartUtc < cutoffWeek);
+    }
+
+    public MilestoneActivity ActivityIn(DateTimeOffset now)
+    {
+        var windowStart = StartOfIsoWeek(now.AddDays(-RecentWindowDays));
+        var inWindow = ActivityWeeks.Where(w => w.WeekStartUtc >= windowStart).ToList();
+        return new MilestoneActivity(inWindow.Sum(w => w.Games), inWindow.Count(w => w.Games > 0));
+    }
+
+    // Monday 00:00 UTC of the ISO week containing the instant.
+    public static DateTimeOffset StartOfIsoWeek(DateTimeOffset instant)
+    {
+        var day = instant.UtcDateTime.Date;
+        var diff = ((int)day.DayOfWeek + 6) % 7; // Monday = 0
+        return new DateTimeOffset(day.AddDays(-diff), TimeSpan.Zero);
+    }
+}
+
+public class ActivityWeek
+{
+    [BsonRepresentation(BsonType.Array)]
+    public DateTimeOffset WeekStartUtc { get; set; }
+    public int Games { get; set; }
+}
+
+public readonly record struct MilestoneActivity(int RecentGames, int ActiveWeeks);

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestone.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestone.cs
@@ -115,3 +115,5 @@ public class ActivityWeek
 }
 
 public readonly record struct MilestoneActivity(int RecentGames, int ActiveWeeks);
+
+public readonly record struct MilestoneTarget(long NextTarget, long WinsToNext);

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestoneHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestoneHandler.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.CommonValueObjects;
+using W3C.Domain.GameModes;
+using W3C.Domain.MatchmakingService;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.ReadModelBase;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+// Ingests MatchFinishedEvent into the permanent per-entity/mode/race win-milestone store.
+// Mirrors PlayerProgressionHandler's AT grouping + keying, but is driven by the per-player `won`
+// flag (NOT updatedProgression) so lifetime wins accrue independently of the progression engine
+// flags, and uses a season-less key so totals accumulate across seasons. totalWins increments on
+// a win; the weekly activity window records every game (won or lost) and is pruned to ~90 days.
+[Trace]
+public class ProgressionMilestoneHandler(IProgressionMilestoneRepository milestoneRepository) : IMatchFinishedReadModelHandler
+{
+    private readonly IProgressionMilestoneRepository _milestoneRepository = milestoneRepository;
+
+    public async Task Update(MatchFinishedEvent nextEvent)
+    {
+        if (nextEvent.WasFakeEvent)
+        {
+            return;
+        }
+
+        var match = nextEvent.match;
+        var players = match.players ?? new List<PlayerMMrChange>();
+        var rawMs = match.endTime > 0 ? match.endTime : match.startTime;
+        var playedAt = DateTimeOffset.FromUnixTimeMilliseconds(rawMs);
+
+        foreach (var team in players.Where(p => p.IsAt).GroupBy(p => p.atTeamId))
+        {
+            await RecordEntity(match, team.ToList(), playedAt);
+        }
+
+        foreach (var soloPlayer in players.Where(p => !p.IsAt))
+        {
+            await RecordEntity(match, new List<PlayerMMrChange> { soloPlayer }, playedAt);
+        }
+    }
+
+    private async Task RecordEntity(Match match, List<PlayerMMrChange> entityPlayers, DateTimeOffset playedAt)
+    {
+        var first = entityPlayers[0];
+        var playerIds = entityPlayers.Select(p => PlayerId.Create(p.battleTag)).ToList();
+        var gameMode = GameModesHelper.ToArrangedTeamVariant(match.gameMode, first.IsAt);
+        // Milestones accumulate across seasons, so the key must be season-less and stable.
+        // Unlike the season-keyed ladder (which gates race on RaceSplitStartSeason), we
+        // always include race for solo GM_1v1 so pre-season-2 wins roll up into the same doc.
+        var race = gameMode == GameMode.GM_1v1
+            ? (Race?)entityPlayers.Single().race
+            : null;
+
+        var id = ProgressionMilestone.BuildId(playerIds, match.gateway, gameMode, race);
+        var milestone = await _milestoneRepository.LoadMilestone(id)
+                        ?? ProgressionMilestone.Create(playerIds, match.gateway, gameMode, race);
+
+        if (first.won)
+        {
+            milestone.RecordWin();
+        }
+        milestone.RecordActivity(playedAt);
+        milestone.PruneStaleActivity(playedAt); // model owns the window+margin policy
+
+        await _milestoneRepository.UpsertMilestone(milestone);
+    }
+}

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestoneHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestoneHandler.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using W3C.Contracts.GameObjects;
-using W3C.Contracts.Matchmaking;
 using W3C.Domain.CommonValueObjects;
 using W3C.Domain.GameModes;
 using W3C.Domain.MatchmakingService;
@@ -51,10 +50,10 @@ public class ProgressionMilestoneHandler(IProgressionMilestoneRepository milesto
         var first = entityPlayers[0];
         var playerIds = entityPlayers.Select(p => PlayerId.Create(p.battleTag)).ToList();
         var gameMode = GameModesHelper.ToArrangedTeamVariant(match.gameMode, first.IsAt);
-        // Milestones accumulate across seasons, so the key must be season-less and stable.
-        // Unlike the season-keyed ladder (which gates race on RaceSplitStartSeason), we
-        // always include race for solo GM_1v1 so pre-season-2 wins roll up into the same doc.
-        var race = gameMode == GameMode.GM_1v1
+        // Milestones accumulate across seasons, so the key must be season-less and stable. Unlike the
+        // season-keyed ladder (UsesRaceInLadderKey gates on RaceSplitStartSeason), we include race for a
+        // race-split mode in ALL seasons so pre-season-2 wins roll up into the same per-race doc.
+        var race = GameModesHelper.IsRaceSplitGameMode(match.gameMode)
             ? (Race?)entityPlayers.Single().race
             : null;
 

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestoneHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestoneHandler.cs
@@ -15,9 +15,9 @@ namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 
 // Ingests MatchFinishedEvent into the permanent per-entity/mode/race win-milestone store.
 // Mirrors PlayerProgressionHandler's AT grouping + keying, but is driven by the per-player `won`
-// flag (NOT updatedProgression) so lifetime wins accrue independently of the progression engine
-// flags, and uses a season-less key so totals accumulate across seasons. totalWins increments on
-// a win; the weekly activity window records every game (won or lost) and is pruned to ~90 days.
+// flag rather than `updatedProgression`, so lifetime wins accrue regardless of whether a rank was
+// recorded for the match. Uses a season-less key so totals accumulate across seasons. totalWins
+// increments on a win; the weekly activity window records every game (won or lost), pruned to ~90 days.
 [Trace]
 public class ProgressionMilestoneHandler(IProgressionMilestoneRepository milestoneRepository) : IMatchFinishedReadModelHandler
 {

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestoneHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestoneHandler.cs
@@ -62,6 +62,10 @@ public class ProgressionMilestoneHandler(IProgressionMilestoneRepository milesto
         var milestone = await _milestoneRepository.LoadMilestone(id)
                         ?? ProgressionMilestone.Create(playerIds, match.gateway, gameMode, race);
 
+        // Every member of an AT team shares the same match result (MM emits one team outcome), so
+        // entityPlayers[0].won represents the whole entity. Activity is recorded for every game (won
+        // or lost); PruneStaleActivity runs after RecordActivity — the just-added bucket can never be
+        // its own victim because the prune margin exceeds the window.
         if (first.won)
         {
             milestone.RecordWin();

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestoneRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionMilestoneRepository.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.Ports;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+[Trace]
+public class ProgressionMilestoneRepository(MongoClient mongoClient)
+    : MongoDbRepositoryBase(mongoClient), IProgressionMilestoneRepository
+{
+    public Task<ProgressionMilestone> LoadMilestone(string id)
+    {
+        return LoadFirst<ProgressionMilestone>(id);
+    }
+
+    public Task UpsertMilestone(ProgressionMilestone milestone)
+    {
+        return Upsert(milestone);
+    }
+}

--- a/W3ChampionsStatisticService/Ports/IProgressionMilestoneRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IProgressionMilestoneRepository.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace W3ChampionsStatisticService.Ports;
+
+public interface IProgressionMilestoneRepository
+{
+    Task<ProgressionMilestone> LoadMilestone(string id);
+    Task UpsertMilestone(ProgressionMilestone milestone);
+}

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -163,6 +163,7 @@ builder.Services.AddInterceptedTransient<IMatchRepository, MatchRepository>();
 builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexes, MatchRepository>();
 builder.Services.AddInterceptedSingleton<IPlayerRepository, PlayerRepository>();
 builder.Services.AddInterceptedTransient<IPlayerProgressionRepository, PlayerProgressionRepository>();
+builder.Services.AddInterceptedTransient<IProgressionMilestoneRepository, ProgressionMilestoneRepository>();
 builder.Services.AddInterceptedTransient<IRankRepository, RankRepository>();
 builder.Services.AddInterceptedTransient<IPlayerStatsRepository, PlayerStatsRepository>();
 builder.Services.AddInterceptedTransient<IW3StatsRepo, W3StatsRepo>();
@@ -254,6 +255,7 @@ if (startHandlers == "true")
     builder.Services.AddMatchFinishedReadModelService<PlayerRaceStatPerGatewayHandler>();
     builder.Services.AddMatchFinishedReadModelService<PlayerMmrRpTimelineHandler>();
     builder.Services.AddMatchFinishedReadModelService<PlayerProgressionHandler>();
+    builder.Services.AddMatchFinishedReadModelService<ProgressionMilestoneHandler>();
     builder.Services.AddMatchFinishedReadModelService<GameLengthForPlayerStatisticsHandler>();
 
     // General Stats

--- a/WC3ChampionsStatisticService.UnitTests/GameModes/GameModesHelperTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/GameModes/GameModesHelperTests.cs
@@ -40,6 +40,20 @@ public class GameModesHelperTests
         Assert.AreEqual(GameMode.GM_DOTA_5ON5_AT, GameModesHelper.ToArrangedTeamVariant(GameMode.GM_DOTA_5ON5, true));
     }
 
+    // IsRaceSplitGameMode
+
+    [Test]
+    public void IsRaceSplitGameMode_1v1_ReturnsTrue()
+    {
+        Assert.IsTrue(GameModesHelper.IsRaceSplitGameMode(GameMode.GM_1v1));
+    }
+
+    [Test]
+    public void IsRaceSplitGameMode_2v2_ReturnsFalse()
+    {
+        Assert.IsFalse(GameModesHelper.IsRaceSplitGameMode(GameMode.GM_2v2));
+    }
+
     // UsesRaceInLadderKey
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/MilestoneTargetCalculatorTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/MilestoneTargetCalculatorTests.cs
@@ -1,0 +1,95 @@
+using NUnit.Framework;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class MilestoneTargetCalculatorTests
+{
+    // An "active" profile: enough recent games/weeks to sit at the baseline curve.
+    private static readonly MilestoneActivity Active = new(40, 8);
+    private static readonly MilestoneActivity LowVolume = new(6, 3);
+    private static readonly MilestoneActivity Dormant = new(0, 0);
+
+    [Test]
+    public void Baseline_Band0_Step5()
+    {
+        var t = MilestoneTargetCalculator.Compute(30, Active);
+        Assert.AreEqual(35, t.NextTarget);
+        Assert.AreEqual(5, t.WinsToNext);
+    }
+
+    [Test]
+    public void Baseline_Band1_Step50()
+    {
+        var t = MilestoneTargetCalculator.Compute(220, Active);
+        Assert.AreEqual(250, t.NextTarget);
+        Assert.AreEqual(30, t.WinsToNext);
+    }
+
+    [Test]
+    public void Baseline_Band2_Step250()
+    {
+        var t = MilestoneTargetCalculator.Compute(1230, Active);
+        Assert.AreEqual(1250, t.NextTarget);
+    }
+
+    [Test]
+    public void Baseline_Band3_Step1000()
+    {
+        var t = MilestoneTargetCalculator.Compute(7300, Active);
+        Assert.AreEqual(8000, t.NextTarget);
+    }
+
+    [Test]
+    public void NextTarget_IsAlwaysStrictlyGreater_EvenOnAMilestone()
+    {
+        var t = MilestoneTargetCalculator.Compute(50, Active);   // exactly on 50, now in band1 (step 50)
+        Assert.AreEqual(100, t.NextTarget);
+        Assert.AreEqual(50, t.WinsToNext);
+        Assert.Greater(t.WinsToNext, 0);
+    }
+
+    [Test]
+    public void Newcomer_LowTotals_GetFineStepsFromCurveAlone()
+    {
+        var t = MilestoneTargetCalculator.Compute(7, Active);
+        Assert.AreEqual(10, t.NextTarget); // step 5 grid
+    }
+
+    [Test]
+    public void CatchUp_Dormant_NarrowsTargetVsBaseline()
+    {
+        var baseline = MilestoneTargetCalculator.Compute(1230, Active);
+        var dormant = MilestoneTargetCalculator.Compute(1230, Dormant);
+        Assert.Less(dormant.NextTarget, baseline.NextTarget); // nearer
+        Assert.Greater(dormant.WinsToNext, 0);
+    }
+
+    [Test]
+    public void CatchUp_LowVolume_NarrowsOrEquals_NeverWidens()
+    {
+        var baseline = MilestoneTargetCalculator.Compute(1230, Active);
+        var low = MilestoneTargetCalculator.Compute(1230, LowVolume);
+        Assert.LessOrEqual(low.NextTarget, baseline.NextTarget);
+    }
+
+    [Test]
+    public void Invariant_CatchUpNeverWidens_AcrossSamples()
+    {
+        long[] totals = { 0, 7, 49, 50, 213, 499, 500, 1230, 4999, 5000, 7300, 99999 };
+        foreach (var total in totals)
+        {
+            var baseline = MilestoneTargetCalculator.Compute(total, Active);
+            var dormant = MilestoneTargetCalculator.Compute(total, Dormant);
+            var low = MilestoneTargetCalculator.Compute(total, LowVolume);
+            Assert.LessOrEqual(dormant.NextTarget, baseline.NextTarget, $"dormant widened at {total}");
+            Assert.LessOrEqual(low.NextTarget, baseline.NextTarget, $"low widened at {total}");
+            foreach (var t in new[] { baseline, dormant, low })
+            {
+                Assert.Greater(t.NextTarget, total, $"target not strictly greater at {total}");
+                Assert.AreEqual(t.NextTarget - total, t.WinsToNext, $"winsToNext mismatch at {total}");
+            }
+        }
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/MilestoneTargetCalculatorTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/MilestoneTargetCalculatorTests.cs
@@ -11,6 +11,8 @@ public class MilestoneTargetCalculatorTests
     private static readonly MilestoneActivity LowVolume = new(6, 3);
     private static readonly MilestoneActivity Dormant = new(0, 0);
 
+    // Baseline curve: steps 5, 10, 25, 50, 100 — capped at 100.
+
     [Test]
     public void Baseline_Band0_Step5()
     {
@@ -20,35 +22,51 @@ public class MilestoneTargetCalculatorTests
     }
 
     [Test]
-    public void Baseline_Band1_Step50()
+    public void Baseline_Band1_Step10()
     {
-        var t = MilestoneTargetCalculator.Compute(220, Active);
-        Assert.AreEqual(250, t.NextTarget);
+        var t = MilestoneTargetCalculator.Compute(64, Active);
+        Assert.AreEqual(70, t.NextTarget);
+        Assert.AreEqual(6, t.WinsToNext);
+    }
+
+    [Test]
+    public void Baseline_Band2_Step25()
+    {
+        var t = MilestoneTargetCalculator.Compute(120, Active);
+        Assert.AreEqual(125, t.NextTarget);
+        Assert.AreEqual(5, t.WinsToNext);
+    }
+
+    [Test]
+    public void Baseline_Band3_Step50()
+    {
+        var t = MilestoneTargetCalculator.Compute(320, Active);
+        Assert.AreEqual(350, t.NextTarget);
         Assert.AreEqual(30, t.WinsToNext);
     }
 
     [Test]
-    public void Baseline_Band2_Step250()
+    public void Baseline_Band4_Step100()
     {
-        var t = MilestoneTargetCalculator.Compute(1230, Active);
-        Assert.AreEqual(1250, t.NextTarget);
-        Assert.AreEqual(20, t.WinsToNext);
+        var t = MilestoneTargetCalculator.Compute(7300, Active);
+        Assert.AreEqual(7400, t.NextTarget);
+        Assert.AreEqual(100, t.WinsToNext);
     }
 
     [Test]
-    public void Baseline_Band3_Step1000()
+    public void MaxStep_IsCappedAt100_NoMatterHowLargeTheTotal()
     {
-        var t = MilestoneTargetCalculator.Compute(7300, Active);
-        Assert.AreEqual(8000, t.NextTarget);
-        Assert.AreEqual(700, t.WinsToNext);
+        var t = MilestoneTargetCalculator.Compute(100_000, Active);
+        Assert.AreEqual(100_100, t.NextTarget);
+        Assert.AreEqual(100, t.WinsToNext); // step never exceeds 100
     }
 
     [Test]
     public void NextTarget_IsAlwaysStrictlyGreater_EvenOnAMilestone()
     {
-        var t = MilestoneTargetCalculator.Compute(50, Active);   // exactly on 50, now in band1 (step 50)
-        Assert.AreEqual(100, t.NextTarget);
-        Assert.AreEqual(50, t.WinsToNext);
+        var t = MilestoneTargetCalculator.Compute(50, Active);   // exactly on 50, now in band1 (step 10)
+        Assert.AreEqual(60, t.NextTarget);
+        Assert.AreEqual(10, t.WinsToNext);
         Assert.Greater(t.WinsToNext, 0);
     }
 
@@ -62,8 +80,10 @@ public class MilestoneTargetCalculatorTests
     [Test]
     public void CatchUp_Dormant_NarrowsTargetVsBaseline()
     {
-        var baseline = MilestoneTargetCalculator.Compute(1230, Active);
-        var dormant = MilestoneTargetCalculator.Compute(1230, Dormant);
+        var baseline = MilestoneTargetCalculator.Compute(1230, Active);  // step 100 → 1300
+        var dormant = MilestoneTargetCalculator.Compute(1230, Dormant);  // finest step 5 → 1235
+        Assert.AreEqual(1300, baseline.NextTarget);
+        Assert.AreEqual(1235, dormant.NextTarget);
         Assert.Less(dormant.NextTarget, baseline.NextTarget); // nearer
         Assert.Greater(dormant.WinsToNext, 0);
     }
@@ -71,27 +91,27 @@ public class MilestoneTargetCalculatorTests
     [Test]
     public void CatchUp_LowVolume_NarrowsOrEquals_NeverWidens()
     {
-        var baseline = MilestoneTargetCalculator.Compute(1230, Active);
-        var low = MilestoneTargetCalculator.Compute(1230, LowVolume);
+        var baseline = MilestoneTargetCalculator.Compute(1230, Active);    // step 100 → 1300
+        var low = MilestoneTargetCalculator.Compute(1230, LowVolume);      // one band finer, step 50 → 1250
         Assert.LessOrEqual(low.NextTarget, baseline.NextTarget);
+        Assert.AreEqual(1250, low.NextTarget);
         Assert.Greater(low.WinsToNext, 0);
-        // 1230 is a multiple of 50 as well as 250, so the low-volume (band1, step50) target equals the baseline here — narrows-or-equals, never widens.
     }
 
     [Test]
     public void CatchUp_FewActiveWeeks_EvenWithEnoughGames_Narrows()
     {
         var fewWeeks = new MilestoneActivity(15, 2); // RecentGames >= 10 but ActiveWeeks < 3
-        var baseline = MilestoneTargetCalculator.Compute(1260, Active);
-        var narrowed = MilestoneTargetCalculator.Compute(1260, fewWeeks);
-        Assert.Less(narrowed.NextTarget, baseline.NextTarget); // band2 step250 → 1500; band1 step50 → 1300 (narrower)
+        var baseline = MilestoneTargetCalculator.Compute(1230, Active);    // step 100 → 1300
+        var narrowed = MilestoneTargetCalculator.Compute(1230, fewWeeks);  // one band finer, step 50 → 1250
+        Assert.Less(narrowed.NextTarget, baseline.NextTarget);
         Assert.Greater(narrowed.WinsToNext, 0);
     }
 
     [Test]
     public void Invariant_CatchUpNeverWidens_AcrossSamples()
     {
-        long[] totals = { 0, 7, 49, 50, 213, 499, 500, 1230, 4999, 5000, 7300, 99999 };
+        long[] totals = { 0, 7, 49, 50, 64, 99, 100, 213, 249, 250, 300, 499, 500, 1230, 7300, 99999 };
         foreach (var total in totals)
         {
             var baseline = MilestoneTargetCalculator.Compute(total, Active);

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/MilestoneTargetCalculatorTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/MilestoneTargetCalculatorTests.cs
@@ -32,6 +32,7 @@ public class MilestoneTargetCalculatorTests
     {
         var t = MilestoneTargetCalculator.Compute(1230, Active);
         Assert.AreEqual(1250, t.NextTarget);
+        Assert.AreEqual(20, t.WinsToNext);
     }
 
     [Test]
@@ -39,6 +40,7 @@ public class MilestoneTargetCalculatorTests
     {
         var t = MilestoneTargetCalculator.Compute(7300, Active);
         Assert.AreEqual(8000, t.NextTarget);
+        Assert.AreEqual(700, t.WinsToNext);
     }
 
     [Test]
@@ -72,6 +74,18 @@ public class MilestoneTargetCalculatorTests
         var baseline = MilestoneTargetCalculator.Compute(1230, Active);
         var low = MilestoneTargetCalculator.Compute(1230, LowVolume);
         Assert.LessOrEqual(low.NextTarget, baseline.NextTarget);
+        Assert.Greater(low.WinsToNext, 0);
+        // 1230 is a multiple of 50 as well as 250, so the low-volume (band1, step50) target equals the baseline here — narrows-or-equals, never widens.
+    }
+
+    [Test]
+    public void CatchUp_FewActiveWeeks_EvenWithEnoughGames_Narrows()
+    {
+        var fewWeeks = new MilestoneActivity(15, 2); // RecentGames >= 10 but ActiveWeeks < 3
+        var baseline = MilestoneTargetCalculator.Compute(1260, Active);
+        var narrowed = MilestoneTargetCalculator.Compute(1260, fewWeeks);
+        Assert.Less(narrowed.NextTarget, baseline.NextTarget); // band2 step250 → 1500; band1 step50 → 1300 (narrower)
+        Assert.Greater(narrowed.WinsToNext, 0);
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionMilestoneHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionMilestoneHandlerTests.cs
@@ -43,8 +43,6 @@ public class ProgressionMilestoneHandlerTests
             won = won,
             race = race,
             atTeamId = atTeamId,
-            mmr = new Mmr { rating = 1500 },
-            updatedMmr = new Mmr { rating = won ? 1520 : 1480 },
         };
     }
 
@@ -68,7 +66,7 @@ public class ProgressionMilestoneHandlerTests
 
     private Task<ProgressionMilestone> Load(string id) => _repository.LoadMilestone(id);
     private Task<long> Count() => _mongoClient.GetDatabase("W3Champions-Statistic-Service")
-        .GetCollection<ProgressionMilestone>("ProgressionMilestone")
+        .GetCollection<ProgressionMilestone>(nameof(ProgressionMilestone))
         .CountDocumentsAsync(FilterDefinition<ProgressionMilestone>.Empty);
 
     [Test]
@@ -104,6 +102,11 @@ public class ProgressionMilestoneHandlerTests
         Assert.IsNotNull(t1);
         Assert.AreEqual(1, t1.TotalWins);
         Assert.IsNull(t1.Race);
+
+        var t2 = await Load("c#3@20_d#4@20_GM_2v2_AT");
+        Assert.IsNotNull(t2);
+        Assert.AreEqual(0, t2.TotalWins);
+        Assert.AreEqual(1, t2.ActivityWeeks.Count); // loss still records activity
     }
 
     [Test]
@@ -180,5 +183,33 @@ public class ProgressionMilestoneHandlerTests
         await _handler.Update(ev);
 
         Assert.AreEqual(2, (await Load("zed#1@20_GM_1v1_HU")).TotalWins);
+    }
+
+    [Test]
+    public async Task MixedAtAndSolo_InSameMatch_WriteCorrectDocs()
+    {
+        await _handler.Update(Event(GameMode.GM_2v2, 2, GateWay.Europe, Ms(2026, 6, 3), new List<PlayerMMrChange>
+        {
+            Player("a#1", 0, true, Race.HU, atTeamId: "T1"),   // AT pair, won
+            Player("b#2", 0, true, Race.OC, atTeamId: "T1"),
+            Player("c#3", 1, false, Race.NE),                  // solo-queued, lost (IsAt false)
+            Player("d#4", 1, false, Race.UD),                  // solo-queued, lost
+        }));
+
+        Assert.AreEqual(3, await Count()); // 1 AT-pair doc + 2 solo docs
+        var atPair = await Load("a#1@20_b#2@20_GM_2v2_AT");
+        Assert.AreEqual(1, atPair.TotalWins);
+        Assert.IsNull(atPair.Race);
+        var solo1 = await Load("c#3@20_GM_2v2");   // solos key under the base (non-AT) variant, no race
+        var solo2 = await Load("d#4@20_GM_2v2");
+        Assert.AreEqual(0, solo1.TotalWins);
+        Assert.AreEqual(0, solo2.TotalWins);
+    }
+
+    [Test]
+    public async Task EmptyPlayers_WritesNothing()
+    {
+        await _handler.Update(Event(GameMode.GM_1v1, 2, GateWay.Europe, Ms(2026, 6, 3), new List<PlayerMMrChange>()));
+        Assert.AreEqual(0, await Count());
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionMilestoneHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionMilestoneHandlerTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mongo2Go;
+using MongoDB.Driver;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.MatchmakingService;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class ProgressionMilestoneHandlerTests
+{
+    private MongoDbRunner _runner;
+    private MongoClient _mongoClient;
+    private ProgressionMilestoneRepository _repository;
+    private ProgressionMilestoneHandler _handler;
+
+    [SetUp]
+    public void Setup()
+    {
+        _runner = MongoDbRunner.Start();
+        _mongoClient = new MongoClient(_runner.ConnectionString);
+        _repository = new ProgressionMilestoneRepository(_mongoClient);
+        _handler = new ProgressionMilestoneHandler(_repository);
+    }
+
+    [TearDown]
+    public void TearDown() => _runner.Dispose();
+
+    private static long Ms(int year, int month, int day) =>
+        new DateTimeOffset(year, month, day, 12, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
+
+    private static PlayerMMrChange Player(string battleTag, int team, bool won, Race race, string atTeamId = null)
+    {
+        return new PlayerMMrChange
+        {
+            battleTag = battleTag,
+            team = team,
+            won = won,
+            race = race,
+            atTeamId = atTeamId,
+            mmr = new Mmr { rating = 1500 },
+            updatedMmr = new Mmr { rating = won ? 1520 : 1480 },
+        };
+    }
+
+    private static MatchFinishedEvent Event(GameMode gameMode, int season, GateWay gateway, long endTimeMs,
+        List<PlayerMMrChange> players, bool wasFake = false)
+    {
+        return new MatchFinishedEvent
+        {
+            WasFakeEvent = wasFake,
+            match = new Match
+            {
+                id = "m-" + season + "-" + endTimeMs,
+                gameMode = gameMode,
+                gateway = gateway,
+                season = season,
+                endTime = endTimeMs,
+                players = players,
+            },
+        };
+    }
+
+    private Task<ProgressionMilestone> Load(string id) => _repository.LoadMilestone(id);
+    private Task<long> Count() => _mongoClient.GetDatabase("W3Champions-Statistic-Service")
+        .GetCollection<ProgressionMilestone>("ProgressionMilestone")
+        .CountDocumentsAsync(FilterDefinition<ProgressionMilestone>.Empty);
+
+    [Test]
+    public async Task Win_IncrementsTotalWins_AndRecordsActivity()
+    {
+        await _handler.Update(Event(GameMode.GM_1v1, 2, GateWay.Europe, Ms(2026, 6, 3), new List<PlayerMMrChange>
+        {
+            Player("winner#1", 0, true, Race.HU),
+            Player("loser#2", 1, false, Race.OC),
+        }));
+
+        var winner = await Load("winner#1@20_GM_1v1_HU");
+        var loser = await Load("loser#2@20_GM_1v1_OC");
+        Assert.AreEqual(1, winner.TotalWins);
+        Assert.AreEqual(1, winner.ActivityWeeks.Count);
+        Assert.AreEqual(0, loser.TotalWins);              // loss does not increment wins…
+        Assert.AreEqual(1, loser.ActivityWeeks.Count);    // …but DOES record activity
+    }
+
+    [Test]
+    public async Task AtTeam_SharesOneDoc_NormalizedGameMode_NoRace()
+    {
+        await _handler.Update(Event(GameMode.GM_2v2, 2, GateWay.Europe, Ms(2026, 6, 3), new List<PlayerMMrChange>
+        {
+            Player("a#1", 0, true, Race.HU, atTeamId: "T1"),
+            Player("b#2", 0, true, Race.OC, atTeamId: "T1"),
+            Player("c#3", 1, false, Race.NE, atTeamId: "T2"),
+            Player("d#4", 1, false, Race.UD, atTeamId: "T2"),
+        }));
+
+        Assert.AreEqual(2, await Count()); // one doc per AT team, not per player
+        var t1 = await Load("a#1@20_b#2@20_GM_2v2_AT");
+        Assert.IsNotNull(t1);
+        Assert.AreEqual(1, t1.TotalWins);
+        Assert.IsNull(t1.Race);
+    }
+
+    [Test]
+    public async Task TwoAtTeams_SameGameTeamNumber_WriteSeparateDocs()
+    {
+        await _handler.Update(Event(GameMode.GM_2v2, 2, GateWay.Europe, Ms(2026, 6, 3), new List<PlayerMMrChange>
+        {
+            Player("a#1", 0, true, Race.HU, atTeamId: "T1"),
+            Player("b#2", 0, true, Race.OC, atTeamId: "T1"),
+            Player("e#5", 0, true, Race.HU, atTeamId: "T3"), // same game-team 0, different AT team
+            Player("f#6", 0, true, Race.OC, atTeamId: "T3"),
+            Player("c#3", 1, false, Race.NE, atTeamId: "T2"),
+            Player("d#4", 1, false, Race.UD, atTeamId: "T2"),
+        }));
+
+        Assert.IsNotNull(await Load("a#1@20_b#2@20_GM_2v2_AT"));
+        Assert.IsNotNull(await Load("e#5@20_f#6@20_GM_2v2_AT"));
+        Assert.AreEqual(3, await Count());
+    }
+
+    [Test]
+    public async Task Solo1v1_KeyedPerRace()
+    {
+        await _handler.Update(Event(GameMode.GM_1v1, 2, GateWay.Europe, Ms(2026, 6, 3), new List<PlayerMMrChange>
+        {
+            Player("zed#1", 0, true, Race.HU),
+        }));
+        await _handler.Update(Event(GameMode.GM_1v1, 2, GateWay.Europe, Ms(2026, 6, 4), new List<PlayerMMrChange>
+        {
+            Player("zed#1", 0, true, Race.OC),
+        }));
+
+        Assert.AreEqual(1, (await Load("zed#1@20_GM_1v1_HU")).TotalWins);
+        Assert.AreEqual(1, (await Load("zed#1@20_GM_1v1_OC")).TotalWins);
+    }
+
+    [Test]
+    public async Task CrossSeason_AccumulatesIntoSameDoc()
+    {
+        await _handler.Update(Event(GameMode.GM_1v1, 1, GateWay.Europe, Ms(2025, 6, 3), new List<PlayerMMrChange>
+        {
+            Player("zed#1", 0, true, Race.HU),
+        }));
+        await _handler.Update(Event(GameMode.GM_1v1, 2, GateWay.Europe, Ms(2026, 6, 3), new List<PlayerMMrChange>
+        {
+            Player("zed#1", 0, true, Race.HU),
+        }));
+
+        Assert.AreEqual(1, await Count());                       // season-less key → one doc
+        Assert.AreEqual(2, (await Load("zed#1@20_GM_1v1_HU")).TotalWins);
+    }
+
+    [Test]
+    public async Task FakeEvent_IsSkipped()
+    {
+        await _handler.Update(Event(GameMode.GM_1v1, 2, GateWay.Europe, Ms(2026, 6, 3), new List<PlayerMMrChange>
+        {
+            Player("zed#1", 0, true, Race.HU),
+        }, wasFake: true));
+
+        Assert.AreEqual(0, await Count());
+    }
+
+    [Test]
+    public async Task Replay_AtLeastOnce_RecountsUnderCursorlessReplay()
+    {
+        // Documents the chosen cursor-only at-least-once behaviour: replaying the same event
+        // re-applies (handler has no per-doc guard; the read-model cursor prevents this in prod).
+        var ev = Event(GameMode.GM_1v1, 2, GateWay.Europe, Ms(2026, 6, 3), new List<PlayerMMrChange>
+        {
+            Player("zed#1", 0, true, Race.HU),
+        });
+        await _handler.Update(ev);
+        await _handler.Update(ev);
+
+        Assert.AreEqual(2, (await Load("zed#1@20_GM_1v1_HU")).TotalWins);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionMilestoneRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionMilestoneRepositoryTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Mongo2Go;
 using MongoDB.Driver;
@@ -28,12 +29,7 @@ public class ProgressionMilestoneRepositoryTests
     [TearDown]
     public void TearDown() => _runner.Dispose();
 
-    private static List<PlayerId> Tags(params string[] tags)
-    {
-        var list = new List<PlayerId>();
-        foreach (var t in tags) list.Add(PlayerId.Create(t));
-        return list;
-    }
+    private static List<PlayerId> Tags(params string[] tags) => tags.Select(PlayerId.Create).ToList();
 
     [Test]
     public async Task UpsertAndLoad_RoundTrips()

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionMilestoneRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionMilestoneRepositoryTests.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mongo2Go;
+using MongoDB.Driver;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.CommonValueObjects;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class ProgressionMilestoneRepositoryTests
+{
+    private MongoDbRunner _runner;
+    private MongoClient _mongoClient;
+    private ProgressionMilestoneRepository _repository;
+
+    [SetUp]
+    public void Setup()
+    {
+        _runner = MongoDbRunner.Start();
+        _mongoClient = new MongoClient(_runner.ConnectionString);
+        _repository = new ProgressionMilestoneRepository(_mongoClient);
+    }
+
+    [TearDown]
+    public void TearDown() => _runner.Dispose();
+
+    private static List<PlayerId> Tags(params string[] tags)
+    {
+        var list = new List<PlayerId>();
+        foreach (var t in tags) list.Add(PlayerId.Create(t));
+        return list;
+    }
+
+    [Test]
+    public async Task UpsertAndLoad_RoundTrips()
+    {
+        var m = ProgressionMilestone.Create(Tags("zed#1"), GateWay.Europe, GameMode.GM_1v1, Race.HU);
+        m.RecordWin();
+        m.RecordActivity(new System.DateTimeOffset(2026, 6, 3, 0, 0, 0, System.TimeSpan.Zero));
+        await _repository.UpsertMilestone(m);
+
+        var loaded = await _repository.LoadMilestone("zed#1@20_GM_1v1_HU");
+        Assert.IsNotNull(loaded);
+        Assert.AreEqual(1, loaded.TotalWins);
+        Assert.AreEqual(1, loaded.ActivityWeeks.Count);
+        Assert.AreEqual(GameMode.GM_1v1, loaded.GameMode);
+        Assert.AreEqual(Race.HU, loaded.Race);
+    }
+
+    [Test]
+    public async Task Upsert_SameId_KeepsSingleDoc()
+    {
+        var m = ProgressionMilestone.Create(Tags("zed#1"), GateWay.Europe, GameMode.GM_1v1, Race.HU);
+        m.RecordWin();
+        await _repository.UpsertMilestone(m);
+        m.RecordWin();
+        await _repository.UpsertMilestone(m);
+
+        var loaded = await _repository.LoadMilestone("zed#1@20_GM_1v1_HU");
+        Assert.AreEqual(2, loaded.TotalWins);
+        var count = await _mongoClient.GetDatabase("W3Champions-Statistic-Service")
+            .GetCollection<ProgressionMilestone>("ProgressionMilestone")
+            .CountDocumentsAsync(FilterDefinition<ProgressionMilestone>.Empty);
+        Assert.AreEqual(1, count);
+    }
+
+    [Test]
+    public async Task LoadMilestone_MissingId_ReturnsNull()
+    {
+        var loaded = await _repository.LoadMilestone("nobody#0@20_GM_1v1_HU");
+        Assert.IsNull(loaded);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionMilestoneTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionMilestoneTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.CommonValueObjects;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class ProgressionMilestoneTests
+{
+    private static List<PlayerId> Tags(params string[] tags)
+    {
+        var list = new List<PlayerId>();
+        foreach (var t in tags) list.Add(PlayerId.Create(t));
+        return list;
+    }
+
+    [Test]
+    public void BuildId_Solo_NoRace_SortsTagsAndEmbedsGatewayInt()
+    {
+        var id = ProgressionMilestone.BuildId(Tags("zed#1"), GateWay.Europe, GameMode.GM_2v2_AT, null);
+        Assert.AreEqual("zed#1@20_GM_2v2_AT", id);
+    }
+
+    [Test]
+    public void BuildId_WithRace_AppendsRaceSuffix()
+    {
+        var id = ProgressionMilestone.BuildId(Tags("zed#1"), GateWay.Europe, GameMode.GM_1v1, Race.HU);
+        Assert.AreEqual("zed#1@20_GM_1v1_HU", id);
+    }
+
+    [Test]
+    public void BuildId_At_SortsTagsAscending_IsOrderIndependent()
+    {
+        var a = ProgressionMilestone.BuildId(Tags("bob#2", "ann#1"), GateWay.Europe, GameMode.GM_2v2_AT, null);
+        var b = ProgressionMilestone.BuildId(Tags("ann#1", "bob#2"), GateWay.Europe, GameMode.GM_2v2_AT, null);
+        Assert.AreEqual(a, b);
+        Assert.AreEqual("ann#1@20_bob#2@20_GM_2v2_AT", a);
+    }
+
+    [Test]
+    public void Id_IsComputedFromComponents()
+    {
+        var m = ProgressionMilestone.Create(Tags("zed#1"), GateWay.Europe, GameMode.GM_1v1, Race.OC);
+        Assert.AreEqual("zed#1@20_GM_1v1_OC", m.Id);
+    }
+
+    [Test]
+    public void RecordWin_IncrementsTotalWinsMonotonically()
+    {
+        var m = ProgressionMilestone.Create(Tags("zed#1"), GateWay.Europe, GameMode.GM_1v1, Race.HU);
+        Assert.AreEqual(0, m.TotalWins);
+        m.RecordWin();
+        m.RecordWin();
+        Assert.AreEqual(2, m.TotalWins);
+    }
+
+    [Test]
+    public void RecordActivity_CreatesWeekBucket_ThenIncrements_AndTracksLastPlayed()
+    {
+        var m = ProgressionMilestone.Create(Tags("zed#1"), GateWay.Europe, GameMode.GM_1v1, Race.HU);
+        var wed = new DateTimeOffset(2026, 6, 3, 10, 0, 0, TimeSpan.Zero); // Wednesday
+        var fri = new DateTimeOffset(2026, 6, 5, 22, 0, 0, TimeSpan.Zero); // same ISO week (Mon 2026-06-01)
+        m.RecordActivity(wed);
+        m.RecordActivity(fri);
+        Assert.AreEqual(1, m.ActivityWeeks.Count);
+        Assert.AreEqual(2, m.ActivityWeeks[0].Games);
+        Assert.AreEqual(new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero), m.ActivityWeeks[0].WeekStartUtc);
+        Assert.AreEqual(fri, m.LastPlayedAt);
+    }
+
+    [Test]
+    public void RecordActivity_DifferentWeeks_CreateSeparateBuckets()
+    {
+        var m = ProgressionMilestone.Create(Tags("zed#1"), GateWay.Europe, GameMode.GM_1v1, Race.HU);
+        m.RecordActivity(new DateTimeOffset(2026, 6, 3, 0, 0, 0, TimeSpan.Zero));   // week of 06-01
+        m.RecordActivity(new DateTimeOffset(2026, 6, 10, 0, 0, 0, TimeSpan.Zero));  // week of 06-08
+        Assert.AreEqual(2, m.ActivityWeeks.Count);
+    }
+
+    [Test]
+    public void PruneActivityBefore_DropsWeeksStrictlyOlderThanCutoffWeek()
+    {
+        var m = ProgressionMilestone.Create(Tags("zed#1"), GateWay.Europe, GameMode.GM_1v1, Race.HU);
+        m.RecordActivity(new DateTimeOffset(2026, 1, 7, 0, 0, 0, TimeSpan.Zero));   // old
+        m.RecordActivity(new DateTimeOffset(2026, 6, 3, 0, 0, 0, TimeSpan.Zero));   // recent
+        m.PruneActivityBefore(new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero));
+        Assert.AreEqual(1, m.ActivityWeeks.Count);
+        Assert.AreEqual(new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero), m.ActivityWeeks[0].WeekStartUtc);
+    }
+
+    [Test]
+    public void ActivityIn_SumsGamesAndActiveWeeks_WithinTrailing90Days()
+    {
+        var m = ProgressionMilestone.Create(Tags("zed#1"), GateWay.Europe, GameMode.GM_1v1, Race.HU);
+        var now = new DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero);
+        m.RecordActivity(now.AddDays(-3));   // in window, week A
+        m.RecordActivity(now.AddDays(-3));   // same week A
+        m.RecordActivity(now.AddDays(-20));  // in window, week B
+        m.RecordActivity(now.AddDays(-120)); // outside 90d window
+        var activity = m.ActivityIn(now);
+        Assert.AreEqual(3, activity.RecentGames);
+        Assert.AreEqual(2, activity.ActiveWeeks);
+    }
+
+    [Test]
+    public void ActivityIn_DormantPlayer_ReturnsZero()
+    {
+        var m = ProgressionMilestone.Create(Tags("zed#1"), GateWay.Europe, GameMode.GM_1v1, Race.HU);
+        var played = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        m.RecordActivity(played);
+        var now = new DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero); // >90d later
+        var activity = m.ActivityIn(now);
+        Assert.AreEqual(0, activity.RecentGames);
+        Assert.AreEqual(0, activity.ActiveWeeks);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionMilestoneTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionMilestoneTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
@@ -11,12 +12,7 @@ namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats
 [TestFixture]
 public class ProgressionMilestoneTests
 {
-    private static List<PlayerId> Tags(params string[] tags)
-    {
-        var list = new List<PlayerId>();
-        foreach (var t in tags) list.Add(PlayerId.Create(t));
-        return list;
-    }
+    private static List<PlayerId> Tags(params string[] tags) => tags.Select(PlayerId.Create).ToList();
 
     [Test]
     public void BuildId_Solo_NoRace_SortsTagsAndEmbedsGatewayInt()
@@ -116,5 +112,39 @@ public class ProgressionMilestoneTests
         var activity = m.ActivityIn(now);
         Assert.AreEqual(0, activity.RecentGames);
         Assert.AreEqual(0, activity.ActiveWeeks);
+    }
+
+    [Test]
+    public void PruneActivityBefore_RetainsWeekEqualToCutoffWeek()
+    {
+        var m = ProgressionMilestone.Create(Tags("zed#1"), GateWay.Europe, GameMode.GM_1v1, Race.HU);
+        m.RecordActivity(new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero)); // Mon 2026-06-01
+        m.PruneActivityBefore(new DateTimeOffset(2026, 6, 3, 0, 0, 0, TimeSpan.Zero)); // cutoff week = 2026-06-01
+        Assert.AreEqual(1, m.ActivityWeeks.Count);
+    }
+
+    [Test]
+    public void ActivityIn_IncludesWindowStartWeek_ExcludesEarlierWeek()
+    {
+        var m = ProgressionMilestone.Create(Tags("zed#1"), GateWay.Europe, GameMode.GM_1v1, Race.HU);
+        var now = new DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero); // Monday
+        var windowStartWeek = ProgressionMilestone.StartOfIsoWeek(now.AddDays(-ProgressionMilestone.RecentWindowDays));
+        m.RecordActivity(windowStartWeek);                 // exactly on the window-start week → included
+        m.RecordActivity(windowStartWeek.AddDays(-1));     // the prior week → excluded
+        var activity = m.ActivityIn(now);
+        Assert.AreEqual(1, activity.RecentGames);
+        Assert.AreEqual(1, activity.ActiveWeeks);
+    }
+
+    [Test]
+    public void PruneStaleActivity_DropsWeeksOlderThanWindowPlusMargin_KeepsRecent()
+    {
+        var m = ProgressionMilestone.Create(Tags("zed#1"), GateWay.Europe, GameMode.GM_1v1, Race.HU);
+        var reference = new DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero);
+        m.RecordActivity(reference);                       // recent → kept
+        m.RecordActivity(reference.AddDays(-200));         // well outside window+margin → dropped
+        m.PruneStaleActivity(reference);
+        Assert.AreEqual(1, m.ActivityWeeks.Count);
+        Assert.AreEqual(ProgressionMilestone.StartOfIsoWeek(reference), m.ActivityWeeks[0].WeekStartUtc);
     }
 }

--- a/docs/ranking/README.md
+++ b/docs/ranking/README.md
@@ -27,3 +27,33 @@ placed rank. The snapshot carries the published rank fields only:
 
 Read-model handlers are off by default locally (`IS_DEVELOPMENT`) — do not enable them against shared
 data.
+
+## Lifetime win-milestone read-model
+
+A separate, **permanent** downstream read-model tracks each player's lifetime win-milestone progress — a
+cosmetic "always something to climb" track that is independent of rank and never resets. It is fed from the
+same event stream but keyed differently from the season-scoped progression rank above.
+
+- **Read-model:** `ProgressionMilestone` (collection `ProgressionMilestone`,
+  `PlayerProfiles/ProgressionStats/`) — one document per entity (a single player, or an arranged team) per
+  game mode, and per race for `GM_1v1`. The `_id` is **season-less**
+  (`"{tags@gateway}_{gameMode}[_race]"`), so wins accumulate across all seasons into one document
+  (contrast `PlayerProgression`, whose `_id` includes the season).
+- **What it stores:** `TotalWins` (monotonic, never decreases) and a compact rolling weekly activity
+  window (`ActivityWeeks`, ~90 days) recording how many games the entity played each week. `LastPlayedAt`
+  is retained for a future display path.
+- **Source of truth:** the per-player `won` flag on `MatchFinishedEvent` (`PlayerMMrChange.won`) — counted
+  for every match, independent of whether a progression rank was recorded. `TotalWins` increments on a win;
+  the activity window records every game (won or lost).
+- **Handler:** `ProgressionMilestoneHandler : IMatchFinishedReadModelHandler` — groups arranged-team players
+  by `atTeamId` into one shared team document and processes solo players individually (mirrors
+  `PlayerProgressionHandler`); skips fake events. Registered via
+  `AddMatchFinishedReadModelService<ProgressionMilestoneHandler>()`.
+- **Next-milestone target:** `MilestoneTargetCalculator` is a pure function of `TotalWins` and the entity's
+  own recent activity. The target is the next round-number of wins on a curve whose step coarsens as totals
+  grow; a returning or low-activity player is given a *nearer* milestone (never a farther one). It is
+  computed **on read** — nothing is stored for it and there is no scheduled job.
+- **Idempotency:** `TotalWins` is an additive counter, so — like the other counting read-models
+  (`PlayerOverallStats`, `GamesPerDay`) — it relies on the read-model cursor (`HandlerVersions`) for
+  at-least-once delivery rather than a per-document guard. A deliberate cursor rewind/backfill would
+  re-count; this is accepted, consistent with those existing handlers.


### PR DESCRIPTION
## Summary

Adds a permanent, downstream **lifetime win-milestone** read-model (P7-1) — a cosmetic "always something to climb" track, independent of rank, that never resets.

- New `ProgressionMilestone` read-model (collection `ProgressionMilestone`), keyed per entity (a player, or an arranged team) / game mode / race-for-`GM_1v1`, **season-less** so wins accumulate across all seasons. Mirrors the P8-2 `PlayerProgression` dedicated-repo triad (not the legacy `IPlayerRepository`).
- `ProgressionMilestoneHandler` ingests `MatchFinishedEvent`: increments `TotalWins` on the per-player `won` flag — AT players grouped by `atTeamId` into one shared team document, solo players individually — and records a compact rolling weekly activity window for every game (won or lost). Skips fake events.
- Pure `MilestoneTargetCalculator`: the next-milestone target is the next round-number of wins on a curve that coarsens as totals grow; a returning/low-activity player is given a nearer milestone (derived from their own recent activity), never a farther one. Computed **on read** — no stored target, no scheduled job.
- Dedicated `IProgressionMilestoneRepository` + impl; both repo and handler registered in `Program.cs` alongside the P8-2 read-model.
- New section in `docs/ranking/README.md` describing the read-model.

Idempotency is cursor-only at-least-once, consistent with the existing counting read-models (`PlayerOverallStats`, `GamesPerDay`).

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 634 passed / 0 failed / 9 skipped (35 new tests across model, calculator, repository, handler — Mongo2Go + pure unit)
- [x] `dotnet format --verify-no-changes` — clean

## Checklist

- [x] Targets `prj/new-ranking-system` (not master/main)
- [x] Task: P7-1
- [x] Tests added (TDD) — Mongo2Go for store/handler/repo + pure unit tests for the calculator
- [x] Gate output green (build + test + format)
- [x] Additive, read-only downstream state; never feeds rank/MMR; no new feature flag (standard read-model handler, like the P8-2 ingest)
- [x] Per-repo doc updated (`docs/ranking/README.md`)
- [x] Public-repo boundary respected (no internal mechanism or roadmap detail; only the player-facing win/milestone contract)