### PR TITLE
feat(progression): apex leaderboard + progression league ladder endpoints (P11-4)

### DIFF
--- a/W3C.Domain/MatchmakingService/ApexStandingsEventDtos.cs
+++ b/W3C.Domain/MatchmakingService/ApexStandingsEventDtos.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using MongoDB.Bson.Serialization.Attributes;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+
+namespace W3C.Domain.MatchmakingService;
+
+[BsonIgnoreExtraElements]
+[BsonNoId]
+public class ApexStandingsChangedEvent : ISyncable
+{
+    [BsonElement("_id")]
+    public int id { get; set; }
+    public int season { get; set; }
+    public GameMode gameMode { get; set; }
+    public int? cutoffApexPoints { get; set; }
+    public int gmCount { get; set; }
+    public ApexStandingRaw[] players { get; set; }
+    public bool wasSyncedJustNow { get; set; }
+}
+
+[BsonIgnoreExtraElements]
+[BsonNoId]
+public class ApexStandingRaw
+{
+    public List<string> battleTags { get; set; }
+    public Race? race { get; set; }
+    public int apexPoints { get; set; }
+    public int league { get; set; }
+}

--- a/W3C.Domain/Repositories/Contracts/IMatchEventRepository.cs
+++ b/W3C.Domain/Repositories/Contracts/IMatchEventRepository.cs
@@ -12,5 +12,6 @@ public interface IMatchEventRepository
     Task<bool> InsertIfNotExisting(MatchFinishedEvent matchFinishedEvent, int i = 0);
     Task<List<RankingChangedEvent>> CheckoutForRead();
     Task<List<LeagueConstellationChangedEvent>> LoadLeagueConstellationChanged();
+    Task<List<ApexStandingsChangedEvent>> CheckoutApexStandingsChanged();
     Task DeleteStartedEvent(ObjectId nextEventId);
 }

--- a/W3C.Domain/Repositories/MatchEventRepository.cs
+++ b/W3C.Domain/Repositories/MatchEventRepository.cs
@@ -71,6 +71,11 @@ public class MatchEventRepository(MongoClient mongoClient) : MongoDbRepositoryBa
         return Checkout<LeagueConstellationChangedEvent>();
     }
 
+    public Task<List<ApexStandingsChangedEvent>> CheckoutApexStandingsChanged()
+    {
+        return Checkout<ApexStandingsChangedEvent>();
+    }
+
     public Task DeleteStartedEvent(ObjectId nextEventId)
     {
         return Delete<MatchStartedEvent>(e => e.Id == nextEventId);

--- a/W3ChampionsStatisticService/Ladder/ApexLeaderboard.cs
+++ b/W3ChampionsStatisticService/Ladder/ApexLeaderboard.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.Repositories;
+
+namespace W3ChampionsStatisticService.Ladder;
+
+public class ApexLeaderboard : IIdentifiable
+{
+    public string Id { get; set; }
+    public int Season { get; set; }
+    public GameMode GameMode { get; set; }
+    public int? CutoffApexPoints { get; set; }
+    public int GmCount { get; set; }
+    public List<ApexLeaderboardEntry> Players { get; set; }
+}
+
+public class ApexLeaderboardEntry
+{
+    public List<string> BattleTags { get; set; }
+    public Race? Race { get; set; }
+    public int ApexPoints { get; set; }
+    public int League { get; set; }
+    public int RankNumber { get; set; }
+}

--- a/W3ChampionsStatisticService/Ladder/ApexLeaderboardRepository.cs
+++ b/W3ChampionsStatisticService/Ladder/ApexLeaderboardRepository.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
+
+namespace W3ChampionsStatisticService.Ladder;
+
+[Trace]
+public class ApexLeaderboardRepository(MongoClient mongoClient)
+    : MongoDbRepositoryBase(mongoClient), IApexLeaderboardRepository
+{
+    public Task UpsertOne(ApexLeaderboard leaderboard)
+    {
+        return Upsert(leaderboard);
+    }
+
+    public Task<ApexLeaderboard> LoadApexLeaderboard(int season, GameMode gameMode)
+    {
+        var id = $"{season}_{(int)gameMode}";
+        return LoadFirst<ApexLeaderboard>(id);
+    }
+}

--- a/W3ChampionsStatisticService/Ladder/ApexLeaderboardResponse.cs
+++ b/W3ChampionsStatisticService/Ladder/ApexLeaderboardResponse.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace W3ChampionsStatisticService.Ladder;
+
+public class ApexLeaderboardResponse
+{
+    public int? CutoffApexPoints { get; set; }
+    public int GmCount { get; set; }
+    public List<ApexLeaderboardRow> Players { get; set; } = new List<ApexLeaderboardRow>();
+}

--- a/W3ChampionsStatisticService/Ladder/ApexLeaderboardRow.cs
+++ b/W3ChampionsStatisticService/Ladder/ApexLeaderboardRow.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace W3ChampionsStatisticService.Ladder;
+
+public class ApexLeaderboardRow
+{
+    public List<PlayerInfo> PlayersInfo { get; set; } = new List<PlayerInfo>();
+    public int ApexPoints { get; set; }
+    public int League { get; set; }
+    public int RankNumber { get; set; }
+}

--- a/W3ChampionsStatisticService/Ladder/ApexSyncHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/ApexSyncHandler.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using W3C.Domain.Repositories;
+using W3ChampionsStatisticService.ReadModelBase;
+using W3C.Domain.Tracing;
+
+namespace W3ChampionsStatisticService.Ladder;
+
+[Trace]
+public class ApexSyncHandler(
+    IApexLeaderboardRepository apexLeaderboardRepository,
+    IMatchEventRepository matchEventRepository
+) : IAsyncUpdatable
+{
+    private readonly IApexLeaderboardRepository _apexLeaderboardRepository = apexLeaderboardRepository;
+    private readonly IMatchEventRepository _matchEventRepository = matchEventRepository;
+
+    public async Task Update()
+    {
+        var events = await _matchEventRepository.CheckoutApexStandingsChanged();
+
+        foreach (var ev in events)
+        {
+            var players = ev.players?
+                .Select((raw, index) => new ApexLeaderboardEntry
+                {
+                    BattleTags = raw.battleTags ?? new List<string>(),
+                    Race = raw.race,
+                    ApexPoints = raw.apexPoints,
+                    League = raw.league,
+                    RankNumber = index + 1,
+                })
+                .ToList() ?? new List<ApexLeaderboardEntry>();
+
+            var leaderboard = new ApexLeaderboard
+            {
+                Id = $"{ev.season}_{(int)ev.gameMode}",
+                Season = ev.season,
+                GameMode = ev.gameMode,
+                CutoffApexPoints = ev.cutoffApexPoints,
+                GmCount = ev.gmCount,
+                Players = players,
+            };
+
+            await _apexLeaderboardRepository.UpsertOne(leaderboard);
+        }
+    }
+}

--- a/W3ChampionsStatisticService/Ladder/IApexLeaderboardRepository.cs
+++ b/W3ChampionsStatisticService/Ladder/IApexLeaderboardRepository.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using W3C.Contracts.Matchmaking;
+
+namespace W3ChampionsStatisticService.Ladder;
+
+public interface IApexLeaderboardRepository
+{
+    Task UpsertOne(ApexLeaderboard leaderboard);
+    Task<ApexLeaderboard> LoadApexLeaderboard(int season, GameMode gameMode);
+}

--- a/W3ChampionsStatisticService/Ladder/LadderController.cs
+++ b/W3ChampionsStatisticService/Ladder/LadderController.cs
@@ -65,6 +65,22 @@ public class LadderController(
         return Ok(playersInLadder);
     }
 
+    [HttpGet("apex")]
+    public async Task<IActionResult> GetApexLeaderboard(int season, GameMode gameMode = GameMode.GM_1v1)
+    {
+        var leaderboard = await _rankQueryHandler.LoadApexLeaderboard(season, gameMode);
+
+        foreach (var row in leaderboard.Players)
+        {
+            foreach (var playerInfo in row.PlayersInfo)
+            {
+                playerInfo.PlayerAkaData = await _playerAkaProvider.GetPlayerAkaDataAsync(playerInfo.BattleTag.ToLower());
+            }
+        }
+
+        return Ok(leaderboard);
+    }
+
     [HttpGet("country/{countryCode}")]
     public async Task<IActionResult> GetCountryLadder([FromRoute] string countryCode, int season, GateWay gateWay = GateWay.Europe, GameMode gameMode = GameMode.GM_1v1)
     {

--- a/W3ChampionsStatisticService/Ladder/LadderController.cs
+++ b/W3ChampionsStatisticService/Ladder/LadderController.cs
@@ -2,7 +2,9 @@
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.Services;
 using W3C.Domain.Tracing;
@@ -79,6 +81,29 @@ public class LadderController(
         }
 
         return Ok(leaderboard);
+    }
+
+    [HttpGet("progression")]
+    public async Task<IActionResult> GetProgressionLadder(
+        int season,
+        GameMode gameMode = GameMode.GM_1v1,
+        int league = (int)ProgressionLeague.Adept,
+        int division = 1,
+        Race? race = null,
+        int skip = 0,
+        int take = 100)
+    {
+        var ladder = await _rankQueryHandler.LoadProgressionLadder(season, gameMode, league, division, race, skip, take);
+
+        foreach (var rank in ladder)
+        {
+            foreach (var playerInfo in rank.PlayersInfo)
+            {
+                playerInfo.PlayerAkaData = await _playerAkaProvider.GetPlayerAkaDataAsync(playerInfo.BattleTag.ToLower());
+            }
+        }
+
+        return Ok(ladder);
     }
 
     [HttpGet("country/{countryCode}")]

--- a/W3ChampionsStatisticService/Ladder/RankQueryHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/RankQueryHandler.cs
@@ -2,6 +2,8 @@
 using System.Linq;
 using System.Threading.Tasks;
 using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.Clans;
+using W3ChampionsStatisticService.PlayerProfiles;
 using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 using W3ChampionsStatisticService.Ports;
 using W3C.Domain.Tracing;
@@ -13,12 +15,14 @@ public class RankQueryHandler(
     IRankRepository rankRepository,
     IPlayerRepository playerRepository,
     IClanRepository clanRepository,
-    ProgressionViewLoader progressionViewLoader)
+    ProgressionViewLoader progressionViewLoader,
+    IApexLeaderboardRepository apexLeaderboardRepository)
 {
     private readonly IRankRepository _rankRepository = rankRepository;
     private readonly IPlayerRepository _playerRepository = playerRepository;
     private readonly IClanRepository _clanRepository = clanRepository;
     private readonly ProgressionViewLoader _progressionViewLoader = progressionViewLoader;
+    private readonly IApexLeaderboardRepository _apexLeaderboardRepository = apexLeaderboardRepository;
 
     public async Task<List<Rank>> SearchPlayersOfLeague(string searchFor, int season, GateWay gateWay, GameMode gameMode)
     {
@@ -62,48 +66,111 @@ public class RankQueryHandler(
 
     private async Task PopulatePlayerInfos(List<Rank> ranks)
     {
-        var playerIds = ranks
+        var battleTags = ranks
             .SelectMany(x => x.Player.PlayerIds)
             .Select(x => x.BattleTag)
             .ToList();
 
-        var raceWinRates = (await _playerRepository.LoadPlayersRaceWins(playerIds))
-            .ToDictionary(x => x.Id);
-
-        var clanMemberships = (await _clanRepository.LoadMemberShips(playerIds))
-            .ToDictionary(x => x.Id);
+        var (raceWinRates, clanMemberships) = await LoadEnrichmentSources(battleTags);
 
         foreach (var rank in ranks)
         {
+            // Rank.PlayersInfo is [BsonIgnore] with a property initializer, so it is never null in
+            // practice; the ??= is a defensive guard kept for clarity after the enrichment refactor.
+            rank.PlayersInfo ??= new List<PlayerInfo>();
             foreach (var playerId in rank.Player.PlayerIds)
             {
-                clanMemberships.TryGetValue(playerId.BattleTag, out var membership);
-                if (raceWinRates.TryGetValue(playerId.BattleTag, out var playerDetails))
+                var info = BuildPlayerInfo(playerId.BattleTag, raceWinRates, clanMemberships);
+                if (info != null)
                 {
-                    if (rank.PlayersInfo == null)
-                    {
-                        rank.PlayersInfo = new List<PlayerInfo>();
-                    }
-
-                    var personalSettings = playerDetails.PersonalSettings?.FirstOrDefault();
-                    var profilePicture = personalSettings?.ProfilePicture;
-
-                    rank.PlayersInfo.Add(new PlayerInfo()
-                    {
-                        BattleTag = playerId.BattleTag,
-                        CalculatedRace = playerDetails.GetMainRace(),
-                        PictureId = profilePicture?.PictureId,
-                        isClassicPicture = profilePicture?.IsClassic ?? false,
-                        SelectedRace = profilePicture?.Race,
-                        Country = personalSettings?.Country,
-                        CountryCode = personalSettings?.CountryCode,
-                        Location = personalSettings?.Location,
-                        TwitchName = personalSettings?.Twitch,
-                        ClanId = membership?.ClanId
-                    });
+                    rank.PlayersInfo.Add(info);
                 }
             }
         }
+    }
+
+    private async Task<(Dictionary<string, PlayerDetails> raceWinRates, Dictionary<string, ClanMembership> clanMemberships)>
+        LoadEnrichmentSources(List<string> battleTags)
+    {
+        var raceWinRates = (await _playerRepository.LoadPlayersRaceWins(battleTags))
+            .ToDictionary(x => x.Id);
+
+        var clanMemberships = (await _clanRepository.LoadMemberShips(battleTags))
+            .ToDictionary(x => x.Id);
+
+        return (raceWinRates, clanMemberships);
+    }
+
+    private static PlayerInfo BuildPlayerInfo(
+        string battleTag,
+        Dictionary<string, PlayerDetails> raceWinRates,
+        Dictionary<string, ClanMembership> clanMemberships)
+    {
+        if (!raceWinRates.TryGetValue(battleTag, out var playerDetails))
+        {
+            return null;
+        }
+
+        clanMemberships.TryGetValue(battleTag, out var membership);
+
+        var personalSettings = playerDetails.PersonalSettings?.FirstOrDefault();
+        var profilePicture = personalSettings?.ProfilePicture;
+
+        return new PlayerInfo
+        {
+            BattleTag = battleTag,
+            CalculatedRace = playerDetails.GetMainRace(),
+            PictureId = profilePicture?.PictureId,
+            isClassicPicture = profilePicture?.IsClassic ?? false,
+            SelectedRace = profilePicture?.Race,
+            Country = personalSettings?.Country,
+            CountryCode = personalSettings?.CountryCode,
+            Location = personalSettings?.Location,
+            TwitchName = personalSettings?.Twitch,
+            ClanId = membership?.ClanId,
+        };
+    }
+
+    public async Task<ApexLeaderboardResponse> LoadApexLeaderboard(int season, GameMode gameMode)
+    {
+        var leaderboard = await _apexLeaderboardRepository.LoadApexLeaderboard(season, gameMode);
+
+        if (leaderboard?.Players == null || leaderboard.Players.Count == 0)
+        {
+            return new ApexLeaderboardResponse
+            {
+                CutoffApexPoints = leaderboard?.CutoffApexPoints,
+                GmCount = leaderboard?.GmCount ?? 0,
+                Players = new List<ApexLeaderboardRow>(),
+            };
+        }
+
+        var battleTags = leaderboard.Players
+            .SelectMany(p => p.BattleTags ?? new List<string>())
+            .Distinct()
+            .ToList();
+
+        var (raceWinRates, clanMemberships) = await LoadEnrichmentSources(battleTags);
+
+        var rows = leaderboard.Players
+            .Select(entry => new ApexLeaderboardRow
+            {
+                ApexPoints = entry.ApexPoints,
+                League = entry.League,
+                RankNumber = entry.RankNumber,
+                PlayersInfo = (entry.BattleTags ?? new List<string>())
+                    .Select(tag => BuildPlayerInfo(tag, raceWinRates, clanMemberships))
+                    .Where(info => info != null)
+                    .ToList(),
+            })
+            .ToList();
+
+        return new ApexLeaderboardResponse
+        {
+            CutoffApexPoints = leaderboard.CutoffApexPoints,
+            GmCount = leaderboard.GmCount,
+            Players = rows,
+        };
     }
 
 

--- a/W3ChampionsStatisticService/Ladder/RankQueryHandler.cs
+++ b/W3ChampionsStatisticService/Ladder/RankQueryHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.Clans;
 using W3ChampionsStatisticService.PlayerProfiles;
@@ -16,13 +17,15 @@ public class RankQueryHandler(
     IPlayerRepository playerRepository,
     IClanRepository clanRepository,
     ProgressionViewLoader progressionViewLoader,
-    IApexLeaderboardRepository apexLeaderboardRepository)
+    IApexLeaderboardRepository apexLeaderboardRepository,
+    IPlayerProgressionRepository playerProgressionRepository)
 {
     private readonly IRankRepository _rankRepository = rankRepository;
     private readonly IPlayerRepository _playerRepository = playerRepository;
     private readonly IClanRepository _clanRepository = clanRepository;
     private readonly ProgressionViewLoader _progressionViewLoader = progressionViewLoader;
     private readonly IApexLeaderboardRepository _apexLeaderboardRepository = apexLeaderboardRepository;
+    private readonly IPlayerProgressionRepository _playerProgressionRepository = playerProgressionRepository;
 
     public async Task<List<Rank>> SearchPlayersOfLeague(string searchFor, int season, GateWay gateWay, GameMode gameMode)
     {
@@ -171,6 +174,66 @@ public class RankQueryHandler(
             GmCount = leaderboard.GmCount,
             Players = rows,
         };
+    }
+
+    // Non-apex (Adept..Grass) progression ladder, served directly from the already-fresh
+    // PlayerProgression read-model. Returns the same Rank shape as GET /api/ladder/{leagueId}
+    // so the website's existing grid renders it unchanged: each row carries the Progression view
+    // (league/division/points/apexPoints) and enriched PlayersInfo; RP-only fields stay at default.
+    // Upper bound on a single progression-ladder page so a caller cannot request an unbounded
+    // number of enriched rows (each row triggers player-detail/clan lookups).
+    private const int MaxProgressionLadderTake = 500;
+
+    public async Task<List<Rank>> LoadProgressionLadder(
+        int season, GameMode gameMode, int league, int division, Race? race, int skip, int take)
+    {
+        skip = System.Math.Max(skip, 0);
+        take = System.Math.Min(take, MaxProgressionLadderTake);
+
+        var progressions = await _playerProgressionRepository
+            .LoadPlayersByProgressionLeague(season, gameMode, league, division, race, skip, take);
+
+        if (progressions.Count == 0)
+        {
+            return new List<Rank>();
+        }
+
+        var battleTags = progressions
+            .SelectMany(p => p.PlayerIds.Select(id => id.BattleTag))
+            .Distinct()
+            .ToList();
+
+        var (raceWinRates, clanMemberships) = await LoadEnrichmentSources(battleTags);
+
+        // The repository already returns rows sorted by Points desc; RankNumber follows that order.
+        // It is the GLOBAL rank across the league/division, so it is offset by the page's skip.
+        return progressions
+            .Select((progression, index) =>
+            {
+                // Rank.Players (the joined PlayerOverview) is deliberately left unpopulated on this
+                // path: progression rows carry only battleTags, and consumers read PlayersInfo, not
+                // Player/Players. The Rank.Player computed property therefore serializes as null by
+                // design — that is expected here, not a missing-data bug.
+                var rank = new Rank(
+                    progression.PlayerIds.Select(id => id.BattleTag).ToList(),
+                    progression.League ?? league,
+                    skip + index + 1,
+                    0,
+                    progression.Race,
+                    progression.GateWay,
+                    progression.GameMode,
+                    progression.Season)
+                {
+                    Progression = PlayerProgressionView.FromReadModel(progression),
+                    PlayersInfo = progression.PlayerIds
+                        .Select(id => BuildPlayerInfo(id.BattleTag, raceWinRates, clanMemberships))
+                        .Where(info => info != null)
+                        .ToList(),
+                };
+
+                return rank;
+            })
+            .ToList();
     }
 
 

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/PlayerProgressionRepository.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Driver;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
 using W3C.Domain.Repositories;
 using W3C.Domain.Tracing;
 using W3ChampionsStatisticService.Ports;
@@ -10,8 +12,14 @@ namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 
 [Trace]
 public class PlayerProgressionRepository(MongoClient mongoClient)
-    : MongoDbRepositoryBase(mongoClient), IPlayerProgressionRepository
+    : MongoDbRepositoryBase(mongoClient), IPlayerProgressionRepository, IRequiresIndexes
 {
+    // Grand Master and Master are the apex leagues; they are served by the dedicated
+    // /api/ladder/apex endpoint, not the per-league progression ladder below.
+    private static bool IsApexLeague(int league) => league < (int)ProgressionLeague.Adept;
+
+    public string CollectionName => nameof(PlayerProgression);
+
     public Task<PlayerProgression> LoadProgression(string id)
     {
         return LoadFirst<PlayerProgression>(id);
@@ -25,5 +33,58 @@ public class PlayerProgressionRepository(MongoClient mongoClient)
     public Task<List<PlayerProgression>> LoadProgressions(IReadOnlyList<string> ids)
     {
         return LoadAll<PlayerProgression>(p => ids.Contains(p.Id));
+    }
+
+    public async Task<List<PlayerProgression>> LoadPlayersByProgressionLeague(
+        int season, GameMode gameMode, int league, int division, Race? race, int skip, int take)
+    {
+        // Apex leagues are served elsewhere; never page their docs through the per-league ladder.
+        if (IsApexLeague(league))
+        {
+            return new List<PlayerProgression>();
+        }
+
+        var builder = Builders<PlayerProgression>.Filter;
+        var filter = builder.Eq(p => p.Season, season)
+            & builder.Eq(p => p.GameMode, gameMode)
+            & builder.Eq(p => p.League, league)
+            & builder.Eq(p => p.Division, division);
+
+        if (race != null)
+        {
+            filter &= builder.Eq(p => p.Race, race);
+        }
+
+        var collection = CreateCollection<PlayerProgression>();
+        return await collection
+            .Find(filter)
+            .SortByDescending(p => p.Points)
+            .Skip(skip)
+            .Limit(take)
+            .ToListAsync();
+    }
+
+    public async Task EnsureIndexesAsync()
+    {
+        var collection = CreateCollection<PlayerProgression>();
+
+        var keys = Builders<PlayerProgression>.IndexKeys
+            .Ascending(p => p.Season)
+            .Ascending(p => p.GameMode)
+            .Ascending(p => p.League)
+            .Ascending(p => p.Division)
+            .Ascending(p => p.Race)
+            .Descending(p => p.Points);
+
+        var indexes = new List<CreateIndexModel<PlayerProgression>>
+        {
+            // Compound index backing LoadPlayersByProgressionLeague: equality on
+            // Season/GameMode/League/Division/Race, then Points descending for the ranked sort.
+            // Without it the per-league ladder query would COLLSCAN a collection that grows one
+            // document per entity/mode/race.
+            new(keys),
+        };
+
+        await collection.Indexes.CreateManyAsync(indexes);
     }
 }

--- a/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionLeague.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/ProgressionStats/ProgressionLeague.cs
@@ -1,0 +1,20 @@
+namespace W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+/// <summary>
+/// Authoritative encoding of a progression league. Lower value = higher rank
+/// (<see cref="GrandMaster"/> = 0 .. <see cref="Grass"/> = 8). <see cref="GrandMaster"/> and
+/// <see cref="Master"/> are the apex leagues. This mirrors the encoding documented on
+/// <see cref="PrestigeRankComparer"/>; the published <c>league</c> field is the integer value below.
+/// </summary>
+public enum ProgressionLeague
+{
+    GrandMaster = 0,
+    Master = 1,
+    Adept = 2,
+    Diamond = 3,
+    Platinum = 4,
+    Gold = 5,
+    Silver = 6,
+    Bronze = 7,
+    Grass = 8,
+}

--- a/W3ChampionsStatisticService/Ports/IPlayerProgressionRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IPlayerProgressionRepository.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
 
 namespace W3ChampionsStatisticService.Ports;
@@ -9,4 +11,6 @@ public interface IPlayerProgressionRepository
     Task<PlayerProgression> LoadProgression(string id);
     Task UpsertProgression(PlayerProgression progression);
     Task<List<PlayerProgression>> LoadProgressions(IReadOnlyList<string> ids);
+    Task<List<PlayerProgression>> LoadPlayersByProgressionLeague(
+        int season, GameMode gameMode, int league, int division, Race? race, int skip, int take);
 }

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -163,6 +163,8 @@ builder.Services.AddInterceptedTransient<IMatchRepository, MatchRepository>();
 builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexes, MatchRepository>();
 builder.Services.AddInterceptedSingleton<IPlayerRepository, PlayerRepository>();
 builder.Services.AddInterceptedTransient<IPlayerProgressionRepository, PlayerProgressionRepository>();
+// Ensure PlayerProgression indexes are created at startup (compound index for the per-league progression ladder query)
+builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexes, PlayerProgressionRepository>();
 builder.Services.AddInterceptedTransient<IProgressionMilestoneRepository, ProgressionMilestoneRepository>();
 // Ensure ProgressionMilestone indexes are created at startup (multikey on PlayerIds.BattleTag for the owner read)
 builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexes, ProgressionMilestoneRepository>();

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -170,6 +170,7 @@ builder.Services.AddInterceptedTransient<IProgressionPrestigeRepository, Progres
 builder.Services.AddInterceptedTransient<ProgressionViewLoader>();
 builder.Services.AddInterceptedTransient<MilestoneQueryHandler>();
 builder.Services.AddInterceptedTransient<IRankRepository, RankRepository>();
+builder.Services.AddInterceptedTransient<IApexLeaderboardRepository, ApexLeaderboardRepository>();
 builder.Services.AddInterceptedTransient<IPlayerStatsRepository, PlayerStatsRepository>();
 builder.Services.AddInterceptedTransient<IW3StatsRepo, W3StatsRepo>();
 builder.Services.AddInterceptedTransient<IPatchRepository, PatchRepository>();
@@ -290,6 +291,7 @@ if (startHandlers == "true")
 
     builder.Services.AddUnversionedReadModelService<RankSyncHandler>();
     builder.Services.AddUnversionedReadModelService<LeagueSyncHandler>();
+    builder.Services.AddUnversionedReadModelService<ApexSyncHandler>();
 }
 
 var runBackfill = System.Environment.GetEnvironmentVariable("RUN_BACKFILL");

--- a/WC3ChampionsStatisticService.UnitTests/Ladder/ApexLeaderboardQueryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ladder/ApexLeaderboardQueryTests.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.CommonValueObjects;
+using W3ChampionsStatisticService.Clans;
+using W3ChampionsStatisticService.Ladder;
+using W3ChampionsStatisticService.PersonalSettings;
+using W3ChampionsStatisticService.PlayerProfiles;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.Tests.Ladder;
+
+[TestFixture]
+public class ApexLeaderboardQueryTests : IntegrationTestBase
+{
+    private RankQueryHandler CreateQueryHandler()
+    {
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+        var clanRepository = new ClanRepository(MongoClient);
+        var progressionViewLoader = new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient));
+        var apexLeaderboardRepository = new ApexLeaderboardRepository(MongoClient);
+        return new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader, apexLeaderboardRepository);
+    }
+
+    private async Task SeedPlayer(string battleTag, AvatarCategory pictureRace, long pictureId, string country)
+    {
+        var playerRepository = new PlayerRepository(MongoClient);
+        var personalSettingsRepository = new PersonalSettingsRepository(MongoClient);
+
+        await playerRepository.UpsertPlayer(new PlayerOverallStats { BattleTag = battleTag });
+        await personalSettingsRepository.Save(new PersonalSetting(battleTag)
+        {
+            ProfilePicture = new ProfilePicture { Race = pictureRace, PictureId = pictureId },
+            Country = country,
+        });
+    }
+
+    [Test]
+    public async Task LoadApexLeaderboard_ReturnsEnrichedRows_GmFirstInRankOrder_WithCutoffAndGmCount()
+    {
+        // Arrange: seed an ApexLeaderboard doc (2 GM league=0, 1 Master league=1) + matching player rows
+        var apexRepository = new ApexLeaderboardRepository(MongoClient);
+        await apexRepository.UpsertOne(new ApexLeaderboard
+        {
+            Id = "22_1",
+            Season = 22,
+            GameMode = GameMode.GM_1v1,
+            CutoffApexPoints = 900,
+            GmCount = 2,
+            Players = new List<ApexLeaderboardEntry>
+            {
+                new() { BattleTags = new List<string> { "alpha#1" }, Race = Race.HU, ApexPoints = 1200, League = 0, RankNumber = 1 },
+                new() { BattleTags = new List<string> { "beta#2" },  Race = Race.NE, ApexPoints = 1000, League = 0, RankNumber = 2 },
+                new() { BattleTags = new List<string> { "gamma#3" }, Race = Race.UD, ApexPoints = 850,  League = 1, RankNumber = 3 },
+            },
+        });
+
+        await SeedPlayer("alpha#1", AvatarCategory.HU, 5, "BG");
+        await SeedPlayer("beta#2", AvatarCategory.NE, 7, "US");
+        await SeedPlayer("gamma#3", AvatarCategory.UD, 9, "DE");
+
+        var queryHandler = CreateQueryHandler();
+
+        // Act
+        var result = await queryHandler.LoadApexLeaderboard(22, GameMode.GM_1v1);
+
+        // Assert: envelope cohort fields
+        Assert.IsNotNull(result);
+        Assert.AreEqual(900, result.CutoffApexPoints);
+        Assert.AreEqual(2, result.GmCount);
+        Assert.AreEqual(3, result.Players.Count);
+
+        // GM-first in rankNumber order
+        Assert.AreEqual(1, result.Players[0].RankNumber);
+        Assert.AreEqual(0, result.Players[0].League);
+        Assert.AreEqual(1200, result.Players[0].ApexPoints);
+        Assert.AreEqual(2, result.Players[1].RankNumber);
+        Assert.AreEqual(3, result.Players[2].RankNumber);
+        Assert.AreEqual(1, result.Players[2].League);
+
+        // Enrichment: PlayersInfo populated from battleTag → personal settings
+        var top = result.Players[0];
+        Assert.AreEqual(1, top.PlayersInfo.Count);
+        Assert.AreEqual("alpha#1", top.PlayersInfo[0].BattleTag);
+        Assert.AreEqual(AvatarCategory.HU, top.PlayersInfo[0].SelectedRace);
+        Assert.AreEqual(5, top.PlayersInfo[0].PictureId);
+        Assert.AreEqual("BG", top.PlayersInfo[0].Country);
+
+        Assert.AreEqual("beta#2", result.Players[1].PlayersInfo[0].BattleTag);
+        Assert.AreEqual("US", result.Players[1].PlayersInfo[0].Country);
+    }
+
+    [Test]
+    public async Task LoadApexLeaderboard_PreservesAtTeamBattleTags()
+    {
+        var apexRepository = new ApexLeaderboardRepository(MongoClient);
+        await apexRepository.UpsertOne(new ApexLeaderboard
+        {
+            Id = "22_6",
+            Season = 22,
+            GameMode = GameMode.GM_2v2_AT,
+            CutoffApexPoints = 800,
+            GmCount = 1,
+            Players = new List<ApexLeaderboardEntry>
+            {
+                new() { BattleTags = new List<string> { "team-a#1", "team-a#2" }, Race = null, ApexPoints = 1100, League = 0, RankNumber = 1 },
+            },
+        });
+
+        await SeedPlayer("team-a#1", AvatarCategory.HU, 1, "BG");
+        await SeedPlayer("team-a#2", AvatarCategory.OC, 2, "PL");
+
+        var queryHandler = CreateQueryHandler();
+
+        var result = await queryHandler.LoadApexLeaderboard(22, GameMode.GM_2v2_AT);
+
+        Assert.AreEqual(1, result.Players.Count);
+        Assert.AreEqual(2, result.Players[0].PlayersInfo.Count);
+        var tags = result.Players[0].PlayersInfo.Select(p => p.BattleTag).ToList();
+        CollectionAssert.Contains(tags, "team-a#1");
+        CollectionAssert.Contains(tags, "team-a#2");
+    }
+
+    [Test]
+    public async Task LoadApexLeaderboard_ReturnsEmptyEnvelope_WhenNoDocForMode()
+    {
+        var queryHandler = CreateQueryHandler();
+
+        var result = await queryHandler.LoadApexLeaderboard(99, GameMode.GM_1v1);
+
+        Assert.IsNotNull(result);
+        Assert.IsNull(result.CutoffApexPoints);
+        Assert.AreEqual(0, result.GmCount);
+        Assert.IsNotNull(result.Players);
+        Assert.IsEmpty(result.Players);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Ladder/ApexLeaderboardQueryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ladder/ApexLeaderboardQueryTests.cs
@@ -23,7 +23,8 @@ public class ApexLeaderboardQueryTests : IntegrationTestBase
         var clanRepository = new ClanRepository(MongoClient);
         var progressionViewLoader = new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient));
         var apexLeaderboardRepository = new ApexLeaderboardRepository(MongoClient);
-        return new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader, apexLeaderboardRepository);
+        var playerProgressionRepository = new PlayerProgressionRepository(MongoClient);
+        return new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader, apexLeaderboardRepository, playerProgressionRepository);
     }
 
     private async Task SeedPlayer(string battleTag, AvatarCategory pictureRace, long pictureId, string country)

--- a/WC3ChampionsStatisticService.UnitTests/Ladder/ApexLeaderboardTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ladder/ApexLeaderboardTests.cs
@@ -1,0 +1,315 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.MatchmakingService;
+using W3C.Domain.Repositories;
+using W3ChampionsStatisticService.Ladder;
+
+namespace WC3ChampionsStatisticService.Tests.Ladder;
+
+[TestFixture]
+public class ApexLeaderboardTests : IntegrationTestBase
+{
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private async Task InsertApexStandingsEvent(ApexStandingsChangedEvent ev)
+    {
+        var db = MongoClient.GetDatabase("W3Champions-Statistic-Service");
+        var col = db.GetCollection<ApexStandingsChangedEvent>(nameof(ApexStandingsChangedEvent));
+        await col.FindOneAndReplaceAsync<ApexStandingsChangedEvent>(
+            e => e.id == ev.id,
+            ev,
+            new FindOneAndReplaceOptions<ApexStandingsChangedEvent> { IsUpsert = true });
+    }
+
+    private static ApexStandingsChangedEvent MakeEvent(
+        int season,
+        GameMode gameMode,
+        bool wasSynced = false,
+        int? cutoff = 800,
+        int gmCount = 2)
+    {
+        int id = season * 100000 + (int)gameMode;
+        return new ApexStandingsChangedEvent
+        {
+            id = id,
+            season = season,
+            gameMode = gameMode,
+            cutoffApexPoints = cutoff,
+            gmCount = gmCount,
+            wasSyncedJustNow = wasSynced,
+            players = new[]
+            {
+                new ApexStandingRaw { battleTags = new List<string> { "alpha#1" },         race = Race.HU, apexPoints = 1000, league = 0 },
+                new ApexStandingRaw { battleTags = new List<string> { "beta#2" },          race = Race.NE, apexPoints = 900,  league = 0 },
+                new ApexStandingRaw { battleTags = new List<string> { "gamma#3", "delta#4" }, race = null, apexPoints = 850, league = 1 },
+                new ApexStandingRaw { battleTags = new List<string> { "epsilon#5" },        race = Race.UD, apexPoints = 820, league = 1 },
+                new ApexStandingRaw { battleTags = new List<string> { "zeta#6" },           race = Race.OC, apexPoints = 810, league = 1 },
+            },
+        };
+    }
+
+    // ── Checkout tests ────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Checkout_ReturnsOnlyUnsyncedEvents_AndMarksThem()
+    {
+        // Arrange — one unsynced, one already-synced
+        var unsynced = MakeEvent(season: 22, gameMode: GameMode.GM_1v1, wasSynced: false);
+        var synced = MakeEvent(season: 22, gameMode: GameMode.GM_2v2, wasSynced: true);
+
+        await InsertApexStandingsEvent(unsynced);
+        await InsertApexStandingsEvent(synced);
+
+        var repo = new MatchEventRepository(MongoClient);
+
+        // Act
+        var result = await repo.CheckoutApexStandingsChanged();
+
+        // Assert: only the unsynced one returned
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual(unsynced.id, result[0].id);
+
+        // Calling again should return nothing (was marked synced)
+        var second = await repo.CheckoutApexStandingsChanged();
+        Assert.AreEqual(0, second.Count);
+    }
+
+    [Test]
+    public async Task Checkout_ReturnsNothing_WhenAllAlreadySynced()
+    {
+        var synced = MakeEvent(season: 5, gameMode: GameMode.GM_1v1, wasSynced: true);
+        await InsertApexStandingsEvent(synced);
+
+        var repo = new MatchEventRepository(MongoClient);
+        var result = await repo.CheckoutApexStandingsChanged();
+
+        Assert.AreEqual(0, result.Count);
+    }
+
+    // ── Repository round-trip tests ───────────────────────────────────────────
+
+    [Test]
+    public async Task Repo_UpsertAndLoad_RoundTrip()
+    {
+        var repo = new ApexLeaderboardRepository(MongoClient);
+
+        var leaderboard = new ApexLeaderboard
+        {
+            Id = "22_1",
+            Season = 22,
+            GameMode = GameMode.GM_1v1,
+            CutoffApexPoints = 750,
+            GmCount = 3,
+            Players = new List<ApexLeaderboardEntry>
+            {
+                new() { BattleTags = new List<string> { "player1#1" }, Race = Race.HU, ApexPoints = 1200, League = 0, RankNumber = 1 },
+                new() { BattleTags = new List<string> { "player2#2" }, Race = Race.NE, ApexPoints = 1100, League = 0, RankNumber = 2 },
+                new() { BattleTags = new List<string> { "player3#3", "partner#4" }, Race = null, ApexPoints = 900, League = 1, RankNumber = 3 },
+            },
+        };
+
+        await repo.UpsertOne(leaderboard);
+
+        var loaded = await repo.LoadApexLeaderboard(season: 22, GameMode.GM_1v1);
+
+        Assert.IsNotNull(loaded);
+        Assert.AreEqual("22_1", loaded.Id);
+        Assert.AreEqual(22, loaded.Season);
+        Assert.AreEqual(GameMode.GM_1v1, loaded.GameMode);
+        Assert.AreEqual(750, loaded.CutoffApexPoints);
+        Assert.AreEqual(3, loaded.GmCount);
+
+        Assert.AreEqual(3, loaded.Players.Count);
+        Assert.AreEqual("player1#1", loaded.Players[0].BattleTags[0]);
+        Assert.AreEqual(Race.HU, loaded.Players[0].Race);
+        Assert.AreEqual(1200, loaded.Players[0].ApexPoints);
+        Assert.AreEqual(0, loaded.Players[0].League);
+        Assert.AreEqual(1, loaded.Players[0].RankNumber);
+
+        // AT entry with two tags preserved
+        Assert.AreEqual(2, loaded.Players[2].BattleTags.Count);
+        Assert.IsNull(loaded.Players[2].Race);
+        Assert.AreEqual(3, loaded.Players[2].RankNumber);
+    }
+
+    [Test]
+    public async Task Repo_Load_ReturnsNull_WhenNotFound()
+    {
+        var repo = new ApexLeaderboardRepository(MongoClient);
+        var result = await repo.LoadApexLeaderboard(season: 99, GameMode.GM_1v1);
+        Assert.IsNull(result);
+    }
+
+    // ── Handler integration tests ─────────────────────────────────────────────
+
+    [Test]
+    public async Task Handler_BuildsLeaderboard_WithCorrectRankNumbers_AndCutoff()
+    {
+        // Arrange
+        var ev = MakeEvent(season: 22, gameMode: GameMode.GM_1v1, wasSynced: false, cutoff: 800, gmCount: 2);
+        await InsertApexStandingsEvent(ev);
+
+        var matchEventRepo = new MatchEventRepository(MongoClient);
+        var leaderboardRepo = new ApexLeaderboardRepository(MongoClient);
+        var handler = new ApexSyncHandler(leaderboardRepo, matchEventRepo);
+
+        // Act
+        await handler.Update();
+
+        // Assert
+        var doc = await leaderboardRepo.LoadApexLeaderboard(season: 22, GameMode.GM_1v1);
+
+        Assert.IsNotNull(doc);
+        Assert.AreEqual(800, doc.CutoffApexPoints);
+        Assert.AreEqual(2, doc.GmCount);
+        Assert.AreEqual(5, doc.Players.Count);
+
+        // GM entries first (league=0), then Master (league=1), order preserved from event
+        Assert.AreEqual(0, doc.Players[0].League);
+        Assert.AreEqual(1000, doc.Players[0].ApexPoints);
+        Assert.AreEqual(1, doc.Players[0].RankNumber);
+
+        Assert.AreEqual(0, doc.Players[1].League);
+        Assert.AreEqual(900, doc.Players[1].ApexPoints);
+        Assert.AreEqual(2, doc.Players[1].RankNumber);
+
+        Assert.AreEqual(1, doc.Players[2].League);
+        Assert.AreEqual(850, doc.Players[2].ApexPoints);
+        Assert.AreEqual(3, doc.Players[2].RankNumber);
+        Assert.AreEqual(2, doc.Players[2].BattleTags.Count);  // AT entry preserved
+
+        Assert.AreEqual(5, doc.Players[4].RankNumber);
+    }
+
+    [Test]
+    public async Task Handler_ReplacesDocument_WhenNewerEventArrives()
+    {
+        // Seed first event
+        var first = MakeEvent(season: 22, gameMode: GameMode.GM_1v1, wasSynced: false, cutoff: 800, gmCount: 2);
+        await InsertApexStandingsEvent(first);
+
+        var matchEventRepo = new MatchEventRepository(MongoClient);
+        var leaderboardRepo = new ApexLeaderboardRepository(MongoClient);
+        var handler = new ApexSyncHandler(leaderboardRepo, matchEventRepo);
+
+        await handler.Update();
+
+        // Verify first event written
+        var afterFirst = await leaderboardRepo.LoadApexLeaderboard(22, GameMode.GM_1v1);
+        Assert.AreEqual(5, afterFirst.Players.Count);
+        Assert.AreEqual(800, afterFirst.CutoffApexPoints);
+
+        // Seed a newer event for the SAME season+gameMode (cutoff has changed, fewer players)
+        var second = new ApexStandingsChangedEvent
+        {
+            id = 22 * 100000 + (int)GameMode.GM_1v1,
+            season = 22,
+            gameMode = GameMode.GM_1v1,
+            cutoffApexPoints = 950,
+            gmCount = 1,
+            wasSyncedJustNow = false,
+            players = new[]
+            {
+                new ApexStandingRaw { battleTags = new List<string> { "top#1" }, race = Race.HU, apexPoints = 1500, league = 0 },
+                new ApexStandingRaw { battleTags = new List<string> { "second#2" }, race = Race.NE, apexPoints = 1200, league = 1 },
+            },
+        };
+        await InsertApexStandingsEvent(second);
+
+        await handler.Update();
+
+        // Assert: document replaced (not appended)
+        var afterSecond = await leaderboardRepo.LoadApexLeaderboard(22, GameMode.GM_1v1);
+        Assert.AreEqual(2, afterSecond.Players.Count);
+        Assert.AreEqual(950, afterSecond.CutoffApexPoints);
+        Assert.AreEqual(1, afterSecond.GmCount);
+        Assert.AreEqual("top#1", afterSecond.Players[0].BattleTags[0]);
+        Assert.AreEqual(1, afterSecond.Players[0].RankNumber);
+        Assert.AreEqual(2, afterSecond.Players[1].RankNumber);
+    }
+
+    [Test]
+    public async Task Handler_DoesNothing_WhenNoEvents()
+    {
+        var matchEventRepo = new MatchEventRepository(MongoClient);
+        var leaderboardRepo = new ApexLeaderboardRepository(MongoClient);
+        var handler = new ApexSyncHandler(leaderboardRepo, matchEventRepo);
+
+        // Should not throw
+        await handler.Update();
+
+        var doc = await leaderboardRepo.LoadApexLeaderboard(22, GameMode.GM_1v1);
+        Assert.IsNull(doc);
+    }
+
+    [Test]
+    public async Task Handler_BuildsEmptyLeaderboard_WhenCohortIsNull_AndCutoffIsNull()
+    {
+        // Realistic season-start "no GM yet" state: no players, no cutoff.
+        var ev = new ApexStandingsChangedEvent
+        {
+            id = 22 * 100000 + (int)GameMode.GM_1v1,
+            season = 22,
+            gameMode = GameMode.GM_1v1,
+            cutoffApexPoints = null,
+            gmCount = 0,
+            wasSyncedJustNow = false,
+            players = null,
+        };
+        await InsertApexStandingsEvent(ev);
+
+        var matchEventRepo = new MatchEventRepository(MongoClient);
+        var leaderboardRepo = new ApexLeaderboardRepository(MongoClient);
+        var handler = new ApexSyncHandler(leaderboardRepo, matchEventRepo);
+
+        // Should not throw
+        await handler.Update();
+
+        var doc = await leaderboardRepo.LoadApexLeaderboard(22, GameMode.GM_1v1);
+
+        Assert.IsNotNull(doc);
+        Assert.IsNull(doc.CutoffApexPoints);
+        Assert.AreEqual(0, doc.GmCount);
+        Assert.IsNotNull(doc.Players);
+        Assert.IsEmpty(doc.Players);
+    }
+
+    [Test]
+    public async Task Handler_DefaultsBattleTagsToEmptyList_WhenRawBattleTagsAreNull()
+    {
+        // A standing whose battleTags field is absent in Mongo deserializes to null;
+        // the handler must default it to an empty list so downstream consumers don't crash.
+        var ev = new ApexStandingsChangedEvent
+        {
+            id = 22 * 100000 + (int)GameMode.GM_1v1,
+            season = 22,
+            gameMode = GameMode.GM_1v1,
+            cutoffApexPoints = 800,
+            gmCount = 1,
+            wasSyncedJustNow = false,
+            players = new[]
+            {
+                new ApexStandingRaw { battleTags = null, race = Race.HU, apexPoints = 1000, league = 0 },
+            },
+        };
+        await InsertApexStandingsEvent(ev);
+
+        var matchEventRepo = new MatchEventRepository(MongoClient);
+        var leaderboardRepo = new ApexLeaderboardRepository(MongoClient);
+        var handler = new ApexSyncHandler(leaderboardRepo, matchEventRepo);
+
+        await handler.Update();
+
+        var doc = await leaderboardRepo.LoadApexLeaderboard(22, GameMode.GM_1v1);
+
+        Assert.IsNotNull(doc);
+        Assert.AreEqual(1, doc.Players.Count);
+        Assert.IsNotNull(doc.Players[0].BattleTags);
+        Assert.IsEmpty(doc.Players[0].BattleTags);
+        Assert.AreEqual(1, doc.Players[0].RankNumber);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Ladder/ProgressionLadderTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ladder/ProgressionLadderTests.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.CommonValueObjects;
+using W3ChampionsStatisticService.Clans;
+using W3ChampionsStatisticService.Ladder;
+using W3ChampionsStatisticService.PersonalSettings;
+using W3ChampionsStatisticService.PlayerProfiles;
+using W3ChampionsStatisticService.PlayerProfiles.ProgressionStats;
+
+namespace WC3ChampionsStatisticService.Tests.Ladder;
+
+[TestFixture]
+public class ProgressionLadderTests : IntegrationTestBase
+{
+    private RankQueryHandler CreateQueryHandler()
+    {
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+        var clanRepository = new ClanRepository(MongoClient);
+        var progressionRepository = new PlayerProgressionRepository(MongoClient);
+        var progressionViewLoader = new ProgressionViewLoader(progressionRepository);
+        var apexLeaderboardRepository = new ApexLeaderboardRepository(MongoClient);
+        return new RankQueryHandler(
+            rankRepository, playerRepository, clanRepository, progressionViewLoader,
+            apexLeaderboardRepository, progressionRepository);
+    }
+
+    private async Task SeedProgression(
+        string battleTag, int season, GameMode gameMode, Race? race, int league, int division, int points)
+    {
+        var repo = new PlayerProgressionRepository(MongoClient);
+        var id = new BattleTagIdCombined(
+            new List<PlayerId> { PlayerId.Create(battleTag) }, GateWay.Europe, gameMode, season, race);
+        var p = PlayerProgression.Create(id);
+        p.RecordRank(league, division, points, null);
+        await repo.UpsertProgression(p);
+    }
+
+    private async Task SeedPlayerDetail(string battleTag, AvatarCategory pictureRace, long pictureId, string country)
+    {
+        var playerRepository = new PlayerRepository(MongoClient);
+        var personalSettingsRepository = new PersonalSettingsRepository(MongoClient);
+
+        await playerRepository.UpsertPlayer(new PlayerOverallStats { BattleTag = battleTag });
+        await personalSettingsRepository.Save(new PersonalSetting(battleTag)
+        {
+            ProfilePicture = new ProfilePicture { Race = pictureRace, PictureId = pictureId },
+            Country = country,
+        });
+    }
+
+    [Test]
+    public async Task LoadProgressionLadder_ReturnsRankRows_PointsDesc_WithProgressionAndPlayersInfo()
+    {
+        // Adept I (league 2, division 1), three players, different points.
+        await SeedProgression("low#1", 2, GameMode.GM_1v1, null, 2, 1, 10);
+        await SeedProgression("high#2", 2, GameMode.GM_1v1, null, 2, 1, 90);
+        await SeedProgression("mid#3", 2, GameMode.GM_1v1, null, 2, 1, 50);
+
+        await SeedPlayerDetail("low#1", AvatarCategory.HU, 1, "BG");
+        await SeedPlayerDetail("high#2", AvatarCategory.NE, 2, "US");
+        await SeedPlayerDetail("mid#3", AvatarCategory.UD, 3, "DE");
+
+        var queryHandler = CreateQueryHandler();
+
+        var rows = await queryHandler.LoadProgressionLadder(2, GameMode.GM_1v1, 2, 1, null, 0, 100);
+
+        Assert.AreEqual(3, rows.Count);
+
+        // Points-desc order with RankNumber 1..3
+        Assert.AreEqual("high#2", rows[0].PlayersInfo[0].BattleTag);
+        Assert.AreEqual(1, rows[0].RankNumber);
+        Assert.AreEqual("mid#3", rows[1].PlayersInfo[0].BattleTag);
+        Assert.AreEqual(2, rows[1].RankNumber);
+        Assert.AreEqual("low#1", rows[2].PlayersInfo[0].BattleTag);
+        Assert.AreEqual(3, rows[2].RankNumber);
+
+        // Progression view stamped from the same row
+        Assert.IsNotNull(rows[0].Progression);
+        Assert.AreEqual(2, rows[0].Progression.League);
+        Assert.AreEqual(1, rows[0].Progression.Division);
+        Assert.AreEqual(90, rows[0].Progression.Points);
+
+        // PlayersInfo enriched (display data resolved from player-detail sources)
+        Assert.AreEqual(AvatarCategory.NE, rows[0].PlayersInfo[0].SelectedRace);
+        Assert.AreEqual(2, rows[0].PlayersInfo[0].PictureId);
+        Assert.AreEqual("US", rows[0].PlayersInfo[0].Country);
+
+        // RP-only field left at default (website renders progression, not RP)
+        Assert.AreEqual(0, rows[0].RankingPoints);
+    }
+
+    [TestCase(0)] // Grand Master
+    [TestCase(1)] // Master
+    public async Task LoadProgressionLadder_ApexLeague_ReturnsEmpty(int apexLeague)
+    {
+        await SeedProgression("apex#1", 2, GameMode.GM_1v1, null, apexLeague, 1, 99);
+        await SeedPlayerDetail("apex#1", AvatarCategory.HU, 1, "BG");
+
+        var queryHandler = CreateQueryHandler();
+
+        var rows = await queryHandler.LoadProgressionLadder(2, GameMode.GM_1v1, apexLeague, 1, null, 0, 100);
+
+        Assert.IsEmpty(rows);
+    }
+
+    [Test]
+    public async Task LoadProgressionLadder_AssignsGlobalRankNumber_AcrossPages()
+    {
+        // Five players in Adept I, points 100..60 desc.
+        for (int i = 0; i < 5; i++)
+        {
+            await SeedProgression($"p{i}#1", 2, GameMode.GM_1v1, null, 2, 1, 100 - i * 10);
+            await SeedPlayerDetail($"p{i}#1", AvatarCategory.HU, i + 1, "BG");
+        }
+
+        var queryHandler = CreateQueryHandler();
+
+        // Second page: skip 1, take 2 -> points 90, 80 with GLOBAL ranks 2, 3.
+        var page = await queryHandler.LoadProgressionLadder(2, GameMode.GM_1v1, 2, 1, null, 1, 2);
+
+        Assert.AreEqual(2, page.Count);
+        Assert.AreEqual(2, page[0].RankNumber);
+        Assert.AreEqual(90, page[0].Progression.Points);
+        Assert.AreEqual(3, page[1].RankNumber);
+        Assert.AreEqual(80, page[1].Progression.Points);
+    }
+
+    [Test]
+    public async Task LoadProgressionLadder_NoRows_ReturnsEmpty()
+    {
+        var queryHandler = CreateQueryHandler();
+
+        var rows = await queryHandler.LoadProgressionLadder(99, GameMode.GM_1v1, 2, 1, null, 0, 100);
+
+        Assert.IsEmpty(rows);
+    }
+
+    [Test]
+    public async Task LoadProgressionLadder_FiltersByRace_WhenRaceProvided()
+    {
+        await SeedProgression("hu#1", 2, GameMode.GM_1v1, Race.HU, 2, 1, 80);
+        await SeedProgression("ne#2", 2, GameMode.GM_1v1, Race.NE, 2, 1, 70);
+        await SeedPlayerDetail("hu#1", AvatarCategory.HU, 1, "BG");
+        await SeedPlayerDetail("ne#2", AvatarCategory.NE, 2, "US");
+
+        var queryHandler = CreateQueryHandler();
+
+        var rows = await queryHandler.LoadProgressionLadder(2, GameMode.GM_1v1, 2, 1, Race.HU, 0, 100);
+
+        Assert.AreEqual(1, rows.Count);
+        Assert.AreEqual("hu#1", rows[0].PlayersInfo[0].BattleTag);
+        Assert.AreEqual(Race.HU, rows[0].Race);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PlayerProfiles/ProgressionStats/PlayerProgressionRepositoryTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Mongo2Go;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using NUnit.Framework;
 using W3C.Contracts.GameObjects;
@@ -105,5 +106,118 @@ public class PlayerProgressionRepositoryTests
     {
         var loaded = await _repository.LoadProgressions(new List<string>());
         Assert.IsEmpty(loaded);
+    }
+
+    private static PlayerProgression MakeFor(
+        string battleTag, int season, GameMode gameMode, Race? race, int league, int division, int points)
+    {
+        var id = new BattleTagIdCombined(
+            new List<PlayerId> { PlayerId.Create(battleTag) },
+            GateWay.Europe, gameMode, season, race);
+        var p = PlayerProgression.Create(id);
+        p.RecordRank(league, division, points, null);
+        return p;
+    }
+
+    // ── C1: index ────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task EnsureIndexes_creates_league_query_index()
+    {
+        await _repository.EnsureIndexesAsync();
+
+        var indexes = await (await Collection().Indexes.ListAsync()).ToListAsync();
+        var indexDump = $"count={indexes.Count}; " + string.Join(" | ", indexes.Select(i => i.ToJson()));
+
+        // Compound index backing LoadPlayersByProgressionLeague:
+        // Season + GameMode + League + Division + Race (eq filters) then Points desc (sort).
+        Assert.That(
+            indexes.Any(i => i.GetValue("name", BsonString.Empty).AsString
+                == "Season_1_GameMode_1_League_1_Division_1_Race_1_Points_-1"),
+            Is.True,
+            "league-query compound index missing — got: " + indexDump);
+    }
+
+    [Test]
+    public async Task EnsureIndexes_is_idempotent()
+    {
+        await _repository.EnsureIndexesAsync();
+        Assert.DoesNotThrowAsync(async () => await _repository.EnsureIndexesAsync());
+    }
+
+    // ── C2: query ────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task LoadPlayersByProgressionLeague_FiltersBySeasonModeLeagueDivision_PointsDesc()
+    {
+        // Adept I (league 2, division 1): three players, different points.
+        await _repository.UpsertProgression(MakeFor("low#1", 2, GameMode.GM_1v1, null, 2, 1, 10));
+        await _repository.UpsertProgression(MakeFor("high#2", 2, GameMode.GM_1v1, null, 2, 1, 90));
+        await _repository.UpsertProgression(MakeFor("mid#3", 2, GameMode.GM_1v1, null, 2, 1, 50));
+        // Noise that must be excluded: Adept II, Diamond I, another mode, another season.
+        await _repository.UpsertProgression(MakeFor("adeptII#4", 2, GameMode.GM_1v1, null, 2, 2, 99));
+        await _repository.UpsertProgression(MakeFor("diamondI#5", 2, GameMode.GM_1v1, null, 4, 1, 99));
+        await _repository.UpsertProgression(MakeFor("othermode#6", 2, GameMode.GM_2v2, null, 2, 1, 99));
+        await _repository.UpsertProgression(MakeFor("otherseason#7", 1, GameMode.GM_1v1, null, 2, 1, 99));
+
+        var result = await _repository.LoadPlayersByProgressionLeague(2, GameMode.GM_1v1, 2, 1, null, 0, 100);
+
+        Assert.AreEqual(3, result.Count);
+        Assert.AreEqual(new[] { 90, 50, 10 }, result.Select(r => r.Points).ToArray());
+        Assert.AreEqual("high#2", result[0].PlayerIds[0].BattleTag);
+    }
+
+    [Test]
+    public async Task LoadPlayersByProgressionLeague_ApexLeagues_ReturnEmpty()
+    {
+        // Leagues 0 (Grand Master) and 1 (Master) are apex — served by /api/ladder/apex, not here.
+        await _repository.UpsertProgression(MakeFor("gm#1", 2, GameMode.GM_1v1, null, 0, 1, 99));
+        await _repository.UpsertProgression(MakeFor("master#2", 2, GameMode.GM_1v1, null, 1, 1, 99));
+
+        var grandMaster = await _repository.LoadPlayersByProgressionLeague(2, GameMode.GM_1v1, 0, 1, null, 0, 100);
+        var master = await _repository.LoadPlayersByProgressionLeague(2, GameMode.GM_1v1, 1, 1, null, 0, 100);
+
+        Assert.IsEmpty(grandMaster);
+        Assert.IsEmpty(master);
+    }
+
+    [Test]
+    public async Task LoadPlayersByProgressionLeague_FiltersByRace_WhenRaceProvided()
+    {
+        // Race-split mode: same league/division, different races.
+        await _repository.UpsertProgression(MakeFor("hu#1", 2, GameMode.GM_1v1, Race.HU, 2, 1, 80));
+        await _repository.UpsertProgression(MakeFor("ne#2", 2, GameMode.GM_1v1, Race.NE, 2, 1, 70));
+
+        var huOnly = await _repository.LoadPlayersByProgressionLeague(2, GameMode.GM_1v1, 2, 1, Race.HU, 0, 100);
+
+        Assert.AreEqual(1, huOnly.Count);
+        Assert.AreEqual("hu#1", huOnly[0].PlayerIds[0].BattleTag);
+        Assert.AreEqual(Race.HU, huOnly[0].Race);
+    }
+
+    [Test]
+    public async Task LoadPlayersByProgressionLeague_NullRace_IgnoresRaceFilter()
+    {
+        await _repository.UpsertProgression(MakeFor("hu#1", 2, GameMode.GM_1v1, Race.HU, 2, 1, 80));
+        await _repository.UpsertProgression(MakeFor("ne#2", 2, GameMode.GM_1v1, Race.NE, 2, 1, 70));
+
+        var all = await _repository.LoadPlayersByProgressionLeague(2, GameMode.GM_1v1, 2, 1, null, 0, 100);
+
+        Assert.AreEqual(2, all.Count);
+    }
+
+    [Test]
+    public async Task LoadPlayersByProgressionLeague_AppliesSkipAndTake()
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            await _repository.UpsertProgression(MakeFor($"p{i}#1", 2, GameMode.GM_1v1, null, 2, 1, 100 - i * 10));
+        }
+
+        var page = await _repository.LoadPlayersByProgressionLeague(2, GameMode.GM_1v1, 2, 1, null, 1, 2);
+
+        // Points desc: 100, 90, 80, 70, 60 -> skip 1, take 2 -> 90, 80
+        Assert.AreEqual(2, page.Count);
+        Assert.AreEqual(new[] { 90, 80 }, page.Select(r => r.Points).ToArray());
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
@@ -249,7 +249,7 @@ public class RankTests : IntegrationTestBase
         var personalSettingsRepository = new PersonalSettingsRepository(MongoClient);
         var clanRepository = new ClanRepository(MongoClient);
         var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository,
-            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)));
+            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)), new ApexLeaderboardRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -292,7 +292,7 @@ public class RankTests : IntegrationTestBase
         var playerRepository = new PlayerRepository(MongoClient);
         var clanRepository = new ClanRepository(MongoClient);
         var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository,
-            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)));
+            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)), new ApexLeaderboardRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -325,7 +325,7 @@ public class RankTests : IntegrationTestBase
         var playerRepository = new PlayerRepository(MongoClient);
         var clanRepository = new ClanRepository(MongoClient);
         var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository,
-            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)));
+            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)), new ApexLeaderboardRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -358,7 +358,7 @@ public class RankTests : IntegrationTestBase
         var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
         var playerRepository = new PlayerRepository(MongoClient);
         var queryHandler = new RankQueryHandler(rankRepository, playerRepository, new ClanRepository(MongoClient),
-            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)));
+            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)), new ApexLeaderboardRepository(MongoClient));
 
         var ranks = new List<Rank>
         {
@@ -466,7 +466,7 @@ public class RankTests : IntegrationTestBase
         var clanRepository = new ClanRepository(MongoClient);
         var progressionRepository = new PlayerProgressionRepository(MongoClient);
         var progressionViewLoader = new ProgressionViewLoader(progressionRepository);
-        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader);
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader, new ApexLeaderboardRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -503,7 +503,7 @@ public class RankTests : IntegrationTestBase
         var playerRepository = new PlayerRepository(MongoClient);
         var clanRepository = new ClanRepository(MongoClient);
         var progressionViewLoader = new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient));
-        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader);
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader, new ApexLeaderboardRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "noprog#1" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -528,7 +528,7 @@ public class RankTests : IntegrationTestBase
         var clanRepository = new ClanRepository(MongoClient);
         var progressionRepository = new PlayerProgressionRepository(MongoClient);
         var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository,
-            new ProgressionViewLoader(progressionRepository));
+            new ProgressionViewLoader(progressionRepository), new ApexLeaderboardRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "searchme#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -564,7 +564,7 @@ public class RankTests : IntegrationTestBase
         var clanRepository = new ClanRepository(MongoClient);
         var progressionRepository = new PlayerProgressionRepository(MongoClient);
         var progressionViewLoader = new ProgressionViewLoader(progressionRepository);
-        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader);
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader, new ApexLeaderboardRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);

--- a/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
@@ -249,7 +249,7 @@ public class RankTests : IntegrationTestBase
         var personalSettingsRepository = new PersonalSettingsRepository(MongoClient);
         var clanRepository = new ClanRepository(MongoClient);
         var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository,
-            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)), new ApexLeaderboardRepository(MongoClient));
+            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)), new ApexLeaderboardRepository(MongoClient), new PlayerProgressionRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -292,7 +292,7 @@ public class RankTests : IntegrationTestBase
         var playerRepository = new PlayerRepository(MongoClient);
         var clanRepository = new ClanRepository(MongoClient);
         var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository,
-            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)), new ApexLeaderboardRepository(MongoClient));
+            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)), new ApexLeaderboardRepository(MongoClient), new PlayerProgressionRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -325,7 +325,7 @@ public class RankTests : IntegrationTestBase
         var playerRepository = new PlayerRepository(MongoClient);
         var clanRepository = new ClanRepository(MongoClient);
         var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository,
-            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)), new ApexLeaderboardRepository(MongoClient));
+            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)), new ApexLeaderboardRepository(MongoClient), new PlayerProgressionRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -358,7 +358,7 @@ public class RankTests : IntegrationTestBase
         var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
         var playerRepository = new PlayerRepository(MongoClient);
         var queryHandler = new RankQueryHandler(rankRepository, playerRepository, new ClanRepository(MongoClient),
-            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)), new ApexLeaderboardRepository(MongoClient));
+            new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient)), new ApexLeaderboardRepository(MongoClient), new PlayerProgressionRepository(MongoClient));
 
         var ranks = new List<Rank>
         {
@@ -466,7 +466,7 @@ public class RankTests : IntegrationTestBase
         var clanRepository = new ClanRepository(MongoClient);
         var progressionRepository = new PlayerProgressionRepository(MongoClient);
         var progressionViewLoader = new ProgressionViewLoader(progressionRepository);
-        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader, new ApexLeaderboardRepository(MongoClient));
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader, new ApexLeaderboardRepository(MongoClient), new PlayerProgressionRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -503,7 +503,7 @@ public class RankTests : IntegrationTestBase
         var playerRepository = new PlayerRepository(MongoClient);
         var clanRepository = new ClanRepository(MongoClient);
         var progressionViewLoader = new ProgressionViewLoader(new PlayerProgressionRepository(MongoClient));
-        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader, new ApexLeaderboardRepository(MongoClient));
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader, new ApexLeaderboardRepository(MongoClient), new PlayerProgressionRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "noprog#1" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -528,7 +528,7 @@ public class RankTests : IntegrationTestBase
         var clanRepository = new ClanRepository(MongoClient);
         var progressionRepository = new PlayerProgressionRepository(MongoClient);
         var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository,
-            new ProgressionViewLoader(progressionRepository), new ApexLeaderboardRepository(MongoClient));
+            new ProgressionViewLoader(progressionRepository), new ApexLeaderboardRepository(MongoClient), new PlayerProgressionRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "searchme#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);
@@ -564,7 +564,7 @@ public class RankTests : IntegrationTestBase
         var clanRepository = new ClanRepository(MongoClient);
         var progressionRepository = new PlayerProgressionRepository(MongoClient);
         var progressionViewLoader = new ProgressionViewLoader(progressionRepository);
-        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader, new ApexLeaderboardRepository(MongoClient));
+        var queryHandler = new RankQueryHandler(rankRepository, playerRepository, clanRepository, progressionViewLoader, new ApexLeaderboardRepository(MongoClient), new PlayerProgressionRepository(MongoClient));
 
         var ranks = new List<Rank> { new(new List<string> { "peter#123" }, 1, 12, 1456, null, GateWay.America, GameMode.GM_1v1, 1) };
         await rankRepository.InsertRanks(ranks);

--- a/docs/ranking/README.md
+++ b/docs/ranking/README.md
@@ -42,6 +42,46 @@ and maps it to `PlayerProgressionView`. The field is a serve-time join (`[BsonIg
 is `null` when the entity has no placed record for that season/mode. Additive — clients that ignore it
 keep rendering the legacy RP fields.
 
+## Apex leaderboard endpoint
+
+`GET /api/ladder/apex?season=&gameMode=` (`LadderController`) serves the **apex** cohort — the combined
+Grand Master and Master players for a season and game mode — as a single ordered leaderboard. It is
+anonymous and gateway-agnostic (apex rank is global; there is no `gateWay` parameter).
+
+- **Response:** `{ cutoffApexPoints, gmCount, players: [{ playersInfo, apexPoints, league, rankNumber }] }`.
+  - `cutoffApexPoints` — the floating apex-points cutoff for the Grand Master tier (nullable; `null` before
+    the cohort exists for that season/mode).
+  - `gmCount` — how many of the listed players are Grand Master.
+  - `players` — ordered Grand Master first, then Master, by apex points; `rankNumber` is the 1-based
+    position in that order. `league` is the apex tier (`0` = Grand Master, `1` = Master). `playersInfo`
+    carries the same per-player display data as the ladder rows (name, race, country, clan, picture).
+  - A season/mode with no cohort yet returns `{ cutoffApexPoints: null, gmCount: 0, players: [] }`.
+- **Read-model:** `ApexLeaderboard` (collection `ApexLeaderboard`, `Ladder/`) — one document per
+  `(season, gameMode)`. Unlike the per-match progression read-model above, the apex cohort and its cutoff
+  are recomputed upstream and **synced** into website-backend the same way the ladder itself is: the
+  matchmaking service publishes an apex-standings snapshot, and an ingest handler keeps the read-model
+  current. The endpoint serves this already-built document; it never computes the cohort.
+
+## Progression league ladder endpoint
+
+`GET /api/ladder/progression?season=&gameMode=&league=&division=&race=` (`LadderController`) serves a
+single **non-apex** progression league/division page (Adept through Grass), read directly from the
+`PlayerProgression` read-model. It is anonymous and gateway-agnostic.
+
+- **Shape:** it returns the **same `Rank` array** as `GET /api/ladder/{leagueId}`, so clients reuse the
+  existing ladder grid unchanged. Each row carries the `progression` object (`{ league, division, points,
+  apexPoints }`) stamped from the same record and the usual `playersInfo`; `rankNumber` is the global
+  points-descending position across the league/division page (offset by paging). The legacy RP fields are
+  left at their defaults — clients render `progression`, not RP, in progression mode.
+- **Ordering & paging:** rows are ordered by points descending. `skip`/`take` page the result; `take` is
+  capped server-side at 500 so a caller cannot request an unbounded, fully enriched page.
+- **Apex leagues:** leagues `0` (Grand Master) and `1` (Master) are apex and return an empty list here —
+  use `GET /api/ladder/apex` for those.
+- **Index:** a compound index on `PlayerProgression` over
+  `(Season, GameMode, League, Division, Race, Points desc)` backs this league/division query so it does not
+  scan the collection. It is created at startup via the standard index-initialization path (the repository
+  implements `IRequiresIndexes`).
+
 ## Lifetime win-milestone read-model
 
 A separate, **permanent** downstream read-model tracks each player's lifetime win-milestone progress — a


### PR DESCRIPTION
Adds two public ladder surfaces for the progression ranking system: the **apex leaderboard** (Grand Master + Master standings) and the **non-apex progression league ladder** (Adept…Grass). Downstream half of P11-4.

## Apex leaderboard — `GET /api/ladder/apex?season=&gameMode=`
The daily Grand Master + Master cohort, ordered by apex points (GM first), with the floating GM cutoff. It is kept current by ingesting a new `ApexStandingsChangedEvent` through the same ISyncable checkout path the ladder already uses (new `ApexSyncHandler` → `ApexLeaderboard` read-model), then served by an anonymous endpoint. Served from the synced read-model rather than the per-player progression collection, because the daily Grand Master/Master assignment changes without a match.
- Response: `{ cutoffApexPoints, gmCount, players: [{ playersInfo, apexPoints, league, rankNumber }] }` (`league` 0 = Grand Master, 1 = Master). Gateway-agnostic.

## Progression league ladder — `GET /api/ladder/progression?season=&gameMode=&league=&division=&race=`
Non-apex league/division pages served directly from the existing `PlayerProgression` read-model (always current for these leagues), backed by a new compound index. Returns the **same `Rank` shape** as `/api/ladder/{leagueId}` so the existing ladder grid renders it unchanged. Points-desc with a global `rankNumber`; `take` capped at 500; apex leagues (0/1) return empty (use `/api/ladder/apex`).

## Notes
- Enrichment DRY: the per-player display enrichment was extracted from `PopulatePlayerInfos` into shared helpers reused by the existing ladder, apex, and progression paths (behavior-preserving — existing `RankTests` green).
- New compound index on `PlayerProgression` `(Season, GameMode, League, Division, Race, Points desc)` via the standard `IRequiresIndexes` startup path.

## Checklist
- [x] Targets `prj/new-ranking-system`
- [x] Task: P11-4 (Workstreams B+C — website-backend)
- [x] Tests (TDD, NUnit + Mongo2Go): apex ingest/handler/repo/endpoint (18) + progression index/query/ladder (incl. apex-guard both leagues, paging, race split, empty cases); full suite 719 passed / 0 failed
- [x] Gates green: `dotnet build` 0 · `dotnet test` · `dotnet format --verify-no-changes` exit 0
- [x] Public-repo boundary: whole diff + commit messages scanned — only league/division/points/apexPoints/Grand Master/Master/cutoff vocabulary; no internal mechanism, no private-repo names
- [x] Anonymous, gateway-agnostic endpoints; additive (legacy ladder untouched)
- [x] Per-repo doc updated (`docs/ranking/README.md`)