### PR TITLE
P7-2: Prestige store (peak progression rank)

### DIFF
--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PeakRank.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PeakRank.cs
@@ -6,7 +6,9 @@ namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 
 // A stored progression-rank snapshot (the published rank fields plus when it was reached).
 // Ordering semantics live in PrestigeRankComparer.
-public class PeakRank
+// A record (not a plain class) for value equality, consistent with the sibling value types;
+// settable properties are retained so the BSON driver's parameterless ctor + setters keep working.
+public record PeakRank
 {
     public int? League { get; set; }
     public int? Division { get; set; }

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PeakRank.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PeakRank.cs
@@ -1,0 +1,20 @@
+using System;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+// A stored progression-rank snapshot (the published rank fields plus when it was reached).
+// Ordering semantics live in PrestigeRankComparer.
+public class PeakRank
+{
+    public int? League { get; set; }
+    public int? Division { get; set; }
+    public int? Points { get; set; }
+    public int? ApexPoints { get; set; }
+
+    public int Season { get; set; }
+
+    [BsonRepresentation(BsonType.Array)]
+    public DateTimeOffset AchievedAt { get; set; }
+}

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PrestigeRankComparer.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PrestigeRankComparer.cs
@@ -2,8 +2,8 @@ namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 
 // Pure, config-free ordering of published progression-rank snapshots.
 // Encoding (authoritative): lower League = higher rank (GrandMaster 0 .. Grass 8);
-// lower Division = better (I=1 .. IV=4); higher Points = better; apexPoints (when set) ranks above all
-// steered leagues, higher = better.
+// lower Division = better (I=1 .. IV=4); higher Points = better; apexPoints (when set) ranks above
+// any league/division rank, higher = better.
 public static class PrestigeRankComparer
 {
     // True iff `candidate` is a strictly higher rank than `current`.
@@ -16,7 +16,7 @@ public static class PrestigeRankComparer
 
         var candidateIsApex = candidate.ApexPoints != null;
         var currentIsApex = current.ApexPoints != null;
-        if (candidateIsApex != currentIsApex) return candidateIsApex; // apex outranks steered
+        if (candidateIsApex != currentIsApex) return candidateIsApex; // apex outranks any league/division rank
 
         if (candidateIsApex)
         {

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PrestigeRankComparer.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PrestigeRankComparer.cs
@@ -1,0 +1,29 @@
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+// Pure, config-free ordering of published progression-rank snapshots.
+// Encoding (authoritative): lower League = higher rank (GrandMaster 0 .. Grass 8);
+// lower Division = better (I=1 .. IV=4); higher Points = better; apexPoints (when set) ranks above all
+// steered leagues, higher = better.
+public static class PrestigeRankComparer
+{
+    // True iff `candidate` is a strictly higher rank than `current`.
+    public static bool IsHigher(PeakRank candidate, PeakRank current)
+    {
+        if (candidate?.League == null) return false; // not a placed rank
+        if (current?.League == null) return true;     // any placed rank beats none
+
+        var candidateIsApex = candidate.ApexPoints != null;
+        var currentIsApex = current.ApexPoints != null;
+        if (candidateIsApex != currentIsApex) return candidateIsApex; // apex outranks steered
+
+        if (candidateIsApex)
+        {
+            if (candidate.ApexPoints != current.ApexPoints) return candidate.ApexPoints > current.ApexPoints;
+            return candidate.League < current.League; // tie: GrandMaster(0) over Master(1)
+        }
+
+        if (candidate.League != current.League) return candidate.League < current.League;
+        if (candidate.Division != current.Division) return candidate.Division < current.Division;
+        return candidate.Points > current.Points;
+    }
+}

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PrestigeRankComparer.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PrestigeRankComparer.cs
@@ -7,6 +7,8 @@ namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 public static class PrestigeRankComparer
 {
     // True iff `candidate` is a strictly higher rank than `current`.
+    // A null reference for either argument is treated identically to a snapshot with League == null
+    // (i.e. not a placed rank): a null candidate is never higher, and any placed candidate beats a null current.
     public static bool IsHigher(PeakRank candidate, PeakRank current)
     {
         if (candidate?.League == null) return false; // not a placed rank

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionPrestige.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionPrestige.cs
@@ -18,6 +18,8 @@ public class ProgressionPrestige : IIdentifiable
 
     public void RecordPeak(GameMode gameMode, Race? race, PeakRank candidate)
     {
+        if (candidate?.League == null) return; // ignore unplaced/calibrating ranks; the store holds placed ranks only
+
         var entry = Peaks.FirstOrDefault(e => e.GameMode == gameMode && e.Race == race);
         if (entry == null)
         {

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionPrestige.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionPrestige.cs
@@ -40,7 +40,9 @@ public class PrestigePeakEntry
     // Reserved cosmetic slot. Persisted and retained; no awarding logic in this stage.
     public List<PrestigeBadge> Badges { get; set; } = new();
 
-    public void Record(PeakRank candidate)
+    // Internal so callers must route through ProgressionPrestige.RecordPeak, which owns the
+    // (game mode, race) entry lookup; tests reach it via InternalsVisibleTo.
+    internal void Record(PeakRank candidate)
     {
         var index = SeasonPeaks.FindIndex(p => p.Season == candidate.Season);
         if (index < 0)
@@ -60,6 +62,7 @@ public class PrestigePeakEntry
 }
 
 // Reserved placeholder — never populated in this stage; exists so the slot round-trips and survives resets.
+// BSON-safe: implicit parameterless ctor + settable props; keep it that way if fields are added.
 public class PrestigeBadge
 {
     public string Code { get; set; }

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionPrestige.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionPrestige.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Linq;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.Repositories;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+// Permanent, reset-immune per-player peak-rank store. One document per battleTag (Id = battleTag),
+// holding the highest rank ever reached per (game mode, race), plus per-season peaks and a reserved
+// badge slot. Survives the seasonal reset because the _id is stable and rows are only ever upserted.
+public class ProgressionPrestige : IIdentifiable
+{
+    public string Id { get; set; }
+    public List<PrestigePeakEntry> Peaks { get; set; } = new();
+
+    public static ProgressionPrestige Create(string battleTag) => new() { Id = battleTag };
+
+    public void RecordPeak(GameMode gameMode, Race? race, PeakRank candidate)
+    {
+        var entry = Peaks.FirstOrDefault(e => e.GameMode == gameMode && e.Race == race);
+        if (entry == null)
+        {
+            entry = new PrestigePeakEntry { GameMode = gameMode, Race = race };
+            Peaks.Add(entry);
+        }
+
+        entry.Record(candidate);
+    }
+}
+
+// Peak track for one (game mode, race). Race is set only for race-split modes (1v1); null otherwise.
+public class PrestigePeakEntry
+{
+    public GameMode GameMode { get; set; }
+    public Race? Race { get; set; }
+    public PeakRank AllTimePeak { get; set; }
+    public List<PeakRank> SeasonPeaks { get; set; } = new();
+
+    // Reserved cosmetic slot. Persisted and retained; no awarding logic in this stage.
+    public List<PrestigeBadge> Badges { get; set; } = new();
+
+    public void Record(PeakRank candidate)
+    {
+        var index = SeasonPeaks.FindIndex(p => p.Season == candidate.Season);
+        if (index < 0)
+        {
+            SeasonPeaks.Add(candidate);
+        }
+        else if (PrestigeRankComparer.IsHigher(candidate, SeasonPeaks[index]))
+        {
+            SeasonPeaks[index] = candidate;
+        }
+
+        if (AllTimePeak == null || PrestigeRankComparer.IsHigher(candidate, AllTimePeak))
+        {
+            AllTimePeak = candidate;
+        }
+    }
+}
+
+// Reserved placeholder — never populated in this stage; exists so the slot round-trips and survives resets.
+public class PrestigeBadge
+{
+    public string Code { get; set; }
+    public int Season { get; set; }
+}

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionPrestigeHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionPrestigeHandler.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using W3C.Contracts.GameObjects;
+using W3C.Domain.GameModes;
+using W3C.Domain.MatchmakingService;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.ReadModelBase;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+// Ingests MatchFinishedEvent into the permanent per-player peak-rank store.
+// Only non-arranged-team players with a placed rank (updatedProgression != null) are recorded;
+// AT rank belongs to the team, not to an individual player's prestige peak.
+[Trace]
+public class ProgressionPrestigeHandler(IProgressionPrestigeRepository repository) : IMatchFinishedReadModelHandler
+{
+    private readonly IProgressionPrestigeRepository _repository = repository;
+
+    public async Task Update(MatchFinishedEvent nextEvent)
+    {
+        if (nextEvent.WasFakeEvent)
+        {
+            return;
+        }
+
+        var match = nextEvent.match;
+        var achievedAt = DateTimeOffset.FromUnixTimeMilliseconds(match.endTime > 0 ? match.endTime : match.startTime);
+
+        // Only individual-rank placements: arranged-team rank is the team's, not attributable to one player's peak.
+        var placed = match.players.Where(p => p.updatedProgression != null && !p.IsAt);
+        foreach (var player in placed)
+        {
+            var race = GameModesHelper.IsRaceSplitGameMode(match.gameMode) ? (Race?)player.race : null;
+            var candidate = new PeakRank
+            {
+                League = player.updatedProgression.league,
+                Division = player.updatedProgression.division,
+                Points = player.updatedProgression.points,
+                ApexPoints = player.updatedProgression.apexPoints,
+                Season = match.season,
+                AchievedAt = achievedAt,
+            };
+
+            var prestige = await _repository.LoadPrestige(player.battleTag) ?? ProgressionPrestige.Create(player.battleTag);
+            prestige.RecordPeak(match.gameMode, race, candidate);
+            await _repository.UpsertPrestige(prestige);
+        }
+    }
+}

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionPrestigeHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionPrestigeHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using W3C.Contracts.GameObjects;
@@ -26,12 +27,17 @@ public class ProgressionPrestigeHandler(IProgressionPrestigeRepository repositor
         }
 
         var match = nextEvent.match;
+        var players = match.players ?? new List<PlayerMMrChange>();
         var achievedAt = DateTimeOffset.FromUnixTimeMilliseconds(match.endTime > 0 ? match.endTime : match.startTime);
 
         // Only individual-rank placements: arranged-team rank is the team's, not attributable to one player's peak.
-        var placed = match.players.Where(p => p.updatedProgression != null && !p.IsAt);
+        var placed = players.Where(p => p.updatedProgression != null && !p.IsAt);
         foreach (var player in placed)
         {
+            // The peak entry key is (gameMode, race) with per-season peaks held inside, so the race key must be
+            // season-agnostic. Unlike the season-keyed ladder (UsesRaceInLadderKey gates on RaceSplitStartSeason),
+            // we include race for a race-split mode in ALL seasons; otherwise a player's lifetime 1v1 peak would
+            // fragment across a race-less entry (pre-season-2) and per-race entries.
             var race = GameModesHelper.IsRaceSplitGameMode(match.gameMode) ? (Race?)player.race : null;
             var candidate = new PeakRank
             {

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionPrestigeRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionPrestigeRepository.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.Ports;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+[Trace]
+public class ProgressionPrestigeRepository(MongoClient mongoClient)
+    : MongoDbRepositoryBase(mongoClient), IProgressionPrestigeRepository
+{
+    public Task<ProgressionPrestige> LoadPrestige(string battleTag)
+    {
+        return LoadFirst<ProgressionPrestige>(battleTag);
+    }
+
+    public Task UpsertPrestige(ProgressionPrestige prestige)
+    {
+        return Upsert(prestige);
+    }
+}

--- a/W3ChampionsStatisticService/Ports/IProgressionPrestigeRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IProgressionPrestigeRepository.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace W3ChampionsStatisticService.Ports;
+
+public interface IProgressionPrestigeRepository
+{
+    Task<ProgressionPrestige> LoadPrestige(string battleTag);
+    Task UpsertPrestige(ProgressionPrestige prestige);
+}

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -164,6 +164,7 @@ builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexe
 builder.Services.AddInterceptedSingleton<IPlayerRepository, PlayerRepository>();
 builder.Services.AddInterceptedTransient<IPlayerProgressionRepository, PlayerProgressionRepository>();
 builder.Services.AddInterceptedTransient<IProgressionMilestoneRepository, ProgressionMilestoneRepository>();
+builder.Services.AddInterceptedTransient<IProgressionPrestigeRepository, ProgressionPrestigeRepository>();
 builder.Services.AddInterceptedTransient<IRankRepository, RankRepository>();
 builder.Services.AddInterceptedTransient<IPlayerStatsRepository, PlayerStatsRepository>();
 builder.Services.AddInterceptedTransient<IW3StatsRepo, W3StatsRepo>();

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -257,6 +257,7 @@ if (startHandlers == "true")
     builder.Services.AddMatchFinishedReadModelService<PlayerMmrRpTimelineHandler>();
     builder.Services.AddMatchFinishedReadModelService<PlayerProgressionHandler>();
     builder.Services.AddMatchFinishedReadModelService<ProgressionMilestoneHandler>();
+    builder.Services.AddMatchFinishedReadModelService<ProgressionPrestigeHandler>();
     builder.Services.AddMatchFinishedReadModelService<GameLengthForPlayerStatisticsHandler>();
 
     // General Stats

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PrestigeRankComparerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PrestigeRankComparerTests.cs
@@ -9,6 +9,7 @@ public class PrestigeRankComparerTests
     private static PeakRank Steered(int league, int division, int points, int season = 1) =>
         new() { League = league, Division = division, Points = points, ApexPoints = null, Season = season };
 
+    // apex: league=Master/GM, division/points unused by the comparator (engine uses division 0 for apex).
     private static PeakRank Apex(int apexPoints, int league = 1, int season = 1) =>
         new() { League = league, Division = 0, Points = 0, ApexPoints = apexPoints, Season = season };
 
@@ -16,65 +17,71 @@ public class PrestigeRankComparerTests
     public void LowerLeagueIsHigherRank()
     {
         // Diamond (league 3) outranks Gold (league 5)
-        Assert.IsTrue(PrestigeRankComparer.IsHigher(Steered(3, 4, 0), Steered(5, 1, 99)));
-        Assert.IsFalse(PrestigeRankComparer.IsHigher(Steered(5, 1, 99), Steered(3, 4, 0)));
+        Assert.That(PrestigeRankComparer.IsHigher(Steered(3, 4, 0), Steered(5, 1, 99)), Is.True);
+        Assert.That(PrestigeRankComparer.IsHigher(Steered(5, 1, 99), Steered(3, 4, 0)), Is.False);
     }
 
     [Test]
     public void WithinLeagueLowerDivisionIsBetter()
     {
         // Division I (1) beats Division IV (4) in the same league
-        Assert.IsTrue(PrestigeRankComparer.IsHigher(Steered(4, 1, 0), Steered(4, 4, 99)));
-        Assert.IsFalse(PrestigeRankComparer.IsHigher(Steered(4, 4, 99), Steered(4, 1, 0)));
+        Assert.That(PrestigeRankComparer.IsHigher(Steered(4, 1, 0), Steered(4, 4, 99)), Is.True);
+        Assert.That(PrestigeRankComparer.IsHigher(Steered(4, 4, 99), Steered(4, 1, 0)), Is.False);
     }
 
     [Test]
     public void WithinDivisionMorePointsIsBetter()
     {
-        Assert.IsTrue(PrestigeRankComparer.IsHigher(Steered(4, 2, 80), Steered(4, 2, 20)));
-        Assert.IsFalse(PrestigeRankComparer.IsHigher(Steered(4, 2, 20), Steered(4, 2, 80)));
+        Assert.That(PrestigeRankComparer.IsHigher(Steered(4, 2, 80), Steered(4, 2, 20)), Is.True);
+        Assert.That(PrestigeRankComparer.IsHigher(Steered(4, 2, 20), Steered(4, 2, 80)), Is.False);
     }
 
     [Test]
     public void EqualRankIsNotHigher()
     {
-        Assert.IsFalse(PrestigeRankComparer.IsHigher(Steered(4, 2, 50), Steered(4, 2, 50)));
+        Assert.That(PrestigeRankComparer.IsHigher(Steered(4, 2, 50), Steered(4, 2, 50)), Is.False);
     }
 
     [Test]
     public void ApexBeatsAnySteered()
     {
-        // even the very top steered rank (Adept league 2, Div I, 99) loses to any apex
-        Assert.IsTrue(PrestigeRankComparer.IsHigher(Apex(1), Steered(2, 1, 99)));
-        Assert.IsFalse(PrestigeRankComparer.IsHigher(Steered(2, 1, 99), Apex(1)));
+        // even the top steered rank (league 2, Div I, 99) loses to any apex
+        Assert.That(PrestigeRankComparer.IsHigher(Apex(1), Steered(2, 1, 99)), Is.True);
+        Assert.That(PrestigeRankComparer.IsHigher(Steered(2, 1, 99), Apex(1)), Is.False);
     }
 
     [Test]
     public void WithinApexMoreApexPointsIsBetter()
     {
-        Assert.IsTrue(PrestigeRankComparer.IsHigher(Apex(500), Apex(100)));
-        Assert.IsFalse(PrestigeRankComparer.IsHigher(Apex(100), Apex(500)));
+        Assert.That(PrestigeRankComparer.IsHigher(Apex(500), Apex(100)), Is.True);
+        Assert.That(PrestigeRankComparer.IsHigher(Apex(100), Apex(500)), Is.False);
     }
 
     [Test]
     public void ApexPointsTieBreaksOnLowerLeague()
     {
         // GrandMaster (0) beats Master (1) at equal apexPoints
-        Assert.IsTrue(PrestigeRankComparer.IsHigher(Apex(200, league: 0), Apex(200, league: 1)));
-        Assert.IsFalse(PrestigeRankComparer.IsHigher(Apex(200, league: 1), Apex(200, league: 0)));
+        Assert.That(PrestigeRankComparer.IsHigher(Apex(200, league: 0), Apex(200, league: 1)), Is.True);
+        Assert.That(PrestigeRankComparer.IsHigher(Apex(200, league: 1), Apex(200, league: 0)), Is.False);
     }
 
     [Test]
     public void NullLeagueCandidateIsNeverHigher()
     {
         var noRank = new PeakRank { League = null };
-        Assert.IsFalse(PrestigeRankComparer.IsHigher(noRank, Steered(8, 4, 0)));
+        Assert.That(PrestigeRankComparer.IsHigher(noRank, Steered(8, 4, 0)), Is.False);
+    }
+
+    [Test]
+    public void NullCandidateReferenceIsNeverHigher()
+    {
+        Assert.That(PrestigeRankComparer.IsHigher(null, Steered(8, 4, 0)), Is.False);
     }
 
     [Test]
     public void AnyPlacedRankBeatsNullCurrent()
     {
         var noRank = new PeakRank { League = null };
-        Assert.IsTrue(PrestigeRankComparer.IsHigher(Steered(8, 4, 0), noRank));
+        Assert.That(PrestigeRankComparer.IsHigher(Steered(8, 4, 0), noRank), Is.True);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PrestigeRankComparerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PrestigeRankComparerTests.cs
@@ -6,7 +6,7 @@ namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats
 [TestFixture]
 public class PrestigeRankComparerTests
 {
-    private static PeakRank Steered(int league, int division, int points, int season = 1) =>
+    private static PeakRank LeagueRank(int league, int division, int points, int season = 1) =>
         new() { League = league, Division = division, Points = points, ApexPoints = null, Season = season };
 
     // apex: league=Master/GM, division/points unused by the comparator (engine uses division 0 for apex).
@@ -17,37 +17,37 @@ public class PrestigeRankComparerTests
     public void LowerLeagueIsHigherRank()
     {
         // Diamond (league 3) outranks Gold (league 5)
-        Assert.That(PrestigeRankComparer.IsHigher(Steered(3, 4, 0), Steered(5, 1, 99)), Is.True);
-        Assert.That(PrestigeRankComparer.IsHigher(Steered(5, 1, 99), Steered(3, 4, 0)), Is.False);
+        Assert.That(PrestigeRankComparer.IsHigher(LeagueRank(3, 4, 0), LeagueRank(5, 1, 99)), Is.True);
+        Assert.That(PrestigeRankComparer.IsHigher(LeagueRank(5, 1, 99), LeagueRank(3, 4, 0)), Is.False);
     }
 
     [Test]
     public void WithinLeagueLowerDivisionIsBetter()
     {
         // Division I (1) beats Division IV (4) in the same league
-        Assert.That(PrestigeRankComparer.IsHigher(Steered(4, 1, 0), Steered(4, 4, 99)), Is.True);
-        Assert.That(PrestigeRankComparer.IsHigher(Steered(4, 4, 99), Steered(4, 1, 0)), Is.False);
+        Assert.That(PrestigeRankComparer.IsHigher(LeagueRank(4, 1, 0), LeagueRank(4, 4, 99)), Is.True);
+        Assert.That(PrestigeRankComparer.IsHigher(LeagueRank(4, 4, 99), LeagueRank(4, 1, 0)), Is.False);
     }
 
     [Test]
     public void WithinDivisionMorePointsIsBetter()
     {
-        Assert.That(PrestigeRankComparer.IsHigher(Steered(4, 2, 80), Steered(4, 2, 20)), Is.True);
-        Assert.That(PrestigeRankComparer.IsHigher(Steered(4, 2, 20), Steered(4, 2, 80)), Is.False);
+        Assert.That(PrestigeRankComparer.IsHigher(LeagueRank(4, 2, 80), LeagueRank(4, 2, 20)), Is.True);
+        Assert.That(PrestigeRankComparer.IsHigher(LeagueRank(4, 2, 20), LeagueRank(4, 2, 80)), Is.False);
     }
 
     [Test]
     public void EqualRankIsNotHigher()
     {
-        Assert.That(PrestigeRankComparer.IsHigher(Steered(4, 2, 50), Steered(4, 2, 50)), Is.False);
+        Assert.That(PrestigeRankComparer.IsHigher(LeagueRank(4, 2, 50), LeagueRank(4, 2, 50)), Is.False);
     }
 
     [Test]
-    public void ApexBeatsAnySteered()
+    public void ApexBeatsAnyLeagueRank()
     {
-        // even the top steered rank (league 2, Div I, 99) loses to any apex
-        Assert.That(PrestigeRankComparer.IsHigher(Apex(1), Steered(2, 1, 99)), Is.True);
-        Assert.That(PrestigeRankComparer.IsHigher(Steered(2, 1, 99), Apex(1)), Is.False);
+        // even the top league rank (league 2, Div I, 99) loses to any apex
+        Assert.That(PrestigeRankComparer.IsHigher(Apex(1), LeagueRank(2, 1, 99)), Is.True);
+        Assert.That(PrestigeRankComparer.IsHigher(LeagueRank(2, 1, 99), Apex(1)), Is.False);
     }
 
     [Test]
@@ -69,19 +69,19 @@ public class PrestigeRankComparerTests
     public void NullLeagueCandidateIsNeverHigher()
     {
         var noRank = new PeakRank { League = null };
-        Assert.That(PrestigeRankComparer.IsHigher(noRank, Steered(8, 4, 0)), Is.False);
+        Assert.That(PrestigeRankComparer.IsHigher(noRank, LeagueRank(8, 4, 0)), Is.False);
     }
 
     [Test]
     public void NullCandidateReferenceIsNeverHigher()
     {
-        Assert.That(PrestigeRankComparer.IsHigher(null, Steered(8, 4, 0)), Is.False);
+        Assert.That(PrestigeRankComparer.IsHigher(null, LeagueRank(8, 4, 0)), Is.False);
     }
 
     [Test]
     public void AnyPlacedRankBeatsNullCurrent()
     {
         var noRank = new PeakRank { League = null };
-        Assert.That(PrestigeRankComparer.IsHigher(Steered(8, 4, 0), noRank), Is.True);
+        Assert.That(PrestigeRankComparer.IsHigher(LeagueRank(8, 4, 0), noRank), Is.True);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PrestigeRankComparerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PrestigeRankComparerTests.cs
@@ -1,0 +1,80 @@
+using NUnit.Framework;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class PrestigeRankComparerTests
+{
+    private static PeakRank Steered(int league, int division, int points, int season = 1) =>
+        new() { League = league, Division = division, Points = points, ApexPoints = null, Season = season };
+
+    private static PeakRank Apex(int apexPoints, int league = 1, int season = 1) =>
+        new() { League = league, Division = 0, Points = 0, ApexPoints = apexPoints, Season = season };
+
+    [Test]
+    public void LowerLeagueIsHigherRank()
+    {
+        // Diamond (league 3) outranks Gold (league 5)
+        Assert.IsTrue(PrestigeRankComparer.IsHigher(Steered(3, 4, 0), Steered(5, 1, 99)));
+        Assert.IsFalse(PrestigeRankComparer.IsHigher(Steered(5, 1, 99), Steered(3, 4, 0)));
+    }
+
+    [Test]
+    public void WithinLeagueLowerDivisionIsBetter()
+    {
+        // Division I (1) beats Division IV (4) in the same league
+        Assert.IsTrue(PrestigeRankComparer.IsHigher(Steered(4, 1, 0), Steered(4, 4, 99)));
+        Assert.IsFalse(PrestigeRankComparer.IsHigher(Steered(4, 4, 99), Steered(4, 1, 0)));
+    }
+
+    [Test]
+    public void WithinDivisionMorePointsIsBetter()
+    {
+        Assert.IsTrue(PrestigeRankComparer.IsHigher(Steered(4, 2, 80), Steered(4, 2, 20)));
+        Assert.IsFalse(PrestigeRankComparer.IsHigher(Steered(4, 2, 20), Steered(4, 2, 80)));
+    }
+
+    [Test]
+    public void EqualRankIsNotHigher()
+    {
+        Assert.IsFalse(PrestigeRankComparer.IsHigher(Steered(4, 2, 50), Steered(4, 2, 50)));
+    }
+
+    [Test]
+    public void ApexBeatsAnySteered()
+    {
+        // even the very top steered rank (Adept league 2, Div I, 99) loses to any apex
+        Assert.IsTrue(PrestigeRankComparer.IsHigher(Apex(1), Steered(2, 1, 99)));
+        Assert.IsFalse(PrestigeRankComparer.IsHigher(Steered(2, 1, 99), Apex(1)));
+    }
+
+    [Test]
+    public void WithinApexMoreApexPointsIsBetter()
+    {
+        Assert.IsTrue(PrestigeRankComparer.IsHigher(Apex(500), Apex(100)));
+        Assert.IsFalse(PrestigeRankComparer.IsHigher(Apex(100), Apex(500)));
+    }
+
+    [Test]
+    public void ApexPointsTieBreaksOnLowerLeague()
+    {
+        // GrandMaster (0) beats Master (1) at equal apexPoints
+        Assert.IsTrue(PrestigeRankComparer.IsHigher(Apex(200, league: 0), Apex(200, league: 1)));
+        Assert.IsFalse(PrestigeRankComparer.IsHigher(Apex(200, league: 1), Apex(200, league: 0)));
+    }
+
+    [Test]
+    public void NullLeagueCandidateIsNeverHigher()
+    {
+        var noRank = new PeakRank { League = null };
+        Assert.IsFalse(PrestigeRankComparer.IsHigher(noRank, Steered(8, 4, 0)));
+    }
+
+    [Test]
+    public void AnyPlacedRankBeatsNullCurrent()
+    {
+        var noRank = new PeakRank { League = null };
+        Assert.IsTrue(PrestigeRankComparer.IsHigher(Steered(8, 4, 0), noRank));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeHandlerTests.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Mongo2Go;
+using MongoDB.Driver;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.MatchmakingService;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class ProgressionPrestigeHandlerTests
+{
+    private MongoDbRunner _runner;
+    private MongoClient _mongoClient;
+    private ProgressionPrestigeRepository _repo;
+    private ProgressionPrestigeHandler _handler;
+
+    [SetUp]
+    public void Setup()
+    {
+        _runner = MongoDbRunner.Start();
+        _mongoClient = new MongoClient(_runner.ConnectionString);
+        _repo = new ProgressionPrestigeRepository(_mongoClient);
+        _handler = new ProgressionPrestigeHandler(_repo);
+    }
+
+    [TearDown]
+    public void TearDown() => _runner.Dispose();
+
+    // --- helpers: copied from ProgressionMilestoneHandlerTests / PlayerProgressionHandlerTests ---
+
+    private static PlayerMMrChange Solo(string battleTag, Race race, bool won, int? league, int? div, int? pts, int? apex = null)
+    {
+        return new PlayerMMrChange
+        {
+            battleTag = battleTag,
+            team = 0,
+            won = won,
+            race = race,
+            atTeamId = null,
+            updatedProgression = league.HasValue
+                ? new UpdatedProgression { league = league.Value, division = div ?? 0, points = pts ?? 0, apexPoints = apex }
+                : null,
+        };
+    }
+
+    private static PlayerMMrChange At(string battleTag, string atTeamId, int? league, int? div, int? pts)
+    {
+        return new PlayerMMrChange
+        {
+            battleTag = battleTag,
+            team = 0,
+            won = true,
+            race = Race.HU,
+            atTeamId = atTeamId,
+            updatedProgression = league.HasValue
+                ? new UpdatedProgression { league = league.Value, division = div ?? 0, points = pts ?? 0 }
+                : null,
+        };
+    }
+
+    private static MatchFinishedEvent Match(int season, GameMode mode, bool fake, params PlayerMMrChange[] players)
+    {
+        return new MatchFinishedEvent
+        {
+            WasFakeEvent = fake,
+            match = new W3C.Domain.MatchmakingService.Match
+            {
+                id = "m-" + season,
+                gameMode = mode,
+                gateway = GateWay.Europe,
+                season = season,
+                endTime = 1_700_000_000_000L,
+                players = new List<PlayerMMrChange>(players),
+            },
+        };
+    }
+
+    [Test]
+    public async Task SoloPlacement_RecordsPeak()
+    {
+        await _handler.Update(Match(1, GameMode.GM_1v1, false,
+            Solo("hero#1", Race.HU, won: true, league: 3, div: 1, pts: 50)));
+
+        var loaded = await _repo.LoadPrestige("hero#1");
+        Assert.IsNotNull(loaded);
+        Assert.AreEqual(3, loaded.Peaks.Single().AllTimePeak.League);
+        Assert.AreEqual(Race.HU, loaded.Peaks.Single().Race); // race in key for 1v1
+    }
+
+    [Test]
+    public async Task ArrangedTeamPlayer_IsSkipped()
+    {
+        await _handler.Update(Match(1, GameMode.GM_2v2, false,
+            At("teamguy#1", "teamA", league: 2, div: 1, pts: 50)));
+
+        Assert.IsNull(await _repo.LoadPrestige("teamguy#1"));
+    }
+
+    [Test]
+    public async Task NullProgression_IsSkipped()
+    {
+        await _handler.Update(Match(1, GameMode.GM_1v1, false,
+            Solo("calib#1", Race.HU, won: false, league: null, div: null, pts: null)));
+
+        Assert.IsNull(await _repo.LoadPrestige("calib#1"));
+    }
+
+    [Test]
+    public async Task FakeEvent_IsSkipped()
+    {
+        await _handler.Update(Match(1, GameMode.GM_1v1, fake: true,
+            Solo("fake#1", Race.HU, won: true, league: 3, div: 1, pts: 50)));
+
+        Assert.IsNull(await _repo.LoadPrestige("fake#1"));
+    }
+
+    [Test]
+    public async Task Replay_IsIdempotent()
+    {
+        var ev = Match(1, GameMode.GM_1v1, false, Solo("idem#1", Race.HU, true, 3, 1, 50));
+        await _handler.Update(ev);
+        await _handler.Update(ev);
+
+        var loaded = await _repo.LoadPrestige("idem#1");
+        Assert.AreEqual(1, loaded.Peaks.Single().SeasonPeaks.Count);
+        Assert.AreEqual(3, loaded.Peaks.Single().AllTimePeak.League);
+    }
+
+    [Test]
+    public async Task LaterDemotion_DoesNotLowerAllTimePeak()
+    {
+        await _handler.Update(Match(1, GameMode.GM_1v1, false, Solo("climb#1", Race.HU, true, 3, 1, 50)));
+        await _handler.Update(Match(1, GameMode.GM_1v1, false, Solo("climb#1", Race.HU, false, 5, 4, 10)));
+
+        var loaded = await _repo.LoadPrestige("climb#1");
+        Assert.AreEqual(3, loaded.Peaks.Single().AllTimePeak.League);
+    }
+
+    [Test]
+    public async Task CrossSeason_RetainsBothSeasonPeaks_AllTimeSurvives()
+    {
+        await _handler.Update(Match(1, GameMode.GM_1v1, false, Solo("vet#1", Race.HU, true, 3, 1, 50)));
+        await _handler.Update(Match(2, GameMode.GM_1v1, false, Solo("vet#1", Race.HU, true, 6, 3, 20)));
+
+        var entry = (await _repo.LoadPrestige("vet#1")).Peaks.Single();
+        Assert.AreEqual(2, entry.SeasonPeaks.Count);
+        Assert.AreEqual(3, entry.AllTimePeak.League);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeHandlerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeHandlerTests.cs
@@ -16,7 +16,7 @@ public class ProgressionPrestigeHandlerTests
 {
     private MongoDbRunner _runner;
     private MongoClient _mongoClient;
-    private ProgressionPrestigeRepository _repo;
+    private ProgressionPrestigeRepository _repository;
     private ProgressionPrestigeHandler _handler;
 
     [SetUp]
@@ -24,14 +24,14 @@ public class ProgressionPrestigeHandlerTests
     {
         _runner = MongoDbRunner.Start();
         _mongoClient = new MongoClient(_runner.ConnectionString);
-        _repo = new ProgressionPrestigeRepository(_mongoClient);
-        _handler = new ProgressionPrestigeHandler(_repo);
+        _repository = new ProgressionPrestigeRepository(_mongoClient);
+        _handler = new ProgressionPrestigeHandler(_repository);
     }
 
     [TearDown]
     public void TearDown() => _runner.Dispose();
 
-    // --- helpers: copied from ProgressionMilestoneHandlerTests / PlayerProgressionHandlerTests ---
+    // --- helpers: follows the same pattern as ProgressionMilestoneHandlerTests / PlayerProgressionHandlerTests ---
 
     private static PlayerMMrChange Solo(string battleTag, Race race, bool won, int? league, int? div, int? pts, int? apex = null)
     {
@@ -48,13 +48,13 @@ public class ProgressionPrestigeHandlerTests
         };
     }
 
-    private static PlayerMMrChange At(string battleTag, string atTeamId, int? league, int? div, int? pts)
+    private static PlayerMMrChange At(string battleTag, string atTeamId, int? league, int? div, int? pts, bool won = true)
     {
         return new PlayerMMrChange
         {
             battleTag = battleTag,
             team = 0,
-            won = true,
+            won = won,
             race = Race.HU,
             atTeamId = atTeamId,
             updatedProgression = league.HasValue
@@ -63,18 +63,23 @@ public class ProgressionPrestigeHandlerTests
         };
     }
 
-    private static MatchFinishedEvent Match(int season, GameMode mode, bool fake, params PlayerMMrChange[] players)
+    private const long BaseEndTimeMs = 1_700_000_000_000L;
+
+    private static MatchFinishedEvent Match(int season, GameMode mode, bool fake, params PlayerMMrChange[] players) =>
+        Match(season, mode, fake, BaseEndTimeMs, players);
+
+    private static MatchFinishedEvent Match(int season, GameMode mode, bool fake, long endTimeMs, params PlayerMMrChange[] players)
     {
         return new MatchFinishedEvent
         {
             WasFakeEvent = fake,
             match = new W3C.Domain.MatchmakingService.Match
             {
-                id = "m-" + season,
+                id = "m-" + season + "-" + endTimeMs, // sibling pattern: season + endTime keeps distinct events distinct
                 gameMode = mode,
                 gateway = GateWay.Europe,
                 season = season,
-                endTime = 1_700_000_000_000L,
+                endTime = endTimeMs,
                 players = new List<PlayerMMrChange>(players),
             },
         };
@@ -86,7 +91,7 @@ public class ProgressionPrestigeHandlerTests
         await _handler.Update(Match(1, GameMode.GM_1v1, false,
             Solo("hero#1", Race.HU, won: true, league: 3, div: 1, pts: 50)));
 
-        var loaded = await _repo.LoadPrestige("hero#1");
+        var loaded = await _repository.LoadPrestige("hero#1");
         Assert.IsNotNull(loaded);
         Assert.AreEqual(3, loaded.Peaks.Single().AllTimePeak.League);
         Assert.AreEqual(Race.HU, loaded.Peaks.Single().Race); // race in key for 1v1
@@ -98,7 +103,7 @@ public class ProgressionPrestigeHandlerTests
         await _handler.Update(Match(1, GameMode.GM_2v2, false,
             At("teamguy#1", "teamA", league: 2, div: 1, pts: 50)));
 
-        Assert.IsNull(await _repo.LoadPrestige("teamguy#1"));
+        Assert.IsNull(await _repository.LoadPrestige("teamguy#1"));
     }
 
     [Test]
@@ -107,7 +112,7 @@ public class ProgressionPrestigeHandlerTests
         await _handler.Update(Match(1, GameMode.GM_1v1, false,
             Solo("calib#1", Race.HU, won: false, league: null, div: null, pts: null)));
 
-        Assert.IsNull(await _repo.LoadPrestige("calib#1"));
+        Assert.IsNull(await _repository.LoadPrestige("calib#1"));
     }
 
     [Test]
@@ -116,17 +121,19 @@ public class ProgressionPrestigeHandlerTests
         await _handler.Update(Match(1, GameMode.GM_1v1, fake: true,
             Solo("fake#1", Race.HU, won: true, league: 3, div: 1, pts: 50)));
 
-        Assert.IsNull(await _repo.LoadPrestige("fake#1"));
+        Assert.IsNull(await _repository.LoadPrestige("fake#1"));
     }
 
     [Test]
     public async Task Replay_IsIdempotent()
     {
+        // Pins at-most-once write semantics: because the peak is a monotonic max keyed by season,
+        // replaying the same event leaves a single season bucket and does not double-count the peak.
         var ev = Match(1, GameMode.GM_1v1, false, Solo("idem#1", Race.HU, true, 3, 1, 50));
         await _handler.Update(ev);
         await _handler.Update(ev);
 
-        var loaded = await _repo.LoadPrestige("idem#1");
+        var loaded = await _repository.LoadPrestige("idem#1");
         Assert.AreEqual(1, loaded.Peaks.Single().SeasonPeaks.Count);
         Assert.AreEqual(3, loaded.Peaks.Single().AllTimePeak.League);
     }
@@ -134,10 +141,10 @@ public class ProgressionPrestigeHandlerTests
     [Test]
     public async Task LaterDemotion_DoesNotLowerAllTimePeak()
     {
-        await _handler.Update(Match(1, GameMode.GM_1v1, false, Solo("climb#1", Race.HU, true, 3, 1, 50)));
-        await _handler.Update(Match(1, GameMode.GM_1v1, false, Solo("climb#1", Race.HU, false, 5, 4, 10)));
+        await _handler.Update(Match(1, GameMode.GM_1v1, false, BaseEndTimeMs, Solo("climb#1", Race.HU, true, 3, 1, 50)));
+        await _handler.Update(Match(1, GameMode.GM_1v1, false, BaseEndTimeMs + 1, Solo("climb#1", Race.HU, false, 5, 4, 10)));
 
-        var loaded = await _repo.LoadPrestige("climb#1");
+        var loaded = await _repository.LoadPrestige("climb#1");
         Assert.AreEqual(3, loaded.Peaks.Single().AllTimePeak.League);
     }
 
@@ -147,7 +154,7 @@ public class ProgressionPrestigeHandlerTests
         await _handler.Update(Match(1, GameMode.GM_1v1, false, Solo("vet#1", Race.HU, true, 3, 1, 50)));
         await _handler.Update(Match(2, GameMode.GM_1v1, false, Solo("vet#1", Race.HU, true, 6, 3, 20)));
 
-        var entry = (await _repo.LoadPrestige("vet#1")).Peaks.Single();
+        var entry = (await _repository.LoadPrestige("vet#1")).Peaks.Single();
         Assert.AreEqual(2, entry.SeasonPeaks.Count);
         Assert.AreEqual(3, entry.AllTimePeak.League);
     }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeRepositoryTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading.Tasks;
+using Mongo2Go;
+using MongoDB.Driver;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class ProgressionPrestigeRepositoryTests
+{
+    private MongoDbRunner _runner;
+    private MongoClient _client;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _runner = MongoDbRunner.Start();
+        _client = new MongoClient(_runner.ConnectionString);
+    }
+
+    [TearDown]
+    public void TearDown() => _runner.Dispose();
+
+    [Test]
+    public async Task UpsertThenLoad_RoundTrips_IncludingDateTimeOffset()
+    {
+        var repo = new ProgressionPrestigeRepository(_client);
+        var prestige = ProgressionPrestige.Create("round#1");
+        var achievedAt = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000);
+        prestige.RecordPeak(GameMode.GM_1v1, Race.HU,
+            new PeakRank { League = 3, Division = 1, Points = 50, Season = 1, AchievedAt = achievedAt });
+
+        await repo.UpsertPrestige(prestige);
+        var loaded = await repo.LoadPrestige("round#1");
+
+        Assert.IsNotNull(loaded);
+        Assert.AreEqual("round#1", loaded.Id);
+        Assert.AreEqual(3, loaded.Peaks[0].AllTimePeak.League);
+        Assert.AreEqual(achievedAt, loaded.Peaks[0].AllTimePeak.AchievedAt);
+    }
+
+    [Test]
+    public async Task LoadMissing_ReturnsNull()
+    {
+        var repo = new ProgressionPrestigeRepository(_client);
+        Assert.IsNull(await repo.LoadPrestige("nobody#1"));
+    }
+
+    [Test]
+    public async Task Upsert_IsReplaceNotDuplicate()
+    {
+        var repo = new ProgressionPrestigeRepository(_client);
+        var p1 = ProgressionPrestige.Create("dup#1");
+        p1.RecordPeak(GameMode.GM_1v1, null,
+            new PeakRank { League = 5, Division = 1, Points = 0, Season = 1, AchievedAt = DateTimeOffset.UnixEpoch });
+        await repo.UpsertPrestige(p1);
+        await repo.UpsertPrestige(p1);
+
+        var collection = _client.GetDatabase("W3Champions-Statistic-Service")
+            .GetCollection<ProgressionPrestige>("ProgressionPrestige");
+        Assert.AreEqual(1, await collection.CountDocumentsAsync(FilterDefinition<ProgressionPrestige>.Empty));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeRepositoryTests.cs
@@ -13,13 +13,15 @@ namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats
 public class ProgressionPrestigeRepositoryTests
 {
     private MongoDbRunner _runner;
-    private MongoClient _client;
+    private MongoClient _mongoClient;
+    private ProgressionPrestigeRepository _repository;
 
     [SetUp]
-    public void SetUp()
+    public void Setup()
     {
         _runner = MongoDbRunner.Start();
-        _client = new MongoClient(_runner.ConnectionString);
+        _mongoClient = new MongoClient(_runner.ConnectionString);
+        _repository = new ProgressionPrestigeRepository(_mongoClient);
     }
 
     [TearDown]
@@ -28,14 +30,13 @@ public class ProgressionPrestigeRepositoryTests
     [Test]
     public async Task UpsertThenLoad_RoundTrips_IncludingDateTimeOffset()
     {
-        var repo = new ProgressionPrestigeRepository(_client);
         var prestige = ProgressionPrestige.Create("round#1");
         var achievedAt = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_000);
         prestige.RecordPeak(GameMode.GM_1v1, Race.HU,
             new PeakRank { League = 3, Division = 1, Points = 50, Season = 1, AchievedAt = achievedAt });
 
-        await repo.UpsertPrestige(prestige);
-        var loaded = await repo.LoadPrestige("round#1");
+        await _repository.UpsertPrestige(prestige);
+        var loaded = await _repository.LoadPrestige("round#1");
 
         Assert.IsNotNull(loaded);
         Assert.AreEqual("round#1", loaded.Id);
@@ -46,22 +47,28 @@ public class ProgressionPrestigeRepositoryTests
     [Test]
     public async Task LoadMissing_ReturnsNull()
     {
-        var repo = new ProgressionPrestigeRepository(_client);
-        Assert.IsNull(await repo.LoadPrestige("nobody#1"));
+        Assert.IsNull(await _repository.LoadPrestige("nobody#1"));
     }
 
     [Test]
     public async Task Upsert_IsReplaceNotDuplicate()
     {
-        var repo = new ProgressionPrestigeRepository(_client);
         var p1 = ProgressionPrestige.Create("dup#1");
         p1.RecordPeak(GameMode.GM_1v1, null,
             new PeakRank { League = 5, Division = 1, Points = 0, Season = 1, AchievedAt = DateTimeOffset.UnixEpoch });
-        await repo.UpsertPrestige(p1);
-        await repo.UpsertPrestige(p1);
+        await _repository.UpsertPrestige(p1);
 
-        var collection = _client.GetDatabase("W3Champions-Statistic-Service")
+        // Mutate to a higher rank (Gold -> Diamond) before the second upsert so the replace
+        // is proven to carry the mutation, not just dedup.
+        p1.RecordPeak(GameMode.GM_1v1, null,
+            new PeakRank { League = 3, Division = 1, Points = 50, Season = 1, AchievedAt = DateTimeOffset.UnixEpoch });
+        await _repository.UpsertPrestige(p1);
+
+        var collection = _mongoClient.GetDatabase("W3Champions-Statistic-Service")
             .GetCollection<ProgressionPrestige>("ProgressionPrestige");
         Assert.AreEqual(1, await collection.CountDocumentsAsync(FilterDefinition<ProgressionPrestige>.Empty));
+
+        var loaded = await _repository.LoadPrestige("dup#1");
+        Assert.AreEqual(3, loaded.Peaks[0].AllTimePeak.League);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class ProgressionPrestigeTests
+{
+    private static PeakRank Rank(int league, int division, int points, int season) =>
+        new() { League = league, Division = division, Points = points, Season = season, AchievedAt = DateTimeOffset.UnixEpoch };
+
+    [Test]
+    public void FirstRecord_SetsBothAllTimeAndSeasonPeak()
+    {
+        var p = ProgressionPrestige.Create("peak#1");
+        p.RecordPeak(GameMode.GM_1v1, Race.HU, Rank(5, 2, 30, season: 1));
+
+        var entry = p.Peaks.Single();
+        Assert.AreEqual(GameMode.GM_1v1, entry.GameMode);
+        Assert.AreEqual(Race.HU, entry.Race);
+        Assert.AreEqual(5, entry.AllTimePeak.League);
+        Assert.AreEqual(1, entry.SeasonPeaks.Single().Season);
+        Assert.IsEmpty(entry.Badges);
+    }
+
+    [Test]
+    public void LowerSubsequentRank_DoesNotLowerEitherPeak()
+    {
+        var p = ProgressionPrestige.Create("peak#1");
+        p.RecordPeak(GameMode.GM_1v1, Race.HU, Rank(3, 1, 50, season: 1)); // Diamond I
+        p.RecordPeak(GameMode.GM_1v1, Race.HU, Rank(5, 4, 10, season: 1)); // dropped to Gold IV
+
+        var entry = p.Peaks.Single();
+        Assert.AreEqual(3, entry.AllTimePeak.League);          // still Diamond
+        Assert.AreEqual(3, entry.SeasonPeaks.Single().League); // season peak also unchanged
+    }
+
+    [Test]
+    public void HigherSubsequentRank_RaisesBothPeaks()
+    {
+        var p = ProgressionPrestige.Create("peak#1");
+        p.RecordPeak(GameMode.GM_1v1, Race.HU, Rank(5, 2, 30, season: 1));
+        p.RecordPeak(GameMode.GM_1v1, Race.HU, Rank(3, 2, 30, season: 1)); // climbed to Diamond
+
+        var entry = p.Peaks.Single();
+        Assert.AreEqual(3, entry.AllTimePeak.League);
+        Assert.AreEqual(3, entry.SeasonPeaks.Single().League);
+    }
+
+    [Test]
+    public void NewSeason_AppendsSeasonPeak_AllTimeSurvivesAcrossSeasons()
+    {
+        var p = ProgressionPrestige.Create("peak#1");
+        p.RecordPeak(GameMode.GM_1v1, Race.HU, Rank(3, 1, 50, season: 1)); // Diamond I in S1
+        p.RecordPeak(GameMode.GM_1v1, Race.HU, Rank(6, 3, 20, season: 2)); // Silver III in S2 (reset)
+
+        var entry = p.Peaks.Single();
+        Assert.AreEqual(2, entry.SeasonPeaks.Count);
+        Assert.AreEqual(3, entry.SeasonPeaks.Single(s => s.Season == 1).League);
+        Assert.AreEqual(6, entry.SeasonPeaks.Single(s => s.Season == 2).League);
+        Assert.AreEqual(3, entry.AllTimePeak.League);          // all-time = the S1 Diamond
+        // Invariant: all-time == best of the per-season peaks
+        var best = entry.SeasonPeaks.Aggregate((a, b) => PrestigeRankComparer.IsHigher(a, b) ? a : b);
+        Assert.AreEqual(best.League, entry.AllTimePeak.League);
+    }
+
+    [Test]
+    public void DistinctRace_ProducesSeparateEntries()
+    {
+        var p = ProgressionPrestige.Create("peak#1");
+        p.RecordPeak(GameMode.GM_1v1, Race.HU, Rank(5, 2, 30, season: 1));
+        p.RecordPeak(GameMode.GM_1v1, Race.OC, Rank(4, 2, 30, season: 1));
+        Assert.AreEqual(2, p.Peaks.Count);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeTests.cs
@@ -91,4 +91,12 @@ public class ProgressionPrestigeTests
         Assert.AreEqual(3, nullRaceEntry.AllTimePeak.League);   // both null-race calls hit the same entry
         Assert.AreEqual(2, p.Peaks.Count);                      // exactly two entries: (2v2, null) and (1v1, HU)
     }
+
+    [Test]
+    public void RecordPeak_IgnoresUnplacedRank()
+    {
+        var p = ProgressionPrestige.Create("unplaced#1");
+        p.RecordPeak(GameMode.GM_1v1, Race.HU, new PeakRank { League = null, Season = 1 });
+        Assert.IsEmpty(p.Peaks); // unplaced/calibrating rank creates no entry or bucket
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionPrestigeTests.cs
@@ -63,9 +63,8 @@ public class ProgressionPrestigeTests
         Assert.AreEqual(3, entry.SeasonPeaks.Single(s => s.Season == 1).League);
         Assert.AreEqual(6, entry.SeasonPeaks.Single(s => s.Season == 2).League);
         Assert.AreEqual(3, entry.AllTimePeak.League);          // all-time = the S1 Diamond
-        // Invariant: all-time == best of the per-season peaks
-        var best = entry.SeasonPeaks.Aggregate((a, b) => PrestigeRankComparer.IsHigher(a, b) ? a : b);
-        Assert.AreEqual(best.League, entry.AllTimePeak.League);
+        // Invariant: all-time is the full S1 peak record (value equality pins every rank field, not just league)
+        Assert.AreEqual(entry.SeasonPeaks.Single(s => s.Season == 1), entry.AllTimePeak);
     }
 
     [Test]
@@ -75,5 +74,21 @@ public class ProgressionPrestigeTests
         p.RecordPeak(GameMode.GM_1v1, Race.HU, Rank(5, 2, 30, season: 1));
         p.RecordPeak(GameMode.GM_1v1, Race.OC, Rank(4, 2, 30, season: 1));
         Assert.AreEqual(2, p.Peaks.Count);
+    }
+
+    [Test]
+    public void NullRaceMode_SharesOneEntry_AndIsDistinctFromRacedMode()
+    {
+        var p = ProgressionPrestige.Create("peak#1");
+        // A non-race-split mode (e.g. 2v2) records under race == null; repeated calls share one entry.
+        p.RecordPeak(GameMode.GM_2v2, null, Rank(5, 2, 30, season: 1));
+        p.RecordPeak(GameMode.GM_2v2, null, Rank(3, 1, 50, season: 1)); // climbed, same (mode, null-race) key
+        // A race-split mode (1v1) with a non-null race lands in its own distinct entry.
+        p.RecordPeak(GameMode.GM_1v1, Race.HU, Rank(4, 2, 30, season: 1));
+
+        var nullRaceEntry = p.Peaks.Single(e => e.GameMode == GameMode.GM_2v2);
+        Assert.IsNull(nullRaceEntry.Race);                      // null-race key preserved
+        Assert.AreEqual(3, nullRaceEntry.AllTimePeak.League);   // both null-race calls hit the same entry
+        Assert.AreEqual(2, p.Peaks.Count);                      // exactly two entries: (2v2, null) and (1v1, HU)
     }
 }

--- a/docs/ranking/README.md
+++ b/docs/ranking/README.md
@@ -57,3 +57,32 @@ same event stream but keyed differently from the season-scoped progression rank 
   (`PlayerOverallStats`, `GamesPerDay`) — it relies on the read-model cursor (`HandlerVersions`) for
   at-least-once delivery rather than a per-document guard. A deliberate cursor rewind/backfill would
   re-count; this is accepted, consistent with those existing handlers.
+
+## Prestige store (peak rank)
+
+`ProgressionPrestige` is a permanent, per-player read-model (one document per battleTag) recording the
+**highest progression rank ever reached** in each individual-rank game mode (per race for race-split
+modes). Each mode entry keeps an all-time peak, the peak reached in each season, and a reserved slot for
+future cosmetic badges. The peak only ever rises, so it is retained across the seasonal reset (the
+current-season rank lives in the season-keyed progression read-model; the peak here is never cleared).
+It is built from the match-finished event stream and is ingest-only — there is no read API yet.
+
+- **Read-model:** `ProgressionPrestige` (collection `ProgressionPrestige`,
+  `PlayerProfiles/ProgressionStats/`) — one document per player (battleTag). Each document holds a list
+  of `PrestigePeakEntry` records, one per `(gameMode, race)` combination. Race is populated only for
+  race-split game modes (e.g. `GM_1v1`); it is `null` for non-race-split modes.
+- **What it stores:** `AllTimePeak` — the single highest rank the player has ever held in that
+  mode/race — and `SeasonPeaks`, a per-season list of the peak rank reached within each individual
+  season. The all-time peak is always equal to the best entry across all season peaks (invariant
+  maintained on every write). A `Badges` list is reserved for future cosmetic awards; it is always
+  empty in the current stage.
+- **Scope:** only **non-arranged-team** placements are recorded. Arranged-team rank is attributed to
+  the team as a whole, not to individual players, so those events are skipped.
+- **Handler:** `ProgressionPrestigeHandler : IMatchFinishedReadModelHandler` — for each placed,
+  non-arranged-team player it reads (or creates) the player's prestige document, applies the peak
+  candidate, and upserts the result. The update is a monotonic `max`; replaying the same event is a
+  no-op. Skips fake events. Registered via
+  `AddMatchFinishedReadModelService<ProgressionPrestigeHandler>()`.
+- **Idempotency:** the peak is updated only when the incoming rank strictly exceeds the stored peak,
+  so replays and out-of-order deliveries are safe. The read-model cursor (`HandlerVersions`) provides
+  at-least-once delivery.


### PR DESCRIPTION
## What

Adds `ProgressionPrestige` — a permanent, per-player read-model that records each player's **peak progression rank** and retains it across seasonal resets.

- One document per player (keyed by battleTag, like `PlayerOverallStats` / `PersonalSetting`).
- Tracks the **highest rank ever reached** per individual-rank game mode (and per race for race-split modes such as 1v1):
  - an **all-time peak**,
  - **per-season peaks** (the best rank reached in each season),
  - a **reserved (currently empty) badge slot** for future cosmetics.
- The peak only ever rises, so it is **retained across the seasonal reset** (the current-season rank lives in the season-keyed progression read-model; the peak here is never cleared).
- Fed from the match-finished event stream; **ingest-only** (no read API in this PR).

Only individual-rank placements are recorded; arranged-team placements are skipped (a team's rank isn't attributed to an individual). Calibrating/unplaced players are ignored.

## How

Mirrors the existing progression read-model pattern (model + dedicated repository + `IMatchFinishedReadModelHandler` + DI registration):

- `PeakRank` — the stored rank snapshot (`record`), plus `PrestigeRankComparer`, a pure, config-free comparison of published rank values (apex above the numbered leagues; then league, division, points). Isolated and exhaustively unit-tested.
- `ProgressionPrestige` / `PrestigePeakEntry` — the document; `RecordPeak` maintains the per-season and all-time peaks via a monotonic `max`. Because the peak is a `max`, ingest is **idempotent under replay** (cursor-based at-least-once delivery is sufficient).
- `ProgressionPrestigeRepository` (`MongoDbRepositoryBase`) + `ProgressionPrestigeHandler`, registered in `Program.cs` alongside the existing handlers.
- New-handler cursor starts at version 0, so the first run backfills each player's historical peak.

## Tests

NUnit + self-contained Mongo2Go (`MongoDbRunner`), 27 new tests:

- **Comparator** (10): league/division/points direction, apex above leagues, apex tie-break, equal-is-not-higher, null-safety.
- **Model** (7): first record sets both peaks; a lower rank never lowers either; a higher one raises both; new season appends a bucket while the all-time peak persists; distinct race → distinct entries; reserved badge slot stays empty; unplaced ranks are ignored.
- **Repository** (3): round-trip (incl. timestamp), load-missing → null, upsert-is-replace-not-duplicate (mutation survives).
- **Handler** (7): solo placement records the peak (race in key for 1v1); arranged-team players skipped; calibrating/null skipped; fake events skipped; replay is idempotent; a later demotion doesn't lower the all-time peak; cross-season retains both season peaks and the all-time peak.

`dotnet build` clean, `dotnet format --verify-no-changes` clean. The full ProgressionStats test namespace is green (80/80).

Docs: a prestige section added to `docs/ranking/README.md`.