### PR TITLE
Pass through in-game time on replay chat log

### DIFF
--- a/W3C.Contracts/Replay/ReplayChatsData.cs
+++ b/W3C.Contracts/Replay/ReplayChatsData.cs
@@ -26,9 +26,13 @@ public class ReplayChatsPlayerInfo
 
 public class ReplayChatsMessage
 {
-    // Time in milliseconds, when the player said this in-game
+    // Real elapsed time in milliseconds (advances even while the game is paused).
     [JsonProperty("time")]
     public int Time { get; set; }
+
+    // In-game clock in milliseconds (frozen while the game is paused).
+    [JsonProperty("game_time")]
+    public int GameTime { get; set; }
 
     [JsonProperty("from_player")]
     public int FromPlayer { get; set; }
@@ -57,9 +61,13 @@ public class ReplayGameEvent
 {
     public ReplayGameEventType Type { get; set; }
 
-    // Time in milliseconds, when this happened in-game
+    // Real elapsed time in milliseconds (advances even while the game is paused).
     [JsonProperty("time")]
     public int Time { get; set; }
+
+    // In-game clock in milliseconds (frozen while the game is paused).
+    [JsonProperty("game_time")]
+    public int GameTime { get; set; }
 
     [JsonProperty("player_id")]
     public int PlayerId { get; set; }


### PR DESCRIPTION
## What

Adds `GameTime` alongside `Time` on replay chat messages and game events, so the website can show both clocks.

- **`Time`** — real elapsed time (advances even while the game is paused).
- **`GameTime`** — the in-game simulation clock (frozen while paused).

## How

Pure pass-through DTO change in `W3C.Contracts/Replay/ReplayChatsData.cs`: a new `[JsonProperty("game_time")] int GameTime` on `ReplayChatsMessage` and `ReplayGameEvent`. The replay service now emits `game_time`; the controller already returns the whole object.

## Scope / ordering

Depends on the replay-service change that emits `game_time` (w3champions/replay-service#4). Safe to deploy in any order — `GameTime` is just `0` until the replay service ships it. No backend logic change; not compiled here (no .NET SDK in env), please `dotnet build` on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)