### PR TITLE
feat(progression): serve progression rank on ladder + profile DTOs (P11-2)

### DIFF
--- a/W3ChampionsStatisticService/Ladder/LadderController.cs
+++ b/W3ChampionsStatisticService/Ladder/LadderController.cs
@@ -33,7 +33,7 @@ public class LadderController(
         {
             return BadRequest("searchFor parameter must be at least 3 letters.");
         }
-        List<Rank> playerRanks = await _rankRepository.SearchPlayerOfLeague(searchFor, season, gateWay, gameMode);
+        List<Rank> playerRanks = await _rankQueryHandler.SearchPlayersOfLeague(searchFor, season, gateWay, gameMode);
 
         var playerStats = await _playerRepository.SearchForPlayer(searchFor);
 

--- a/W3ChampionsStatisticService/Ladder/Rank.cs
+++ b/W3ChampionsStatisticService/Ladder/Rank.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.Repositories;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 
 namespace W3ChampionsStatisticService.Ladder;
 
@@ -63,4 +64,7 @@ public class Rank : IIdentifiable
     [JsonIgnore]
     [BsonIgnoreIfNull]
     public List<PersonalSettings.PersonalSetting> PlayerSettings { get; set; } = new List<PersonalSettings.PersonalSetting>();
+
+    [BsonIgnore]
+    public PlayerProgressionView Progression { get; set; }
 }

--- a/W3ChampionsStatisticService/Ladder/RankQueryHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/RankQueryHandler.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 using W3ChampionsStatisticService.Ports;
 using W3C.Domain.Tracing;
 
@@ -11,17 +12,20 @@ namespace W3ChampionsStatisticService.Ladder;
 public class RankQueryHandler(
     IRankRepository rankRepository,
     IPlayerRepository playerRepository,
-    IClanRepository clanRepository)
+    IClanRepository clanRepository,
+    ProgressionViewLoader progressionViewLoader)
 {
     private readonly IRankRepository _rankRepository = rankRepository;
     private readonly IPlayerRepository _playerRepository = playerRepository;
     private readonly IClanRepository _clanRepository = clanRepository;
+    private readonly ProgressionViewLoader _progressionViewLoader = progressionViewLoader;
 
     public async Task<List<Rank>> LoadPlayersOfLeague(int leagueId, int season, GateWay gateWay, GameMode gameMode)
     {
         var playerRanks = await _rankRepository.LoadPlayersOfLeague(leagueId, season, gateWay, gameMode);
 
         await PopulatePlayerInfos(playerRanks);
+        await PopulateProgression(playerRanks);
 
         return playerRanks;
     }
@@ -32,6 +36,7 @@ public class RankQueryHandler(
 
         await PopulatePlayerInfos(playerRanks);
         await PopulateLeagueInfo(playerRanks, season, gateWay, gameMode);
+        await PopulateProgression(playerRanks);
         if (gameMode == GameMode.GM_2v2_AT
             || gameMode == GameMode.GM_4v4_AT
             || gameMode == GameMode.GM_LEGION_4v4_x20_AT
@@ -110,6 +115,15 @@ public class RankQueryHandler(
                 rank.LeagueDivision = league.Division;
                 rank.LeagueOrder = league.Order;
             }
+        }
+    }
+
+    private async Task PopulateProgression(List<Rank> ranks)
+    {
+        var views = await _progressionViewLoader.LoadViews(ranks.Select(r => r.Id).ToList());
+        foreach (var rank in ranks)
+        {
+            rank.Progression = views.GetValueOrDefault(rank.Id);
         }
     }
 

--- a/W3ChampionsStatisticService/Ladder/RankQueryHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/RankQueryHandler.cs
@@ -20,6 +20,13 @@ public class RankQueryHandler(
     private readonly IClanRepository _clanRepository = clanRepository;
     private readonly ProgressionViewLoader _progressionViewLoader = progressionViewLoader;
 
+    public async Task<List<Rank>> SearchPlayersOfLeague(string searchFor, int season, GateWay gateWay, GameMode gameMode)
+    {
+        var playerRanks = await _rankRepository.SearchPlayerOfLeague(searchFor, season, gateWay, gameMode);
+        await PopulateProgression(playerRanks);
+        return playerRanks;
+    }
+
     public async Task<List<Rank>> LoadPlayersOfLeague(int leagueId, int season, GateWay gateWay, GameMode gameMode)
     {
         var playerRanks = await _rankRepository.LoadPlayersOfLeague(leagueId, season, gateWay, gameMode);

--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/GameModeStatQueryHandler.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/GameModeStatQueryHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.Ladder;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.Services;
 using Serilog;
@@ -16,12 +17,14 @@ public class GameModeStatQueryHandler(
     IPlayerRepository playerRepository,
     PlayerService playerService,
     ITrackingService trackingService,
-    IRankRepository rankRepository)
+    IRankRepository rankRepository,
+    ProgressionViewLoader progressionViewLoader)
 {
     private readonly IPlayerRepository _playerRepository = playerRepository;
     private readonly PlayerService _playerService = playerService;
     private readonly ITrackingService _trackingService = trackingService;
     private readonly IRankRepository _rankRepository = rankRepository;
+    private readonly ProgressionViewLoader _progressionViewLoader = progressionViewLoader;
 
     public async Task<List<PlayerGameModeStatPerGateway>> LoadPlayerStatsWithRanks(
         string battleTag,
@@ -38,6 +41,7 @@ public class GameModeStatQueryHandler(
         }
 
         await PopulateQuantilesAsync(playerGameModeStats, season);
+        await PopulateProgression(playerGameModeStats);
 
         return playerGameModeStats.OrderByDescending(r => r.RankingPoints).ToList();
     }
@@ -86,6 +90,15 @@ public class GameModeStatQueryHandler(
         foreach (var gameModeStat in playerGameModeStats)
         {
             gameModeStat.Quantile = await _playerService.GetQuantileForPlayer(gameModeStat.PlayerIds, gameModeStat.GateWay, gameModeStat.GameMode, gameModeStat.Race, season);
+        }
+    }
+
+    private async Task PopulateProgression(List<PlayerGameModeStatPerGateway> stats)
+    {
+        var views = await _progressionViewLoader.LoadViews(stats.Select(s => s.Id).ToList());
+        foreach (var stat in stats)
+        {
+            stat.Progression = views.GetValueOrDefault(stat.Id);
         }
     }
 }

--- a/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGateway.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GameModeStats/PlayerGameModeStatPerGateway.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
 using W3C.Contracts.GameObjects;
 using W3C.Domain.CommonValueObjects;
 using W3C.Domain.Repositories;
 using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 
 namespace W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
 
@@ -36,6 +38,9 @@ public class PlayerGameModeStatPerGateway : WinLoss, IIdentifiable
     public int LeagueOrder { get; set; }
     public int Division { get; set; }
     public double? Quantile { get; set; }
+
+    [BsonIgnore]
+    public PlayerProgressionView Progression { get; set; }
 
     public RankProgression RankingPointsProgress
     {

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionRepository.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Driver;
 using W3C.Domain.Repositories;
@@ -18,5 +20,10 @@ public class PlayerProgressionRepository(MongoClient mongoClient)
     public Task UpsertProgression(PlayerProgression progression)
     {
         return Upsert(progression);
+    }
+
+    public Task<List<PlayerProgression>> LoadProgressions(IReadOnlyList<string> ids)
+    {
+        return LoadAll<PlayerProgression>(p => ids.Contains(p.Id));
     }
 }

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionView.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionView.cs
@@ -1,0 +1,28 @@
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+// The progression rank as served to clients on the Rank / PlayerGameModeStatPerGateway DTOs.
+// Carries only the four published fields (no keying/identity fields). Null when the player has
+// no placed progression record for that (season, mode, ...).
+public class PlayerProgressionView
+{
+    public int? League { get; set; }
+    public int? Division { get; set; }
+    public int? Points { get; set; }
+    public int? ApexPoints { get; set; }
+
+    public static PlayerProgressionView FromReadModel(PlayerProgression progression)
+    {
+        if (progression == null)
+        {
+            return null;
+        }
+
+        return new PlayerProgressionView
+        {
+            League = progression.League,
+            Division = progression.Division,
+            Points = progression.Points,
+            ApexPoints = progression.ApexPoints,
+        };
+    }
+}

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionView.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionView.cs
@@ -2,26 +2,27 @@ namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 
 // The progression rank as served to clients on the Rank / PlayerGameModeStatPerGateway DTOs.
 // Carries only the four published fields (no keying/identity fields). Null when the player has
-// no placed progression record for that (season, mode, ...).
+// no placed progression record for that (season, mode, ...). A record exists only for a placed
+// player, so league/division/points are always present; apexPoints is apex-only (nullable).
 public class PlayerProgressionView
 {
-    public int? League { get; set; }
-    public int? Division { get; set; }
-    public int? Points { get; set; }
+    public int League { get; set; }
+    public int Division { get; set; }
+    public int Points { get; set; }
     public int? ApexPoints { get; set; }
 
     public static PlayerProgressionView FromReadModel(PlayerProgression progression)
     {
-        if (progression == null)
+        if (progression?.League == null || progression.Division == null || progression.Points == null)
         {
             return null;
         }
 
         return new PlayerProgressionView
         {
-            League = progression.League,
-            Division = progression.Division,
-            Points = progression.Points,
+            League = progression.League.Value,
+            Division = progression.Division.Value,
+            Points = progression.Points.Value,
             ApexPoints = progression.ApexPoints,
         };
     }

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionViewLoader.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionViewLoader.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using W3C.Domain.Tracing;
 using W3ChampionsStatisticService.Ports;
@@ -22,6 +21,16 @@ public class ProgressionViewLoader(IPlayerProgressionRepository repository)
         }
 
         var docs = await _repository.LoadProgressions(ids);
-        return docs.ToDictionary(d => d.Id, PlayerProgressionView.FromReadModel);
+        var views = new Dictionary<string, PlayerProgressionView>();
+        foreach (var doc in docs)
+        {
+            var view = PlayerProgressionView.FromReadModel(doc);
+            if (view != null)
+            {
+                views[doc.Id] = view;
+            }
+        }
+
+        return views;
     }
 }

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionViewLoader.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionViewLoader.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.Ports;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+// Batch-loads progression read-model docs for a set of entity ids and maps them to serve-views,
+// keyed by id. Shared by the ladder (RankQueryHandler) and profile (GameModeStatQueryHandler)
+// query paths so both stamp the DTO the same way. Ids that have no record are simply absent.
+[Trace]
+public class ProgressionViewLoader(IPlayerProgressionRepository repository)
+{
+    private readonly IPlayerProgressionRepository _repository = repository;
+
+    public async Task<Dictionary<string, PlayerProgressionView>> LoadViews(IReadOnlyList<string> ids)
+    {
+        if (ids.Count == 0)
+        {
+            return new Dictionary<string, PlayerProgressionView>();
+        }
+
+        var docs = await _repository.LoadProgressions(ids);
+        return docs.ToDictionary(d => d.Id, PlayerProgressionView.FromReadModel);
+    }
+}

--- a/W3ChampionsStatisticService/Ports/IPlayerProgressionRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IPlayerProgressionRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 
@@ -7,4 +8,5 @@ public interface IPlayerProgressionRepository
 {
     Task<PlayerProgression> LoadProgression(string id);
     Task UpsertProgression(PlayerProgression progression);
+    Task<List<PlayerProgression>> LoadProgressions(IReadOnlyList<string> ids);
 }

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -165,6 +165,7 @@ builder.Services.AddInterceptedSingleton<IPlayerRepository, PlayerRepository>();
 builder.Services.AddInterceptedTransient<IPlayerProgressionRepository, PlayerProgressionRepository>();
 builder.Services.AddInterceptedTransient<IProgressionMilestoneRepository, ProgressionMilestoneRepository>();
 builder.Services.AddInterceptedTransient<IProgressionPrestigeRepository, ProgressionPrestigeRepository>();
+builder.Services.AddInterceptedTransient<ProgressionViewLoader>();
 builder.Services.AddInterceptedTransient<IRankRepository, RankRepository>();
 builder.Services.AddInterceptedTransient<IPlayerStatsRepository, PlayerStatsRepository>();
 builder.Services.AddInterceptedTransient<IW3StatsRepo, W3StatsRepo>();

--- a/WC3ChampionsStatisticService.UnitTests/Ladder/RankSerializationTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ladder/RankSerializationTests.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using MongoDB.Bson;
+using NUnit.Framework;
+using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.Ladder;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.Ladder;
+
+[TestFixture]
+public class RankSerializationTests
+{
+    [Test]
+    public void Progression_IsNotPersisted_ButSerializesToJsonAsProgression()
+    {
+        var rank = new Rank(new List<string> { "p#1" }, 1, 12, 1456, null, GateWay.Europe, GameMode.GM_1v1, 2)
+        {
+            Progression = new PlayerProgressionView { League = 3, Division = 2, Points = 50, ApexPoints = null },
+        };
+
+        // BSON: Progression is a serve-time join, never written to the Rank collection.
+        var bson = rank.ToBsonDocument();
+        Assert.IsFalse(bson.Contains("Progression"), "Progression must be [BsonIgnore]");
+
+        // JSON: serialized for the client (camelCase like the rest of the DTO).
+        var json = System.Text.Json.JsonSerializer.Serialize(
+            rank,
+            new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase });
+        StringAssert.Contains("\"progression\"", json);
+        StringAssert.Contains("\"league\":3", json);
+    }
+
+    [Test]
+    public void Progression_NullByDefault()
+    {
+        var rank = new Rank(new List<string> { "p#1" }, 1, 12, 1456, null, GateWay.Europe, GameMode.GM_1v1, 2);
+        Assert.IsNull(rank.Progression);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/GameModeStats/PlayerGameModeStatSerializationTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/GameModeStats/PlayerGameModeStatSerializationTests.cs
@@ -1,0 +1,36 @@
+using MongoDB.Bson;
+using NUnit.Framework;
+using W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.GameModeStats;
+
+[TestFixture]
+public class PlayerGameModeStatSerializationTests
+{
+    [Test]
+    public void Progression_IsNotPersisted_ButSerializesToJsonAsProgression()
+    {
+        var stat = new PlayerGameModeStatPerGateway
+        {
+            Id = "x",
+            Progression = new PlayerProgressionView { League = 3, Division = 2, Points = 50, ApexPoints = null },
+        };
+
+        var bson = stat.ToBsonDocument();
+        Assert.IsFalse(bson.Contains("Progression"), "Progression must be [BsonIgnore]");
+
+        var json = System.Text.Json.JsonSerializer.Serialize(
+            stat,
+            new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase });
+        StringAssert.Contains("\"progression\"", json);
+        StringAssert.Contains("\"league\":3", json);
+    }
+
+    [Test]
+    public void Progression_NullByDefault()
+    {
+        var stat = new PlayerGameModeStatPerGateway { Id = "x" };
+        Assert.IsNull(stat.Progression);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionRepositoryTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Mongo2Go;
 using MongoDB.Driver;
@@ -83,5 +84,26 @@ public class PlayerProgressionRepositoryTests
     {
         var loaded = await _repository.LoadProgression("nope");
         Assert.IsNull(loaded);
+    }
+
+    [Test]
+    public async Task LoadProgressions_ReturnsMatchingDocs_OmitsMissing()
+    {
+        var a = Make("a#1", 2, 3, 2, 50);
+        var b = Make("b#2", 2, 4, 1, 10);
+        await _repository.UpsertProgression(a);
+        await _repository.UpsertProgression(b);
+
+        var loaded = await _repository.LoadProgressions(new List<string> { a.Id, b.Id, "missing#9" });
+
+        Assert.AreEqual(2, loaded.Count);
+        CollectionAssert.AreEquivalent(new[] { a.Id, b.Id }, loaded.Select(p => p.Id).ToList());
+    }
+
+    [Test]
+    public async Task LoadProgressions_EmptyInput_ReturnsEmpty()
+    {
+        var loaded = await _repository.LoadProgressions(new List<string>());
+        Assert.IsEmpty(loaded);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionViewTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionViewTests.cs
@@ -22,4 +22,13 @@ public class PlayerProgressionViewTests
         Assert.AreEqual(50, view.Points);
         Assert.AreEqual(120, view.ApexPoints);
     }
+
+    [TestCase(null, 2, 50, TestName = "FromReadModel_PartialRecord_LeagueNull_ReturnsNull")]
+    [TestCase(3, null, 50, TestName = "FromReadModel_PartialRecord_DivisionNull_ReturnsNull")]
+    [TestCase(3, 2, null, TestName = "FromReadModel_PartialRecord_PointsNull_ReturnsNull")]
+    public void FromReadModel_PartialRecord_ReturnsNull(int? league, int? division, int? points)
+    {
+        var p = new PlayerProgression { League = league, Division = division, Points = points };
+        Assert.IsNull(PlayerProgressionView.FromReadModel(p));
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionViewTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionViewTests.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class PlayerProgressionViewTests
+{
+    [Test]
+    public void FromReadModel_Null_ReturnsNull()
+    {
+        Assert.IsNull(PlayerProgressionView.FromReadModel(null));
+    }
+
+    [Test]
+    public void FromReadModel_MapsTheFourPublishedFields()
+    {
+        var p = new PlayerProgression { League = 3, Division = 2, Points = 50, ApexPoints = 120 };
+        var view = PlayerProgressionView.FromReadModel(p);
+        Assert.AreEqual(3, view.League);
+        Assert.AreEqual(2, view.Division);
+        Assert.AreEqual(50, view.Points);
+        Assert.AreEqual(120, view.ApexPoints);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionViewLoaderTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/ProgressionViewLoaderTests.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mongo2Go;
+using MongoDB.Driver;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.CommonValueObjects;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.UnitTests.PlayerProfiles.ProgressionStats;
+
+[TestFixture]
+public class ProgressionViewLoaderTests
+{
+    private MongoDbRunner _runner;
+    private MongoClient _mongoClient;
+    private PlayerProgressionRepository _repository;
+    private ProgressionViewLoader _loader;
+
+    [SetUp]
+    public void Setup()
+    {
+        _runner = MongoDbRunner.Start();
+        _mongoClient = new MongoClient(_runner.ConnectionString);
+        _repository = new PlayerProgressionRepository(_mongoClient);
+        _loader = new ProgressionViewLoader(_repository);
+    }
+
+    [TearDown]
+    public void TearDown() => _runner.Dispose();
+
+    private static PlayerProgression Make(string battleTag, int league, int division, int points)
+    {
+        var id = new BattleTagIdCombined(
+            new List<PlayerId> { PlayerId.Create(battleTag) },
+            // season fixed (race-split era); loader tests don't differ by season
+            GateWay.Europe, GameMode.GM_1v1, 2, Race.HU);
+        var p = PlayerProgression.Create(id);
+        p.RecordRank(league, division, points, null);
+        return p;
+    }
+
+    [Test]
+    public async Task LoadViews_MapsById_OmitsMissing()
+    {
+        var a = Make("a#1", 3, 2, 50);
+        await _repository.UpsertProgression(a);
+
+        var views = await _loader.LoadViews(new List<string> { a.Id, "missing#9" });
+
+        Assert.IsTrue(views.ContainsKey(a.Id));
+        Assert.AreEqual(3, views[a.Id].League);
+        Assert.AreEqual(2, views[a.Id].Division);
+        Assert.AreEqual(50, views[a.Id].Points);
+        Assert.IsNull(views[a.Id].ApexPoints);
+        Assert.IsFalse(views.ContainsKey("missing#9"));
+    }
+
+    [Test]
+    public async Task LoadViews_EmptyInput_ReturnsEmptyMap()
+    {
+        var views = await _loader.LoadViews(new List<string>());
+        Assert.IsEmpty(views);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
@@ -10,6 +10,7 @@ using W3ChampionsStatisticService.Clans;
 using W3ChampionsStatisticService.Ladder;
 using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.PlayerProfiles;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 using W3ChampionsStatisticService.Ports;
 using W3C.Contracts.Matchmaking;
 
@@ -247,7 +248,8 @@ public class RankTests : IntegrationTestBase
         var playerRepository = new PlayerRepository(MongoClient);
         var personalSettingsRepository = new PersonalSettingsRepository(MongoClient);
         var clanRepository = new ClanRepository(MongoClient);
-        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository);
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository,
+            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)));
 
         var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -289,7 +291,8 @@ public class RankTests : IntegrationTestBase
         var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
         var playerRepository = new PlayerRepository(MongoClient);
         var clanRepository = new ClanRepository(MongoClient);
-        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository);
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository,
+            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)));
 
         var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -321,7 +324,8 @@ public class RankTests : IntegrationTestBase
         var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
         var playerRepository = new PlayerRepository(MongoClient);
         var clanRepository = new ClanRepository(MongoClient);
-        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository);
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository,
+            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)));
 
         var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -353,7 +357,8 @@ public class RankTests : IntegrationTestBase
         // Arrange
         var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
         var playerRepository = new PlayerRepository(MongoClient);
-        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, new ClanRepository(MongoClient));
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, new ClanRepository(MongoClient),
+            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)));
 
         var ranks = new List<Rank>
         {
@@ -450,5 +455,106 @@ public class RankTests : IntegrationTestBase
 
         // Assert
         Assert.AreEqual(2, playerLoaded2.Count);
+    }
+
+    [Test]
+    public async Task LoadPlayersOfLeague_StampsProgression_WhenRecordExists_AndLeavesRpUntouched()
+    {
+        // Arrange
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+        var clanRepository = new ClanRepository(MongoClient);
+        var progressionRepository = new PlayerProgressionRepository(MongoClient);
+        var progressionViewLoader = new ProgressionViewLoader(progressionRepository);
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader);
+
+        var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
+        await rankRepository.InsertRanks(ranks);
+
+        var player = PlayerOverview.Create(new List<PlayerId> { PlayerId.Create("peter#123") }, GateWay.America, GameMode.GM_1v1, 1, null);
+        player.RecordWin(true, 1234);
+        await playerRepository.UpsertPlayerOverview(player);
+
+        // matching progression doc -- same composite id as Rank.PlayerId ("1_peter#123@10_GM_1v1")
+        var progId = new BattleTagIdCombined(new List<PlayerId> { PlayerId.Create("peter#123") }, GateWay.America, GameMode.GM_1v1, 1, null);
+        var prog = PlayerProgression.Create(progId);
+        prog.RecordRank(3, 2, 50, null);
+        await progressionRepository.UpsertProgression(prog);
+
+        // Act
+        var loaded = await queryHandler.LoadPlayersOfLeague(1, 1, GateWay.America, GameMode.GM_1v1);
+
+        // Assert
+        Assert.AreEqual(1, loaded.Count);
+        Assert.IsNotNull(loaded[0].Progression, "progression should be stamped for a matching record");
+        Assert.AreEqual(3, loaded[0].Progression.League);
+        Assert.AreEqual(2, loaded[0].Progression.Division);
+        Assert.AreEqual(50, loaded[0].Progression.Points);
+        Assert.IsNull(loaded[0].Progression.ApexPoints);
+        // legacy RP untouched
+        Assert.AreEqual(1456, loaded[0].RankingPoints);
+    }
+
+    [Test]
+    public async Task LoadPlayersOfLeague_ProgressionNull_WhenNoRecord()
+    {
+        // Arrange
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+        var clanRepository = new ClanRepository(MongoClient);
+        var progressionViewLoader = new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient));
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader);
+
+        var ranks = new List<Rank> { new(new List<string> { "noprog#1" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
+        await rankRepository.InsertRanks(ranks);
+        var player = PlayerOverview.Create(new List<PlayerId> { PlayerId.Create("noprog#1") }, GateWay.America, GameMode.GM_1v1, 1, null);
+        player.RecordWin(true, 1234);
+        await playerRepository.UpsertPlayerOverview(player);
+
+        // Act
+        var loaded = await queryHandler.LoadPlayersOfLeague(1, 1, GateWay.America, GameMode.GM_1v1);
+
+        // Assert
+        Assert.AreEqual(1, loaded.Count);
+        Assert.IsNull(loaded[0].Progression);
+    }
+
+    [Test]
+    public async Task LoadPlayersOfCountry_StampsProgression_WhenRecordExists()
+    {
+        // Arrange
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+        var personalSettingsRepository = new PersonalSettingsRepository(MongoClient);
+        var clanRepository = new ClanRepository(MongoClient);
+        var progressionRepository = new PlayerProgressionRepository(MongoClient);
+        var progressionViewLoader = new ProgressionViewLoader(progressionRepository);
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader);
+
+        var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
+        await rankRepository.InsertRanks(ranks);
+
+        var player = PlayerOverview.Create(new List<PlayerId> { PlayerId.Create("peter#123") }, GateWay.America, GameMode.GM_1v1, 1, null);
+        player.RecordWin(true, 1234);
+        await playerRepository.UpsertPlayerOverview(player);
+
+        // LoadPlayersOfCountry filters by personal-settings CountryCode (or Location).
+        var settings = new PersonalSetting("peter#123") { CountryCode = "US" };
+        await personalSettingsRepository.Save(settings);
+
+        // matching progression doc -- same composite id as Rank.PlayerId ("1_peter#123@10_GM_1v1")
+        var progId = new BattleTagIdCombined(new List<PlayerId> { PlayerId.Create("peter#123") }, GateWay.America, GameMode.GM_1v1, 1, null);
+        var prog = PlayerProgression.Create(progId);
+        prog.RecordRank(3, 2, 50, null);
+        await progressionRepository.UpsertProgression(prog);
+
+        // Act
+        var countryRankings = await queryHandler.LoadPlayersOfCountry("US", 1, GateWay.America, GameMode.GM_1v1);
+
+        // Assert
+        var stampedRank = countryRankings.SelectMany(cr => cr.Ranks).Single(r => r.Id == "1_peter#123@10_GM_1v1");
+        Assert.IsNotNull(stampedRank.Progression, "progression should be stamped for a matching record");
+        Assert.AreEqual(3, stampedRank.Progression.League);
+        Assert.AreEqual(50, stampedRank.Progression.Points);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
@@ -520,6 +520,41 @@ public class RankTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task SearchPlayersOfLeague_StampsProgression_WhenRecordExists()
+    {
+        // Arrange
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+        var clanRepository = new ClanRepository(MongoClient);
+        var progressionRepository = new PlayerProgressionRepository(MongoClient);
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository,
+            new ProgressionViewLoader(progressionRepository));
+
+        var ranks = new List<Rank> { new(new List<string> { "searchme#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
+        await rankRepository.InsertRanks(ranks);
+
+        var player = PlayerOverview.Create(new List<PlayerId> { PlayerId.Create("searchme#123") }, GateWay.America, GameMode.GM_1v1, 1, null);
+        player.RecordWin(true, 1234);
+        await playerRepository.UpsertPlayerOverview(player);
+
+        var progId = new BattleTagIdCombined(new List<PlayerId> { PlayerId.Create("searchme#123") }, GateWay.America, GameMode.GM_1v1, 1, null);
+        var prog = PlayerProgression.Create(progId);
+        prog.RecordRank(3, 2, 50, null);
+        await progressionRepository.UpsertProgression(prog);
+
+        // Act
+        var loaded = await queryHandler.SearchPlayersOfLeague("searchme", 1, GateWay.America, GameMode.GM_1v1);
+
+        // Assert
+        var rank = loaded.Find(r => r.Id == "1_searchme#123@10_GM_1v1");
+        Assert.IsNotNull(rank, "the inserted rank should be found by search");
+        Assert.IsNotNull(rank.Progression);
+        Assert.AreEqual(3, rank.Progression.League);
+        Assert.AreEqual(2, rank.Progression.Division);
+        Assert.AreEqual(50, rank.Progression.Points);
+    }
+
+    [Test]
     public async Task LoadPlayersOfCountry_StampsProgression_WhenRecordExists()
     {
         // Arrange

--- a/docs/ranking.md
+++ b/docs/ranking.md
@@ -1,5 +1,7 @@
 # Progression ranking — website-backend
 
+> Read-model ingest + serving of the progression rank is documented in [ranking/README.md](ranking/README.md).
+
 website-backend serves the ranking data the website and launcher render; it does not compute rank. A new
 progression ranking system runs alongside the legacy "RP" ladder. Each game mode uses exactly one of the
 two, selected per mode by a season flag sourced from matchmaking-service.

--- a/docs/ranking/README.md
+++ b/docs/ranking/README.md
@@ -28,6 +28,20 @@ placed rank. The snapshot carries the published rank fields only:
 Read-model handlers are off by default locally (`IS_DEVELOPMENT`) — do not enable them against shared
 data.
 
+## Serving the rank to clients
+
+The read-model is surfaced on the public rank DTOs as a nullable `progression` object carrying the
+published fields only — `{ league, division, points, apexPoints }`:
+
+- `Rank.Progression` (ladder, `Ladder/Rank.cs`) — populated in `RankQueryHandler` for `api/ladder/*`.
+- `PlayerGameModeStatPerGateway.Progression` (profile, `PlayerProfiles/GameModeStats/...`) — populated
+  in `GameModeStatQueryHandler` for `api/players/{tag}/game-mode-stats`.
+
+Both stamp via `ProgressionViewLoader`, which batch-loads `PlayerProgression` by the shared composite id
+and maps it to `PlayerProgressionView`. The field is a serve-time join (`[BsonIgnore]`, never stored) and
+is `null` when the entity has no placed record for that season/mode. Additive — clients that ignore it
+keep rendering the legacy RP fields.
+
 ## Lifetime win-milestone read-model
 
 A separate, **permanent** downstream read-model tracks each player's lifetime win-milestone progress — a


### PR DESCRIPTION
## Summary
Adds a nullable `progression` object — `{ league, division, points, apexPoints }` — **alongside** the existing RP fields on the ladder (`Rank`) and player game-mode-stats (`PlayerGameModeStatPerGateway`) DTOs. Populated from the existing season-keyed `PlayerProgression` read-model as a serve-time join (never persisted; `[BsonIgnore]`), and `null` when a player has no placed progression rank for that season/mode. Additive — clients that ignore it keep rendering RP.

- New `PlayerProgressionView` (the 4 published fields) + `ProgressionViewLoader` (batch-loads the read-model by the shared composite id, maps id→view).
- Wired into the ladder query paths (`RankQueryHandler`: league, country, **search**) and the profile path (`GameModeStatQueryHandler`).
- A partial/unplaced record maps to `null` (treated as "no progression"), so `league/division/points` are always present when `progression` is set; `apexPoints` is apex-only.
- Per-repo doc updated (`docs/ranking/`).

## Tests (TDD, NUnit + Mongo2Go / IntegrationTestBase)
- `PlayerProgressionView` mapping + partial-record guard (3 branches)
- `ProgressionViewLoader` batch load + empty input
- `[BsonIgnore]` (not persisted) + JSON `progression` shape on both DTOs
- ladder league + country + search integration join; null-when-no-record; legacy RP fields untouched

Gate: `dotnet build` 0 errors · `dotnet test` **653 passed / 0 failed / 9 skipped** · `dotnet format --verify-no-changes` clean.

## Checklist
- [x] Targets `prj/new-ranking-system`
- [x] Additive — no legacy RP field/behavior changed; ranking ⊥ matchmaking; MMR untouched
- [x] TDD; gate output green (above)
- [x] Per-repo doc updated