### PR TITLE
feat: tag lag reports with player-side network category (LAN / LastMile)

### DIFF
--- a/W3ChampionsStatisticService/LagReports/LagReport.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReport.cs
@@ -98,6 +98,12 @@ public class LagReportPlayer
     [JsonConverter(typeof(JsonStringEnumListConverter<EIssueCategory>))]
     public List<EIssueCategory> IssueCategories { get; set; } = [];
 
+    /// <summary>
+    /// System-derived connection-issue verdict tags from the launcher
+    /// (e.g. LAN, LastMile). Distinct from the player-selected IssueCategories.
+    /// </summary>
+    public List<ELagReportTag> Tags { get; set; } = [];
+
     /// <summary>Free-text description from the player.</summary>
     public string FreeText { get; set; } = "";
 

--- a/W3ChampionsStatisticService/LagReports/LagReport.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReport.cs
@@ -102,7 +102,7 @@ public class LagReportPlayer
     /// System-derived connection-issue verdict tags from the launcher
     /// (e.g. LAN, LastMile). Distinct from the player-selected IssueCategories.
     /// </summary>
-    public List<ELagReportTag> Tags { get; set; } = [];
+    public List<ELagReportTag> ConnectionIssueTags { get; set; } = [];
 
     /// <summary>Free-text description from the player.</summary>
     public string FreeText { get; set; } = "";

--- a/W3ChampionsStatisticService/LagReports/LagReportController.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportController.cs
@@ -121,6 +121,7 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
         if ((diag.ConnectionEvents?.Count ?? 0) > 200) return "Too many connection_events";
         if ((dto.Annotations?.Count ?? 0) > 200) return "Too many annotations";
         if ((dto.Categories?.Count ?? 0) > 20) return "Too many categories";
+        if ((dto.Tags?.Count ?? 0) > 20) return "Too many tags";
 
         if (dto.FreeText?.Length > 5000) return "free_text too long";
         if (dto.GameMetadata.GameName?.Length > 500) return "game_name too long";

--- a/W3ChampionsStatisticService/LagReports/LagReportController.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportController.cs
@@ -190,6 +190,7 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
             ProxyPort = proxyPort,
             IsExplicit = dto.IsExplicit,
             IssueCategories = dto.Categories ?? [],
+            Tags = dto.Tags ?? [],
             FreeText = dto.FreeText ?? "",
             Annotations = (dto.Annotations ?? []).Select(a => new LagReportAnnotation
             {

--- a/W3ChampionsStatisticService/LagReports/LagReportController.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportController.cs
@@ -103,7 +103,7 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
                 ConnectionType = p.ConnectionType,
                 ProxyName = p.ProxyName,
                 IssueCategories = p.IssueCategories,
-                Tags = p.Tags ?? [],
+                ConnectionIssueTags = p.ConnectionIssueTags ?? [],
                 LagEventCount = p.Diagnostics?.LagEvents?.Count ?? 0,
                 ConnectionEventCount = p.Diagnostics?.ConnectionEvents?.Count ?? 0,
             }).ToList(),
@@ -140,7 +140,7 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
         if ((diag.ConnectionEvents?.Count ?? 0) > MaxConnectionEvents) return "Too many connection_events";
         if ((dto.Annotations?.Count ?? 0) > MaxAnnotations) return "Too many annotations";
         if ((dto.Categories?.Count ?? 0) > MaxIssueCategories) return "Too many categories";
-        if ((dto.Tags?.Count ?? 0) > MaxTagsPerReport) return "Too many tags";
+        if ((dto.ConnectionIssueTags?.Count ?? 0) > MaxTagsPerReport) return "Too many tags";
 
         if (dto.FreeText?.Length > MaxFreeTextLength) return "free_text too long";
         if (dto.GameMetadata.GameName?.Length > MaxShortStringLength) return "game_name too long";
@@ -211,7 +211,7 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
             ProxyPort = proxyPort,
             IsExplicit = dto.IsExplicit,
             IssueCategories = dto.Categories ?? [],
-            Tags = dto.Tags ?? [],
+            ConnectionIssueTags = dto.ConnectionIssueTags ?? [],
             FreeText = dto.FreeText ?? "",
             Annotations = (dto.Annotations ?? []).Select(a => new LagReportAnnotation
             {

--- a/W3ChampionsStatisticService/LagReports/LagReportController.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportController.cs
@@ -84,6 +84,7 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
                 ConnectionType = p.ConnectionType,
                 ProxyName = p.ProxyName,
                 IssueCategories = p.IssueCategories,
+                Tags = p.Tags ?? [],
                 LagEventCount = p.Diagnostics?.LagEvents?.Count ?? 0,
                 ConnectionEventCount = p.Diagnostics?.ConnectionEvents?.Count ?? 0,
             }).ToList(),

--- a/W3ChampionsStatisticService/LagReports/LagReportController.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportController.cs
@@ -17,6 +17,25 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
     private readonly LagReportRepository _lagReportRepository = lagReportRepository;
     private readonly IFloStatsService _floStatsService = floStatsService;
 
+    // ── Submission validation caps ────────────────────────────────────
+    private const int MaxLagEvents = 200;
+    private const int MaxTargetMtrEntries = 500;
+    private const int MaxAllServerBaselines = 1000;
+    private const int MaxReverseMtrEntries = 500;
+    private const int MaxPingHistoryEntries = 5000;
+    private const int MaxConnectionEvents = 200;
+    private const int MaxAnnotations = 200;
+    private const int MaxIssueCategories = 20;
+    private const int MaxTagsPerReport = 20;
+    private const int MaxHopsPerTrace = 64;
+
+    private const int MaxFreeTextLength = 5000;
+    private const int MaxShortStringLength = 500;
+    private const int MaxClientIpLength = 100;
+    private const int MaxAnnotationTextLength = 1000;
+
+    private const int MaxPageSize = 100;
+
     /// <summary>
     /// Submit a lag report — called by the launcher for each player (explicit or auto).
     /// Authenticated users only (any player, not admin-only).
@@ -61,7 +80,7 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
     [BearerHasPermissionFilter(Permission = EPermission.Proxies)]
     public async Task<IActionResult> GetReports([FromQuery] LagReportQueryRequest req)
     {
-        req.PageSize = Math.Clamp(req.PageSize, 1, 100);
+        req.PageSize = Math.Clamp(req.PageSize, 1, MaxPageSize);
         req.Page = Math.Max(req.Page, 0);
 
         var (items, total) = await _lagReportRepository.GetReports(req);
@@ -113,39 +132,39 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
         if (dto.ConnectionTopology == null) return "Missing connection_topology";
 
         var diag = dto.Diagnostics;
-        if ((diag.LagEvents?.Count ?? 0) > 200) return "Too many lag_events";
-        if ((diag.TargetMtr?.Count ?? 0) > 500) return "Too many target_mtr";
-        if ((diag.AllServerBaselines?.Count ?? 0) > 1000) return "Too many all_server_baselines";
-        if ((diag.ReverseMtr?.Count ?? 0) > 500) return "Too many reverse_mtr";
-        if ((diag.PingHistory?.Count ?? 0) > 5000) return "Too many ping_history";
-        if ((diag.ConnectionEvents?.Count ?? 0) > 200) return "Too many connection_events";
-        if ((dto.Annotations?.Count ?? 0) > 200) return "Too many annotations";
-        if ((dto.Categories?.Count ?? 0) > 20) return "Too many categories";
-        if ((dto.Tags?.Count ?? 0) > 20) return "Too many tags";
+        if ((diag.LagEvents?.Count ?? 0) > MaxLagEvents) return "Too many lag_events";
+        if ((diag.TargetMtr?.Count ?? 0) > MaxTargetMtrEntries) return "Too many target_mtr";
+        if ((diag.AllServerBaselines?.Count ?? 0) > MaxAllServerBaselines) return "Too many all_server_baselines";
+        if ((diag.ReverseMtr?.Count ?? 0) > MaxReverseMtrEntries) return "Too many reverse_mtr";
+        if ((diag.PingHistory?.Count ?? 0) > MaxPingHistoryEntries) return "Too many ping_history";
+        if ((diag.ConnectionEvents?.Count ?? 0) > MaxConnectionEvents) return "Too many connection_events";
+        if ((dto.Annotations?.Count ?? 0) > MaxAnnotations) return "Too many annotations";
+        if ((dto.Categories?.Count ?? 0) > MaxIssueCategories) return "Too many categories";
+        if ((dto.Tags?.Count ?? 0) > MaxTagsPerReport) return "Too many tags";
 
-        if (dto.FreeText?.Length > 5000) return "free_text too long";
-        if (dto.GameMetadata.GameName?.Length > 500) return "game_name too long";
-        if (dto.GameMetadata.MapPath?.Length > 500) return "map_path too long";
-        if (dto.ConnectionTopology.ServerNodeName?.Length > 500) return "server_node_name too long";
-        if (dto.ConnectionTopology.ProxyName?.Length > 500) return "proxy_name too long";
-        if (dto.ConnectionTopology.ProxyAddress?.Length > 500) return "proxy_address too long";
-        if (dto.ConnectionTopology.ClientIp?.Length > 100) return "client_ip too long";
+        if (dto.FreeText?.Length > MaxFreeTextLength) return "free_text too long";
+        if (dto.GameMetadata.GameName?.Length > MaxShortStringLength) return "game_name too long";
+        if (dto.GameMetadata.MapPath?.Length > MaxShortStringLength) return "map_path too long";
+        if (dto.ConnectionTopology.ServerNodeName?.Length > MaxShortStringLength) return "server_node_name too long";
+        if (dto.ConnectionTopology.ProxyName?.Length > MaxShortStringLength) return "proxy_name too long";
+        if (dto.ConnectionTopology.ProxyAddress?.Length > MaxShortStringLength) return "proxy_address too long";
+        if (dto.ConnectionTopology.ClientIp?.Length > MaxClientIpLength) return "client_ip too long";
 
         foreach (var trace in (diag.TargetMtr ?? []).Concat(diag.ReverseMtr ?? []))
         {
-            if (trace.Trace?.Hops?.Count > 64) return "Too many hops in trace";
+            if (trace.Trace?.Hops?.Count > MaxHopsPerTrace) return "Too many hops in trace";
         }
         foreach (var baseline in diag.AllServerBaselines ?? [])
         {
-            if (baseline.Trace?.Hops?.Count > 64) return "Too many hops in baseline";
+            if (baseline.Trace?.Hops?.Count > MaxHopsPerTrace) return "Too many hops in baseline";
         }
         foreach (var annotation in dto.Annotations ?? [])
         {
-            if (annotation.Text?.Length > 1000) return "Annotation text too long";
+            if (annotation.Text?.Length > MaxAnnotationTextLength) return "Annotation text too long";
         }
         foreach (var lagEvent in diag.LagEvents ?? [])
         {
-            if (lagEvent.Annotation?.Length > 1000) return "Lag event annotation too long";
+            if (lagEvent.Annotation?.Length > MaxAnnotationTextLength) return "Lag event annotation too long";
         }
 
         return null;

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -28,6 +28,10 @@ public class LagReportSubmissionDto
     [JsonConverter(typeof(JsonStringEnumListConverter<EIssueCategory>))]
     public List<EIssueCategory> Categories { get; set; } = [];
 
+    [JsonPropertyName("tags")]
+    [JsonConverter(typeof(JsonStringEnumListConverter<ELagReportTag>))]
+    public List<ELagReportTag> Tags { get; set; } = [];
+
     [JsonPropertyName("free_text")]
     public string FreeText { get; set; } = "";
 }

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -30,7 +30,7 @@ public class LagReportSubmissionDto
 
     [JsonPropertyName("tags")]
     [JsonConverter(typeof(JsonStringEnumListConverter<ELagReportTag>))]
-    public List<ELagReportTag> Tags { get; set; } = [];
+    public List<ELagReportTag> ConnectionIssueTags { get; set; } = [];
 
     [JsonPropertyName("free_text")]
     public string FreeText { get; set; } = "";
@@ -286,8 +286,9 @@ public class LagReportPlayerSummary
     public string ProxyName { get; set; }
     [JsonConverter(typeof(JsonStringEnumListConverter<EIssueCategory>))]
     public List<EIssueCategory> IssueCategories { get; set; } = [];
+    [JsonPropertyName("tags")]
     [JsonConverter(typeof(JsonStringEnumListConverter<ELagReportTag>))]
-    public List<ELagReportTag> Tags { get; set; } = [];
+    public List<ELagReportTag> ConnectionIssueTags { get; set; } = [];
     public int LagEventCount { get; set; }
     public int ConnectionEventCount { get; set; }
 }

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -255,6 +255,7 @@ public class LagReportQueryRequest
     public string DateFrom { get; set; }
     public string DateTo { get; set; }
     public string IssueCategory { get; set; }
+    public string Tag { get; set; }
     public bool? ExplicitOnly { get; set; }
     public int Page { get; set; } = 0;
     public int PageSize { get; set; } = 20;

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -286,6 +286,8 @@ public class LagReportPlayerSummary
     public string ProxyName { get; set; }
     [JsonConverter(typeof(JsonStringEnumListConverter<EIssueCategory>))]
     public List<EIssueCategory> IssueCategories { get; set; } = [];
+    [JsonConverter(typeof(JsonStringEnumListConverter<ELagReportTag>))]
+    public List<ELagReportTag> Tags { get; set; } = [];
     public int LagEventCount { get; set; }
     public int ConnectionEventCount { get; set; }
 }

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -28,7 +28,7 @@ public class LagReportSubmissionDto
     [JsonConverter(typeof(JsonStringEnumListConverter<EIssueCategory>))]
     public List<EIssueCategory> Categories { get; set; } = [];
 
-    [JsonPropertyName("tags")]
+    [JsonPropertyName("connection_issue_tags")]
     [JsonConverter(typeof(JsonStringEnumListConverter<ELagReportTag>))]
     public List<ELagReportTag> ConnectionIssueTags { get; set; } = [];
 
@@ -255,7 +255,8 @@ public class LagReportQueryRequest
     public string DateFrom { get; set; }
     public string DateTo { get; set; }
     public string IssueCategory { get; set; }
-    public string Tag { get; set; }
+    [Microsoft.AspNetCore.Mvc.FromQuery(Name = "connection_issue_tag")]
+    public string ConnectionIssueTag { get; set; }
     public bool? ExplicitOnly { get; set; }
     public int Page { get; set; } = 0;
     public int PageSize { get; set; } = 20;
@@ -286,7 +287,7 @@ public class LagReportPlayerSummary
     public string ProxyName { get; set; }
     [JsonConverter(typeof(JsonStringEnumListConverter<EIssueCategory>))]
     public List<EIssueCategory> IssueCategories { get; set; } = [];
-    [JsonPropertyName("tags")]
+    [JsonPropertyName("connection_issue_tags")]
     [JsonConverter(typeof(JsonStringEnumListConverter<ELagReportTag>))]
     public List<ELagReportTag> ConnectionIssueTags { get; set; } = [];
     public int LagEventCount { get; set; }

--- a/W3ChampionsStatisticService/LagReports/LagReportEnums.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportEnums.cs
@@ -13,6 +13,18 @@ public enum Transport
     QUIC,
 }
 
+/// <summary>
+/// System-derived connection-issue verdict tags attached to a lag report by the
+/// launcher (NOT player-selected — kept distinct from <see cref="EIssueCategory"/>).
+/// Serialized on the wire as the literal strings "LAN" / "LastMile" via
+/// <see cref="JsonStringEnumListConverter{T}"/> (member names ARE the wire values).
+/// </summary>
+public enum ELagReportTag
+{
+    LAN,
+    LastMile,
+}
+
 public enum EIssueCategory
 {
     InputDelay,

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -252,7 +252,7 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
 
         // ignoreCase: true — ELagReportTag has mixed-case members (LAN, LastMile); URL query params
         // shouldn't need exact casing (matches the wire converter's case-insensitive read).
-        if (!string.IsNullOrEmpty(req.Tag) && Enum.TryParse<ELagReportTag>(req.Tag, ignoreCase: true, out var tag))
+        if (!string.IsNullOrEmpty(req.ConnectionIssueTag) && Enum.TryParse<ELagReportTag>(req.ConnectionIssueTag, ignoreCase: true, out var tag))
         {
             filters.Add(builder.ElemMatch(r => r.Players, p => p.ConnectionIssueTags.Contains(tag)));
         }

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -250,6 +250,8 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
             filters.Add(builder.ElemMatch(r => r.Players, p => p.IssueCategories.Contains(category)));
         }
 
+        // ignoreCase: true — ELagReportTag has mixed-case members (LAN, LastMile); URL query params
+        // shouldn't need exact casing (matches the wire converter's case-insensitive read).
         if (!string.IsNullOrEmpty(req.Tag) && Enum.TryParse<ELagReportTag>(req.Tag, ignoreCase: true, out var tag))
         {
             filters.Add(builder.ElemMatch(r => r.Players, p => p.Tags.Contains(tag)));

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -45,7 +45,7 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
             new(Builders<LagReport>.IndexKeys.Ascending("Players.IssueCategories")),
 
             // System-derived tag filter (inside nested array), mirrors IssueCategories
-            new(Builders<LagReport>.IndexKeys.Ascending("Players.Tags")),
+            new(Builders<LagReport>.IndexKeys.Ascending("Players.ConnectionIssueTags")),
 
             // Explicit filter — most reports are auto-submitted, admins typically filter to explicit only
             new(Builders<LagReport>.IndexKeys.Ascending(r => r.HasExplicitReport)),
@@ -254,7 +254,7 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
         // shouldn't need exact casing (matches the wire converter's case-insensitive read).
         if (!string.IsNullOrEmpty(req.Tag) && Enum.TryParse<ELagReportTag>(req.Tag, ignoreCase: true, out var tag))
         {
-            filters.Add(builder.ElemMatch(r => r.Players, p => p.Tags.Contains(tag)));
+            filters.Add(builder.ElemMatch(r => r.Players, p => p.ConnectionIssueTags.Contains(tag)));
         }
 
         if (req.ExplicitOnly == true)

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -44,6 +44,9 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
             // Issue category filter (inside nested array)
             new(Builders<LagReport>.IndexKeys.Ascending("Players.IssueCategories")),
 
+            // System-derived tag filter (inside nested array), mirrors IssueCategories
+            new(Builders<LagReport>.IndexKeys.Ascending("Players.Tags")),
+
             // Explicit filter — most reports are auto-submitted, admins typically filter to explicit only
             new(Builders<LagReport>.IndexKeys.Ascending(r => r.HasExplicitReport)),
 
@@ -245,6 +248,11 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
         if (!string.IsNullOrEmpty(req.IssueCategory) && Enum.TryParse<EIssueCategory>(req.IssueCategory, out var category))
         {
             filters.Add(builder.ElemMatch(r => r.Players, p => p.IssueCategories.Contains(category)));
+        }
+
+        if (!string.IsNullOrEmpty(req.Tag) && Enum.TryParse<ELagReportTag>(req.Tag, ignoreCase: true, out var tag))
+        {
+            filters.Add(builder.ElemMatch(r => r.Players, p => p.Tags.Contains(tag)));
         }
 
         if (req.ExplicitOnly == true)

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
@@ -324,10 +324,11 @@ public class LagReportControllerTests
     }
 
     [Test]
-    public void LagReportPlayerSummary_CarriesTags()
+    public void LagReportPlayerSummary_CanHoldTags()
     {
-        // The admin list maps LagReportPlayer -> LagReportPlayerSummary; tags must
-        // be representable on the summary so the (future) admin UI can show them.
+        // Asserts the summary DTO has the Tags property with the correct converter.
+        // The actual GetReports projection coverage is in GetReports_ListProjection_IncludesTags
+        // (LagReportTagRepositoryTests).
         var summary = new LagReportPlayerSummary { Tags = [ELagReportTag.LastMile] };
 
         Assert.AreEqual(1, summary.Tags.Count);

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
@@ -52,6 +52,7 @@ public class LagReportControllerTests
         },
         IsExplicit = true,
         Categories = [EIssueCategory.SpikeLag],
+        Tags = [ELagReportTag.LAN],
         FreeText = "Lag spike at 5 min",
         Annotations = [new AnnotationDto { GameTimeOffsetMs = 300000, Text = "Froze for 2 seconds" }],
     };
@@ -256,6 +257,32 @@ public class LagReportControllerTests
         Assert.IsEmpty(player.Diagnostics.ConnectionEvents);
         Assert.IsEmpty(player.Annotations);
         Assert.IsEmpty(player.IssueCategories);
+    }
+
+    // ── Tag mapping tests ─────────────────────────────────────────────
+
+    [Test]
+    public void MapToPlayer_CopiesTagsFromDto()
+    {
+        var dto = CreateValidDto();
+        dto.Tags = [ELagReportTag.LastMile];
+
+        var player = LagReportController.MapToPlayer(dto, "P#1");
+
+        Assert.AreEqual(1, player.Tags.Count);
+        Assert.AreEqual(ELagReportTag.LastMile, player.Tags[0]);
+    }
+
+    [Test]
+    public void MapToPlayer_NullTags_ProducesEmptyList()
+    {
+        var dto = CreateValidDto();
+        dto.Tags = null;
+
+        var player = LagReportController.MapToPlayer(dto, "P#1");
+
+        Assert.IsNotNull(player.Tags);
+        Assert.IsEmpty(player.Tags);
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
@@ -322,4 +322,15 @@ public class LagReportControllerTests
         Assert.AreEqual(1, player.Diagnostics.PingHistory.Count);
         Assert.AreEqual(25, player.Diagnostics.PingHistory[0].Avg);
     }
+
+    [Test]
+    public void LagReportPlayerSummary_CarriesTags()
+    {
+        // The admin list maps LagReportPlayer -> LagReportPlayerSummary; tags must
+        // be representable on the summary so the (future) admin UI can show them.
+        var summary = new LagReportPlayerSummary { Tags = [ELagReportTag.LastMile] };
+
+        Assert.AreEqual(1, summary.Tags.Count);
+        Assert.AreEqual(ELagReportTag.LastMile, summary.Tags[0]);
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
@@ -109,6 +109,23 @@ public class LagReportControllerTests
     }
 
     [Test]
+    public void Validate_TooManyTags_ReturnsError()
+    {
+        var dto = CreateValidDto();
+        dto.Tags = System.Linq.Enumerable.Range(0, 21)
+            .Select(_ => ELagReportTag.LAN).ToList();
+        Assert.AreEqual("Too many tags", LagReportController.ValidateSubmission(dto));
+    }
+
+    [Test]
+    public void Validate_NullTags_DoesNotThrow()
+    {
+        var dto = CreateValidDto();
+        dto.Tags = null;
+        Assert.IsNull(LagReportController.ValidateSubmission(dto));
+    }
+
+    [Test]
     public void Validate_FreeTextTooLong_ReturnsError()
     {
         var dto = CreateValidDto();

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
@@ -118,6 +118,17 @@ public class LagReportControllerTests
     }
 
     [Test]
+    public void Validate_ExactlyAtTagsCap_IsValid()
+    {
+        // Boundary: exactly 20 tags must pass (cap is > 20, not >= 20).
+        var dto = CreateValidDto();
+        dto.Tags = System.Linq.Enumerable.Range(0, 20)
+            .Select(i => i % 2 == 0 ? ELagReportTag.LAN : ELagReportTag.LastMile)
+            .ToList();
+        Assert.IsNull(LagReportController.ValidateSubmission(dto));
+    }
+
+    [Test]
     public void Validate_NullTags_DoesNotThrow()
     {
         var dto = CreateValidDto();
@@ -341,7 +352,7 @@ public class LagReportControllerTests
     }
 
     [Test]
-    public void LagReportPlayerSummary_CanHoldTags()
+    public void LagReportPlayerSummary_CarriesTags()
     {
         // Asserts the summary DTO has the Tags property with the correct converter.
         // The actual GetReports projection coverage is in GetReports_ListProjection_IncludesTags

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportControllerTests.cs
@@ -52,7 +52,7 @@ public class LagReportControllerTests
         },
         IsExplicit = true,
         Categories = [EIssueCategory.SpikeLag],
-        Tags = [ELagReportTag.LAN],
+        ConnectionIssueTags = [ELagReportTag.LAN],
         FreeText = "Lag spike at 5 min",
         Annotations = [new AnnotationDto { GameTimeOffsetMs = 300000, Text = "Froze for 2 seconds" }],
     };
@@ -112,7 +112,7 @@ public class LagReportControllerTests
     public void Validate_TooManyTags_ReturnsError()
     {
         var dto = CreateValidDto();
-        dto.Tags = System.Linq.Enumerable.Range(0, 21)
+        dto.ConnectionIssueTags = System.Linq.Enumerable.Range(0, 21)
             .Select(_ => ELagReportTag.LAN).ToList();
         Assert.AreEqual("Too many tags", LagReportController.ValidateSubmission(dto));
     }
@@ -122,7 +122,7 @@ public class LagReportControllerTests
     {
         // Boundary: exactly 20 tags must pass (cap is > 20, not >= 20).
         var dto = CreateValidDto();
-        dto.Tags = System.Linq.Enumerable.Range(0, 20)
+        dto.ConnectionIssueTags = System.Linq.Enumerable.Range(0, 20)
             .Select(i => i % 2 == 0 ? ELagReportTag.LAN : ELagReportTag.LastMile)
             .ToList();
         Assert.IsNull(LagReportController.ValidateSubmission(dto));
@@ -132,7 +132,7 @@ public class LagReportControllerTests
     public void Validate_NullTags_DoesNotThrow()
     {
         var dto = CreateValidDto();
-        dto.Tags = null;
+        dto.ConnectionIssueTags = null;
         Assert.IsNull(LagReportController.ValidateSubmission(dto));
     }
 
@@ -293,24 +293,24 @@ public class LagReportControllerTests
     public void MapToPlayer_CopiesTagsFromDto()
     {
         var dto = CreateValidDto();
-        dto.Tags = [ELagReportTag.LastMile];
+        dto.ConnectionIssueTags = [ELagReportTag.LastMile];
 
         var player = LagReportController.MapToPlayer(dto, "P#1");
 
-        Assert.AreEqual(1, player.Tags.Count);
-        Assert.AreEqual(ELagReportTag.LastMile, player.Tags[0]);
+        Assert.AreEqual(1, player.ConnectionIssueTags.Count);
+        Assert.AreEqual(ELagReportTag.LastMile, player.ConnectionIssueTags[0]);
     }
 
     [Test]
     public void MapToPlayer_NullTags_ProducesEmptyList()
     {
         var dto = CreateValidDto();
-        dto.Tags = null;
+        dto.ConnectionIssueTags = null;
 
         var player = LagReportController.MapToPlayer(dto, "P#1");
 
-        Assert.IsNotNull(player.Tags);
-        Assert.IsEmpty(player.Tags);
+        Assert.IsNotNull(player.ConnectionIssueTags);
+        Assert.IsEmpty(player.ConnectionIssueTags);
     }
 
     [Test]
@@ -354,12 +354,12 @@ public class LagReportControllerTests
     [Test]
     public void LagReportPlayerSummary_CarriesTags()
     {
-        // Asserts the summary DTO has the Tags property with the correct converter.
+        // Asserts the summary DTO has the ConnectionIssueTags property with the correct converter.
         // The actual GetReports projection coverage is in GetReports_ListProjection_IncludesTags
         // (LagReportTagRepositoryTests).
-        var summary = new LagReportPlayerSummary { Tags = [ELagReportTag.LastMile] };
+        var summary = new LagReportPlayerSummary { ConnectionIssueTags = [ELagReportTag.LastMile] };
 
-        Assert.AreEqual(1, summary.Tags.Count);
-        Assert.AreEqual(ELagReportTag.LastMile, summary.Tags[0]);
+        Assert.AreEqual(1, summary.ConnectionIssueTags.Count);
+        Assert.AreEqual(ELagReportTag.LastMile, summary.ConnectionIssueTags[0]);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagRepositoryTests.cs
@@ -35,7 +35,7 @@ public class LagReportTagRepositoryTests
     }
 
     private static LagReportPlayer CreatePlayer(
-        string battleTag, List<ELagReportTag>? tags = null) => new()
+        string battleTag, List<ELagReportTag> tags = null) => new()
         {
             BattleTag = battleTag,
             ClientIp = "203.0.113.1",
@@ -103,5 +103,70 @@ public class LagReportTagRepositoryTests
 
         Assert.IsNotNull(report.Players[0].Tags);
         Assert.IsEmpty(report.Players[0].Tags);
+    }
+
+    [Test]
+    public async Task GetReports_FiltersByTag()
+    {
+        var t1 = CreateTemplate(2001, 6001);
+        var t2 = CreateTemplate(2002, 6002);
+        await _repo.UpsertPlayerData(t1.FloGameId, CreatePlayer("Lan#1", [ELagReportTag.LAN]), t1);
+        await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("LastMile#2", [ELagReportTag.LastMile]), t2);
+
+        var (lan, lanTotal) = await _repo.GetReports(new LagReportQueryRequest { Tag = "LAN" });
+        Assert.AreEqual(1, lanTotal);
+        Assert.AreEqual(1, lan.Count);
+        Assert.AreEqual(6001, lan[0].GameId);
+
+        var (lastMile, lmTotal) = await _repo.GetReports(new LagReportQueryRequest { Tag = "LastMile" });
+        Assert.AreEqual(1, lmTotal);
+        Assert.AreEqual(6002, lastMile[0].GameId);
+    }
+
+    [Test]
+    public async Task GetReports_TagFilter_IsCaseInsensitive()
+    {
+        var t = CreateTemplate(2003, 6003);
+        await _repo.UpsertPlayerData(t.FloGameId, CreatePlayer("Lan#1", [ELagReportTag.LAN]), t);
+
+        // Enum.TryParse(ignoreCase: true) → "lan" still resolves to LAN.
+        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { Tag = "lan" });
+        Assert.AreEqual(1, items.Count);
+    }
+
+    [Test]
+    public async Task EnsureIndexesAsync_CreatesPlayersTagsIndex()
+    {
+        await _repo.EnsureIndexesAsync();
+
+        var collection = _mongoClient
+            .GetDatabase("W3Champions-Statistic-Service")
+            .GetCollection<LagReport>("LagReport");
+
+        var names = new List<string>();
+        using var cursor = await collection.Indexes.ListAsync();
+        foreach (var idx in await cursor.ToListAsync())
+        {
+            names.Add(idx["name"].AsString);
+        }
+
+        Assert.Contains("Players.Tags_1", names,
+            "Tags must be indexed like Players.IssueCategories for filterable queries");
+    }
+
+    [Test]
+    public async Task GetReports_ListProjection_IncludesTags()
+    {
+        // Tags are tiny; unlike the heavy diagnostics arrays they are NOT projected
+        // out, so the admin list can show/filter them without a detail fetch.
+        var template = CreateTemplate(2100, 6100);
+        await _repo.UpsertPlayerData(
+            template.FloGameId, CreatePlayer("Lan#1", [ELagReportTag.LAN]), template);
+
+        var (items, _) = await _repo.GetReports(new LagReportQueryRequest());
+
+        Assert.AreEqual(1, items.Count);
+        CollectionAssert.Contains(items[0].Players[0].Tags, ELagReportTag.LAN,
+            "Tags are small and must survive the list projection");
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagRepositoryTests.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mongo2Go;
+using MongoDB.Driver;
+using NUnit.Framework;
+using W3ChampionsStatisticService.LagReports;
+
+namespace WC3ChampionsStatisticService.Tests.LagReports;
+
+/// <summary>
+/// Round-trip + filter coverage for the system-derived <see cref="LagReportPlayer.Tags"/>
+/// field. Uses an ISOLATED in-memory mongod (Mongo2Go) per fixture — NOT the shared
+/// remote Mongo of <c>IntegrationTestBase</c> — to avoid cross-session contamination.
+/// Mirrors the structure of the existing Categories repository tests.
+/// </summary>
+[TestFixture]
+public class LagReportTagRepositoryTests
+{
+    private MongoDbRunner _runner;
+    private MongoClient _mongoClient;
+    private LagReportRepository _repo;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _runner = MongoDbRunner.Start();
+        _mongoClient = new MongoClient(_runner.ConnectionString);
+        _repo = new LagReportRepository(_mongoClient);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _runner.Dispose();
+    }
+
+    private static LagReportPlayer CreatePlayer(
+        string battleTag, List<ELagReportTag>? tags = null) => new()
+        {
+            BattleTag = battleTag,
+            ClientIp = "203.0.113.1",
+            ConnectionType = EConnectionType.Direct,
+            IssueCategories = [],
+            Tags = tags ?? [],
+            FreeText = "",
+            Diagnostics = new PlayerDiagnostics(),
+        };
+
+    private static LagReport CreateTemplate(int floGameId, int gameId) => new()
+    {
+        GameId = gameId,
+        FloGameId = floGameId,
+        GameName = "tag-test-game",
+        MapPath = "(2)EchoIsles.w3x",
+        ServerNodeId = 1,
+        ServerNodeName = "EU West",
+    };
+
+    [Test]
+    public async Task UpsertPlayerData_PersistsTags()
+    {
+        var template = CreateTemplate(1001, 5001);
+        var player = CreatePlayer("Tagged#1", [ELagReportTag.LastMile]);
+
+        var reportId = await _repo.UpsertPlayerData(template.FloGameId, player, template);
+        var report = await _repo.GetById(reportId);
+
+        Assert.AreEqual(1, report.Players.Count);
+        Assert.AreEqual(1, report.Players[0].Tags.Count);
+        Assert.AreEqual(ELagReportTag.LastMile, report.Players[0].Tags[0]);
+    }
+
+    [Test]
+    public async Task UpsertPlayerData_MergesTagsPerPlayerInSameGame()
+    {
+        // Two players in one flo game each carry their own (different) verdict tag.
+        // They must merge into the SAME document, each retaining its own tags.
+        var template = CreateTemplate(1002, 5002);
+        var lanPlayer = CreatePlayer("Lan#1", [ELagReportTag.LAN]);
+        var lastMilePlayer = CreatePlayer("LastMile#2", [ELagReportTag.LastMile]);
+
+        var id1 = await _repo.UpsertPlayerData(template.FloGameId, lanPlayer, template);
+        var id2 = await _repo.UpsertPlayerData(template.FloGameId, lastMilePlayer, template);
+
+        Assert.AreEqual(id1, id2, "both players merge into one per-game document");
+
+        var report = await _repo.GetById(id1);
+        Assert.AreEqual(2, report.Players.Count);
+        CollectionAssert.Contains(report.Players[0].Tags, ELagReportTag.LAN);
+        CollectionAssert.Contains(report.Players[1].Tags, ELagReportTag.LastMile);
+    }
+
+    [Test]
+    public async Task UpsertPlayerData_EmptyTags_RoundTripsAsEmpty()
+    {
+        // A player with no verdict (Beyond/None/Insufficient) stores an empty
+        // tag list and does not break deserialization.
+        var template = CreateTemplate(1003, 5003);
+        var player = CreatePlayer("Untagged#3");
+
+        var reportId = await _repo.UpsertPlayerData(template.FloGameId, player, template);
+        var report = await _repo.GetById(reportId);
+
+        Assert.IsNotNull(report.Players[0].Tags);
+        Assert.IsEmpty(report.Players[0].Tags);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagRepositoryTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Mongo2Go;
 using MongoDB.Driver;
@@ -116,11 +117,14 @@ public class LagReportTagRepositoryTests
         var (lan, lanTotal) = await _repo.GetReports(new LagReportQueryRequest { Tag = "LAN" });
         Assert.AreEqual(1, lanTotal);
         Assert.AreEqual(1, lan.Count);
-        Assert.AreEqual(6001, lan[0].GameId);
+        CollectionAssert.Contains(lan.Select(r => r.GameId).ToList(), 6001);
+        CollectionAssert.DoesNotContain(lan.Select(r => r.GameId).ToList(), 6002);
 
         var (lastMile, lmTotal) = await _repo.GetReports(new LagReportQueryRequest { Tag = "LastMile" });
         Assert.AreEqual(1, lmTotal);
-        Assert.AreEqual(6002, lastMile[0].GameId);
+        Assert.AreEqual(1, lastMile.Count);
+        CollectionAssert.Contains(lastMile.Select(r => r.GameId).ToList(), 6002);
+        CollectionAssert.DoesNotContain(lastMile.Select(r => r.GameId).ToList(), 6001);
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagRepositoryTests.cs
@@ -114,13 +114,13 @@ public class LagReportTagRepositoryTests
         await _repo.UpsertPlayerData(t1.FloGameId, CreatePlayer("Lan#1", [ELagReportTag.LAN]), t1);
         await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("LastMile#2", [ELagReportTag.LastMile]), t2);
 
-        var (lan, lanTotal) = await _repo.GetReports(new LagReportQueryRequest { Tag = "LAN" });
+        var (lan, lanTotal) = await _repo.GetReports(new LagReportQueryRequest { ConnectionIssueTag = "LAN" });
         Assert.AreEqual(1, lanTotal);
         Assert.AreEqual(1, lan.Count);
         CollectionAssert.Contains(lan.Select(r => r.GameId).ToList(), 6001);
         CollectionAssert.DoesNotContain(lan.Select(r => r.GameId).ToList(), 6002);
 
-        var (lastMile, lmTotal) = await _repo.GetReports(new LagReportQueryRequest { Tag = "LastMile" });
+        var (lastMile, lmTotal) = await _repo.GetReports(new LagReportQueryRequest { ConnectionIssueTag = "LastMile" });
         Assert.AreEqual(1, lmTotal);
         Assert.AreEqual(1, lastMile.Count);
         CollectionAssert.Contains(lastMile.Select(r => r.GameId).ToList(), 6002);
@@ -134,7 +134,7 @@ public class LagReportTagRepositoryTests
         await _repo.UpsertPlayerData(t.FloGameId, CreatePlayer("Lan#1", [ELagReportTag.LAN]), t);
 
         // Enum.TryParse(ignoreCase: true) → "lan" still resolves to LAN.
-        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { Tag = "lan" });
+        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { ConnectionIssueTag = "lan" });
         Assert.AreEqual(1, items.Count);
     }
 

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagRepositoryTests.cs
@@ -9,7 +9,7 @@ using W3ChampionsStatisticService.LagReports;
 namespace WC3ChampionsStatisticService.Tests.LagReports;
 
 /// <summary>
-/// Round-trip + filter coverage for the system-derived <see cref="LagReportPlayer.Tags"/>
+/// Round-trip + filter coverage for the system-derived <see cref="LagReportPlayer.ConnectionIssueTags"/>
 /// field. Uses an ISOLATED in-memory mongod (Mongo2Go) per fixture — NOT the shared
 /// remote Mongo of <c>IntegrationTestBase</c> — to avoid cross-session contamination.
 /// Mirrors the structure of the existing Categories repository tests.
@@ -42,7 +42,7 @@ public class LagReportTagRepositoryTests
             ClientIp = "203.0.113.1",
             ConnectionType = EConnectionType.Direct,
             IssueCategories = [],
-            Tags = tags ?? [],
+            ConnectionIssueTags = tags ?? [],
             FreeText = "",
             Diagnostics = new PlayerDiagnostics(),
         };
@@ -67,8 +67,8 @@ public class LagReportTagRepositoryTests
         var report = await _repo.GetById(reportId);
 
         Assert.AreEqual(1, report.Players.Count);
-        Assert.AreEqual(1, report.Players[0].Tags.Count);
-        Assert.AreEqual(ELagReportTag.LastMile, report.Players[0].Tags[0]);
+        Assert.AreEqual(1, report.Players[0].ConnectionIssueTags.Count);
+        Assert.AreEqual(ELagReportTag.LastMile, report.Players[0].ConnectionIssueTags[0]);
     }
 
     [Test]
@@ -87,8 +87,8 @@ public class LagReportTagRepositoryTests
 
         var report = await _repo.GetById(id1);
         Assert.AreEqual(2, report.Players.Count);
-        CollectionAssert.Contains(report.Players[0].Tags, ELagReportTag.LAN);
-        CollectionAssert.Contains(report.Players[1].Tags, ELagReportTag.LastMile);
+        CollectionAssert.Contains(report.Players[0].ConnectionIssueTags, ELagReportTag.LAN);
+        CollectionAssert.Contains(report.Players[1].ConnectionIssueTags, ELagReportTag.LastMile);
     }
 
     [Test]
@@ -102,8 +102,8 @@ public class LagReportTagRepositoryTests
         var reportId = await _repo.UpsertPlayerData(template.FloGameId, player, template);
         var report = await _repo.GetById(reportId);
 
-        Assert.IsNotNull(report.Players[0].Tags);
-        Assert.IsEmpty(report.Players[0].Tags);
+        Assert.IsNotNull(report.Players[0].ConnectionIssueTags);
+        Assert.IsEmpty(report.Players[0].ConnectionIssueTags);
     }
 
     [Test]
@@ -154,8 +154,8 @@ public class LagReportTagRepositoryTests
             names.Add(idx["name"].AsString);
         }
 
-        Assert.Contains("Players.Tags_1", names,
-            "Tags must be indexed like Players.IssueCategories for filterable queries");
+        Assert.Contains("Players.ConnectionIssueTags_1", names,
+            "ConnectionIssueTags must be indexed like Players.IssueCategories for filterable queries");
     }
 
     [Test]
@@ -170,7 +170,7 @@ public class LagReportTagRepositoryTests
         var (items, _) = await _repo.GetReports(new LagReportQueryRequest());
 
         Assert.AreEqual(1, items.Count);
-        CollectionAssert.Contains(items[0].Players[0].Tags, ELagReportTag.LAN,
-            "Tags are small and must survive the list projection");
+        CollectionAssert.Contains(items[0].Players[0].ConnectionIssueTags, ELagReportTag.LAN,
+            "ConnectionIssueTags are small and must survive the list projection");
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagSerializationTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagSerializationTests.cs
@@ -8,9 +8,9 @@ namespace WC3ChampionsStatisticService.Tests.LagReports;
 
 /// <summary>
 /// The launcher submits the system-derived connection verdict as a string array
-/// under "tags": ["LAN"] / ["LastMile"] / []. These tests pin the exact wire
-/// contract: the <see cref="ELagReportTag"/> members must serialize to and
-/// deserialize from the literal strings "LAN" and "LastMile" via the shared
+/// under "connection_issue_tags": ["LAN"] / ["LastMile"] / []. These tests pin
+/// the exact wire contract: the <see cref="ELagReportTag"/> members must serialize
+/// to and deserialize from the literal strings "LAN" and "LastMile" via the shared
 /// <see cref="JsonStringEnumListConverter{T}"/> (case-insensitive read).
 /// </summary>
 [TestFixture]
@@ -73,7 +73,7 @@ public class LagReportTagSerializationTests
           "is_explicit": false,
           "free_text": "",
           "categories": ["SpikeLag"],
-          "tags": ["LAN"]
+          "connection_issue_tags": ["LAN"]
         }
         """;
 
@@ -111,7 +111,7 @@ public class LagReportTagSerializationTests
         const string json = """
         {
           "is_explicit": false,
-          "tags": ["LastMile"],
+          "connection_issue_tags": ["LastMile"],
           "some_future_field": { "nested": 123 },
           "another_unknown": "ignored"
         }

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagSerializationTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagSerializationTests.cs
@@ -79,7 +79,7 @@ public class LagReportTagSerializationTests
 
         var dto = JsonSerializer.Deserialize<LagReportSubmissionDto>(json, Web);
 
-        Assert.That(dto!.Tags, Is.EqualTo(new List<ELagReportTag> { ELagReportTag.LAN }));
+        Assert.That(dto!.ConnectionIssueTags, Is.EqualTo(new List<ELagReportTag> { ELagReportTag.LAN }));
         // Categories still parse independently — the two are distinct fields.
         Assert.That(dto.Categories, Is.EqualTo(new List<EIssueCategory> { EIssueCategory.SpikeLag }));
     }
@@ -99,8 +99,8 @@ public class LagReportTagSerializationTests
 
         var dto = JsonSerializer.Deserialize<LagReportSubmissionDto>(json, Web);
 
-        Assert.That(dto!.Tags, Is.Not.Null);
-        Assert.That(dto.Tags, Is.Empty);
+        Assert.That(dto!.ConnectionIssueTags, Is.Not.Null);
+        Assert.That(dto.ConnectionIssueTags, Is.Empty);
     }
 
     [Test]
@@ -119,6 +119,6 @@ public class LagReportTagSerializationTests
 
         var dto = JsonSerializer.Deserialize<LagReportSubmissionDto>(json, Web);
 
-        Assert.That(dto!.Tags, Is.EqualTo(new List<ELagReportTag> { ELagReportTag.LastMile }));
+        Assert.That(dto!.ConnectionIssueTags, Is.EqualTo(new List<ELagReportTag> { ELagReportTag.LastMile }));
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagSerializationTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagSerializationTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using NUnit.Framework;
 using W3ChampionsStatisticService.LagReports;
 
@@ -19,8 +20,8 @@ public class LagReportTagSerializationTests
     // is on the DTO property.
     private sealed class TagHolder
     {
-        [System.Text.Json.Serialization.JsonPropertyName("tags")]
-        [System.Text.Json.Serialization.JsonConverter(typeof(JsonStringEnumListConverter<ELagReportTag>))]
+        [JsonPropertyName("tags")]
+        [JsonConverter(typeof(JsonStringEnumListConverter<ELagReportTag>))]
         public List<ELagReportTag> Tags { get; set; } = [];
     }
 
@@ -33,9 +34,8 @@ public class LagReportTagSerializationTests
 
         var json = JsonSerializer.Serialize(holder, Web);
 
-        // Exact literals — these are the strings the launcher sends/reads.
-        Assert.That(json, Does.Contain("\"LAN\""));
-        Assert.That(json, Does.Contain("\"LastMile\""));
+        // Exact array shape — pins both member order and wire strings in one assertion.
+        Assert.That(json, Does.Contain("[\"LAN\",\"LastMile\"]"));
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagSerializationTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagSerializationTests.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using NUnit.Framework;
+using W3ChampionsStatisticService.LagReports;
+
+namespace WC3ChampionsStatisticService.Tests.LagReports;
+
+/// <summary>
+/// The launcher submits the system-derived connection verdict as a string array
+/// under "tags": ["LAN"] / ["LastMile"] / []. These tests pin the exact wire
+/// contract: the <see cref="ELagReportTag"/> members must serialize to and
+/// deserialize from the literal strings "LAN" and "LastMile" via the shared
+/// <see cref="JsonStringEnumListConverter{T}"/> (case-insensitive read).
+/// </summary>
+[TestFixture]
+public class LagReportTagSerializationTests
+{
+    // A holder so the [JsonConverter] list converter is exercised exactly as it
+    // is on the DTO property.
+    private sealed class TagHolder
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("tags")]
+        [System.Text.Json.Serialization.JsonConverter(typeof(JsonStringEnumListConverter<ELagReportTag>))]
+        public List<ELagReportTag> Tags { get; set; } = [];
+    }
+
+    private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+    [Test]
+    public void Tags_serialize_to_exact_wire_strings_LAN_and_LastMile()
+    {
+        var holder = new TagHolder { Tags = [ELagReportTag.LAN, ELagReportTag.LastMile] };
+
+        var json = JsonSerializer.Serialize(holder, Web);
+
+        // Exact literals — these are the strings the launcher sends/reads.
+        Assert.That(json, Does.Contain("\"LAN\""));
+        Assert.That(json, Does.Contain("\"LastMile\""));
+    }
+
+    [Test]
+    public void Tags_deserialize_from_LAN_and_LastMile()
+    {
+        const string json = """{ "tags": ["LAN", "LastMile"] }""";
+
+        var holder = JsonSerializer.Deserialize<TagHolder>(json, Web);
+
+        Assert.That(holder!.Tags, Is.EqualTo(new List<ELagReportTag>
+        {
+            ELagReportTag.LAN, ELagReportTag.LastMile,
+        }));
+    }
+
+    [Test]
+    public void Tags_deserialize_is_case_insensitive()
+    {
+        // The shared list converter uses Enum.TryParse(ignoreCase: true).
+        const string json = """{ "tags": ["lan", "lastmile"] }""";
+
+        var holder = JsonSerializer.Deserialize<TagHolder>(json, Web);
+
+        Assert.That(holder!.Tags, Is.EqualTo(new List<ELagReportTag>
+        {
+            ELagReportTag.LAN, ELagReportTag.LastMile,
+        }));
+    }
+
+    [Test]
+    public void SubmissionDto_deserializes_body_WITH_tags()
+    {
+        const string json = """
+        {
+          "is_explicit": false,
+          "free_text": "",
+          "categories": ["SpikeLag"],
+          "tags": ["LAN"]
+        }
+        """;
+
+        var dto = JsonSerializer.Deserialize<LagReportSubmissionDto>(json, Web);
+
+        Assert.That(dto!.Tags, Is.EqualTo(new List<ELagReportTag> { ELagReportTag.LAN }));
+        // Categories still parse independently — the two are distinct fields.
+        Assert.That(dto.Categories, Is.EqualTo(new List<EIssueCategory> { EIssueCategory.SpikeLag }));
+    }
+
+    [Test]
+    public void SubmissionDto_deserializes_body_WITHOUT_tags_DefaultsToEmpty()
+    {
+        // Older launcher payloads omit "tags" entirely. Must default to an empty
+        // list, never null, and never throw.
+        const string json = """
+        {
+          "is_explicit": false,
+          "free_text": "",
+          "categories": []
+        }
+        """;
+
+        var dto = JsonSerializer.Deserialize<LagReportSubmissionDto>(json, Web);
+
+        Assert.That(dto!.Tags, Is.Not.Null);
+        Assert.That(dto.Tags, Is.Empty);
+    }
+
+    [Test]
+    public void SubmissionDto_tolerates_unknown_extra_field()
+    {
+        // System.Text.Json Web defaults ignore unknown members (no
+        // [JsonExtensionData] needed) — a forward-compat payload must still bind.
+        const string json = """
+        {
+          "is_explicit": false,
+          "tags": ["LastMile"],
+          "some_future_field": { "nested": 123 },
+          "another_unknown": "ignored"
+        }
+        """;
+
+        var dto = JsonSerializer.Deserialize<LagReportSubmissionDto>(json, Web);
+
+        Assert.That(dto!.Tags, Is.EqualTo(new List<ELagReportTag> { ELagReportTag.LastMile }));
+    }
+}


### PR DESCRIPTION
## Summary

Adds optional **`tags`** to lag-report submissions so player-side network issues can be categorised and filtered. The desktop client classifies whether a post-game connection problem was on the player's local network (`LAN`) or the link to their ISP (`LastMile`) and attaches the corresponding tag to the background lag report it already submits.

This PR is the backend half: accept, persist, index, filter, and surface those tags.

## Changes

- `ELagReportTag` enum (`LAN`, `LastMile`) — member names are the wire strings via the existing `JsonStringEnumListConverter`.
- `tags` on the submission DTO — tolerant of the field being **absent** (older clients) and of unknown values.
- Persist `Tags` on `LagReportPlayer` (BSON int array); map from the submission DTO.
- Index `Players.Tags`; add a case-insensitive `tag` filter to the report query endpoint (unknown tag ⇒ no filter, not an error).
- Surface `Tags` in the admin list projection.
- Cap the number of tags in submission validation (mirrors the existing categories cap).
- Boyscout: the validation method's inline numeric caps are now named constants.

## Compatibility / rollout

Fully backward-compatible — `tags` absent behaves exactly as empty, so this can (and should) **deploy before** the client change ships. No migration required.

## Tests

Isolated Mongo2Go coverage: BSON round-trip, multi-player single-game merge, filter-by-tag (positive + negative), case-insensitivity, index existence, list-projection retention, and the validation cap boundary. `dotnet format --verify-no-changes` clean.

## Test plan

- [ ] CI green
- [ ] Submit a report with `tags: ["LAN"]` ⇒ persists and is filterable; submit one with no `tags` ⇒ no regression
