### PR TITLE
fix(auth): tolerate unknown permission claims in JWT validation

### DIFF
--- a/W3ChampionsStatisticService/WebApi/ActionFilters/W3CAuthenticationService.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/W3CAuthenticationService.cs
@@ -50,9 +50,17 @@ public class W3CUserAuthenticationDto
         var btag = claims.Claims.First(c => c.Type == "battleTag").Value;
         var isAdmin = bool.Parse(claims.Claims.First(c => c.Type == "isAdmin").Value);
         var name = claims.Claims.First(c => c.Type == "name").Value;
+        // Keep only the permissions this service recognizes. identification-service grows its own
+        // EPermission vocabulary independently; a value this enum does not yet contain must NOT throw
+        // here. A hard Enum.Parse on an unknown permission throws ArgumentException, which propagates to
+        // every GetUserByToken caller's catch and 401s the user on ALL admin/permission/acting-player/
+        // hub endpoints — and two of those filters mask the real reason. Skip unknown values via
+        // TryParse so vocabulary drift can never lock a user out.
         var permissions = claims.Claims
             .Where(claim => claim.Type == "permissions")
-            .Select(x => Enum.Parse<EPermission>(x.Value))
+            .Select(x => Enum.TryParse<EPermission>(x.Value, out var permission) ? (EPermission?)permission : null)
+            .Where(permission => permission.HasValue)
+            .Select(permission => permission.Value)
             .ToHashSet();
 
         if (!string.IsNullOrEmpty(btag))

--- a/WC3ChampionsStatisticService.UnitTests/Auth/JwtTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Auth/JwtTests.cs
@@ -1,4 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.IdentityModel.Tokens;
 using NUnit.Framework;
+using W3C.Contracts.Admin.Permission;
 using W3ChampionsStatisticService.WebApi.ActionFilters;
 
 namespace WC3ChampionsStatisticService.Tests.Auth;
@@ -15,5 +24,74 @@ public class JwtTests
         var userByToken1 = w3CAuthenticationService.GetUserByToken(_jwt, false);
 
         Assert.AreEqual("modmoto#2809", userByToken1.BattleTag);
+    }
+
+    // ── Permission-vocabulary drift between identification-service and this service ────────
+    //
+    // identification-service grows its EPermission vocabulary independently and emits granted
+    // permissions in the JWT `permissions` claim (a JSON array, expanded into one claim per element on
+    // read). A value this service's enum does not yet contain must be IGNORED, not throw: FromJWT has no
+    // try/catch, so an Enum.Parse throw propagates to every GetUserByToken caller and 401s the user on
+    // ALL admin/permission/acting-player/hub endpoints (two of those filters mask the real reason).
+
+    /// <summary>
+    /// Builds a JWT signed with a freshly-generated RSA keypair, mirroring the claim shape the
+    /// identification-service emits — crucially the <c>permissions</c> claim as a serialized JSON array
+    /// (<see cref="JsonClaimValueTypes.JsonArray"/>), which the handler expands into one claim per
+    /// element on read. Returns the token plus the matching public-key PEM that
+    /// <see cref="W3CUserAuthenticationDto.FromJWT"/> validates against.
+    /// </summary>
+    private static (string jwt, string publicKeyPem) CreateSignedJwt(string battleTag, bool isAdmin, IEnumerable<string> permissions)
+    {
+        using var rsa = RSA.Create(2048);
+        var publicKeyPem = rsa.ExportSubjectPublicKeyInfoPem();
+
+        var signingCredentials = new SigningCredentials(new RsaSecurityKey(rsa), SecurityAlgorithms.RsaSha256)
+        {
+            CryptoProviderFactory = new CryptoProviderFactory { CacheSignatureProviders = false },
+        };
+
+        var token = new JwtSecurityToken(
+            claims: new[]
+            {
+                new Claim("battleTag", battleTag),
+                new Claim("isAdmin", isAdmin.ToString()),
+                new Claim("name", battleTag.Split('#')[0]),
+                new Claim("permissions", JsonSerializer.Serialize(permissions.ToList()), JsonClaimValueTypes.JsonArray),
+            },
+            signingCredentials: signingCredentials,
+            expires: DateTime.UtcNow.AddDays(7));
+
+        return (new JwtSecurityTokenHandler().WriteToken(token), publicKeyPem);
+    }
+
+    [Test]
+    public void FromJWT_TokenWithPermissionUnknownToThisService_StillAuthenticates()
+    {
+        // Models the next id-service-only permission this service hasn't mirrored yet.
+        var (jwt, publicKeyPem) = CreateSignedJwt("moderator#123", isAdmin: true,
+            new[] { "Moderation", "SomeFuturePermissionNotInEnum" });
+
+        var result = W3CUserAuthenticationDto.FromJWT(jwt, publicKeyPem, validateLifetime: false);
+
+        Assert.IsNotNull(result, "A user holding a permission unknown to this service must still authenticate");
+        Assert.AreEqual("moderator#123", result.BattleTag);
+        Assert.IsTrue(result.IsAdmin);
+        Assert.IsTrue(result.Permissions.Contains(EPermission.Moderation), "Known permissions must be retained");
+        Assert.AreEqual(1, result.Permissions.Count, "The unrecognized permission must be dropped, not throw");
+    }
+
+    [Test]
+    public void FromJWT_TokenWithOnlyKnownPermissions_ParsesAll()
+    {
+        // Control: proves the JSON-array claim is expanded into per-element claims and all known
+        // permissions parse. Passes both before and after the tolerant-parse fix.
+        var (jwt, publicKeyPem) = CreateSignedJwt("admin#1", isAdmin: true,
+            new[] { "Moderation", "Warnings" });
+
+        var result = W3CUserAuthenticationDto.FromJWT(jwt, publicKeyPem, validateLifetime: false);
+
+        Assert.IsNotNull(result);
+        CollectionAssert.AreEquivalent(new[] { EPermission.Moderation, EPermission.Warnings }, result.Permissions);
     }
 }


### PR DESCRIPTION
## Background

Companion to the chat-service fix (w3champions/chat-service#32). There, a user holding a permission the service's `EPermission` enum didn't contain could not authenticate, because `FromJWT` ran `Enum.Parse<EPermission>` over the JWT `permissions` claim and threw on the unknown value.

website-backend has the **same latent pattern** in `W3CUserAuthenticationDto.FromJWT`:

```csharp
.Select(x => Enum.Parse<EPermission>(x.Value))
```

## Why it isn't broken today — and why it's worse when it breaks

It isn't currently triggered only because this service's enum already contains every permission identification-service issues (it owns the admin features that define them). But the moment identification-service grants a permission this enum hasn't mirrored yet, `Enum.Parse` throws `ArgumentException`.

Unlike chat-service, `FromJWT` here has **no try/catch**, so the throw propagates to **every** `GetUserByToken` caller:

- `WebsiteBackendHub`
- `BearerHasPermissionFilter`
- `CheckIfBattleTagIsAdminFilter`
- `InjectActingPlayerFromAuthCodeFilter`
- `BearerCheckIfBattleTagBelongsToAuthFilter`

Each wraps the call in `catch (Exception)` → **401**. So an affected user is locked out of all admin / permission / acting-player / hub endpoints at once — and two of those filters return a generic `"Sorry H4ckerb0i"` with no log of the real reason, so it would be hard to diagnose.

## Fix

Parse permissions tolerantly with `Enum.TryParse` and skip unrecognized values, so identification-service growing its permission vocabulary can never lock a user out. No try/catch is added — genuinely-invalid tokens still throw and are handled as 401 by the existing callers, which is the intended behaviour.

## Tests

Added to `Auth/JwtTests.cs` (self-contained — builds a JWT with a test RSA keypair mirroring the real `JsonClaimValueTypes.JsonArray` claim shape):

- `FromJWT_TokenWithPermissionUnknownToThisService_StillAuthenticates` — models the next drift with a synthetic `"SomeFuturePermissionNotInEnum"` (since `Warnings` is already known here). **RED before this change** (threw `ArgumentException: Requested value 'SomeFuturePermissionNotInEnum' was not found.`), green after.
- `FromJWT_TokenWithOnlyKnownPermissions_ParsesAll` — control; proves the JSON-array claim expands into per-element claims.

`Auth.JwtTests` 3/3 green (scoped to avoid the shared-remote-Mongo integration suites). `dotnet format` clean.