### PR TITLE
Pass through pause/resume/leave events on replay chat log

### DIFF
--- a/W3C.Contracts/Replay/ReplayChatsData.cs
+++ b/W3C.Contracts/Replay/ReplayChatsData.cs
@@ -64,8 +64,11 @@ public class ReplayGameEvent
     [JsonProperty("player_id")]
     public int PlayerId { get; set; }
 
-    // Only present for Leave events (LeaveReason code from the replay)
-    public int? Reason { get; set; }
+    // Only present for Leave events. A snake_case LeaveReason string emitted by
+    // the replay service (e.g. "disconnect", "lost_buildings", "won"). Passed
+    // through verbatim; the website remaps it to human-readable text.
+    [JsonProperty("leave_reason")]
+    public string LeaveReason { get; set; }
 }
 
 public enum ReplayGameEventType

--- a/W3C.Contracts/Replay/ReplayChatsData.cs
+++ b/W3C.Contracts/Replay/ReplayChatsData.cs
@@ -8,6 +8,9 @@ public class ReplayChatsData
     public List<ReplayChatsPlayerInfo> Players { get; set; }
 
     public List<ReplayChatsMessage> Messages { get; set; }
+
+    // Pause/resume/leave events parsed from the replay, ordered by Time.
+    public List<ReplayGameEvent> Events { get; set; }
 }
 
 public class ReplayChatsPlayerInfo
@@ -48,4 +51,26 @@ public enum ReplayChatsScopeType
     Allies,
     Observers,
     Player,
+}
+
+public class ReplayGameEvent
+{
+    public ReplayGameEventType Type { get; set; }
+
+    // Time in milliseconds, when this happened in-game
+    [JsonProperty("time")]
+    public int Time { get; set; }
+
+    [JsonProperty("player_id")]
+    public int PlayerId { get; set; }
+
+    // Only present for Leave events (LeaveReason code from the replay)
+    public int? Reason { get; set; }
+}
+
+public enum ReplayGameEventType
+{
+    Pause,
+    Resume,
+    Leave,
 }


### PR DESCRIPTION
## What

Forwards the new **pause / unpause / player-leave events** from the replay service through the replay chat log endpoints (`GET /api/replays/{gameId}/chats` and the `by-flo-id` variant), so the website admin can display them.

## How

Pure pass-through — `ReplaysController.GetReplayChatLogs` already returns the whole deserialized object, so the only change is the contract in `W3C.Contracts/Replay/ReplayChatsData.cs`:

- New `Events` list on `ReplayChatsData`.
- New `ReplayGameEvent` (`Type`, `Time`, `PlayerId`, optional `LeaveReason`) and `ReplayGameEventType` enum (`Pause`, `Resume`, `Leave`).
- `LeaveReason` is modeled as a **`string`** (the replay service's snake_case `leave_reason` enum, e.g. `"disconnect"`, `"lost_buildings"`), passed through verbatim. Kept as a string rather than a C# enum because the inbound (Newtonsoft) and outbound (System.Text.Json) serializers would otherwise diverge on snake_case enum names; the real enum lives in the replay service and the website.

Naming/serialization follows the existing `ReplayChatsScope` pattern: `[JsonProperty]` snake_case attributes for **deserializing** the replay service's JSON, while the **outgoing** response uses the app default (System.Text.Json, camelCase, enums as integers) — so the website receives `{ "type": 0, "time": ..., "playerId": ..., "reason": ... }`, mirroring how `scope.type` is already a numeric enum on the frontend.

## Testing

- `.NET` SDK isn't available in my environment, so this wasn't compiled here — it's a straightforward additive DTO. Please run `dotnet build` on merge.
- The field is `null` until the replay service deploys the producing change; the website tolerates that.

## Deploy / merge ordering (read before rolling out)

All three repos in this change are **additive and backward/forward-compatible**.

| Repo | Change | Safe out of order? |
|------|--------|--------------------|
| **replay-service** | emits new `events` array | yes |
| **website-backend** (this PR) | passes `events` through (null until replay-service deploys) | yes — harmless before replay-service |
| **website** | renders events; guards `events ?? []` | yes |

**Recommended deploy order:** `replay-service` → `website-backend` → `website`. This PR is safe to deploy at any time (the field is simply null until the replay service produces it). No DB migrations; rollback just drops the field.

Companion PRs:
- replay-service: https://github.com/w3champions/replay-service/pull/1
- website: https://github.com/w3champions/website/pull/1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)
