### PR TITLE
Add matches/search-opponents endpoint

### DIFF
--- a/W3ChampionsStatisticService/Matches/MatchRepository.cs
+++ b/W3ChampionsStatisticService/Matches/MatchRepository.cs
@@ -5,6 +5,7 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
@@ -138,6 +139,61 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
         var mongoCollection = CreateCollection<Matchup>();
         var filter = BuildPlayerMatchupFilter(playerId, opponentId, gateWay, gameMode, playerRace, opponentRace, season, hero, playerIncludeRandom, opponentIncludeRandom);
         return mongoCollection.CountDocumentsAsync(filter);
+    }
+
+    // Finds the players a given player shares finished matches with, filtered by
+    // a (case-insensitive) battleTag fragment and ordered by shared match count.
+    // The aggregation only ever touches the player's own matches of that season,
+    // so it stays cheap even for very active players.
+    public async Task<List<OpponentInfo>> SearchOpponentsFor(
+        string playerId,
+        string search,
+        int season,
+        GateWay gateWay = GateWay.Undefined,
+        int limit = 10)
+    {
+        var mongoCollection = CreateCollection<Matchup>();
+        var builder = Builders<Matchup>.Filter;
+        var playerMatchesFilter = builder.Where(m => m.Teams.Any(team => team.Players.Any(player => player.BattleTag == playerId)))
+            & builder.Where(m => m.Season == season)
+            & builder.Where(m => gateWay == GateWay.Undefined || m.GateWay == gateWay);
+
+        // An empty search matches everyone, i.e. returns the most played opponents.
+        var opponentFilter = new BsonDocument
+        {
+            {
+                "Teams.Players.BattleTag", new BsonDocument
+                {
+                    { "$regex", Regex.Escape(search ?? string.Empty) },
+                    { "$options", "i" },
+                    { "$ne", playerId }
+                }
+            }
+        };
+
+        return await mongoCollection.Aggregate()
+            .Match(playerMatchesFilter)
+            // Drop everything but the battleTags before unwinding so the rest of
+            // the pipeline never carries full match documents.
+            .Project(new BsonDocument { { "Teams.Players.BattleTag", 1 } })
+            .Unwind("Teams")
+            .Unwind("Teams.Players")
+            .Match(opponentFilter)
+            .Group(new BsonDocument
+            {
+                { "_id", "$Teams.Players.BattleTag" },
+                { "MatchCount", new BsonDocument("$sum", 1) }
+            })
+            .Sort(new BsonDocument { { "MatchCount", -1 }, { "_id", 1 } })
+            .Limit(limit)
+            .Project(new BsonDocument
+            {
+                { "_id", 0 },
+                { "BattleTag", "$_id" },
+                { "MatchCount", 1 }
+            })
+            .As<OpponentInfo>()
+            .ToListAsync();
     }
 
     private FilterDefinition<Matchup> BuildPlayerMatchupFilter(

--- a/W3ChampionsStatisticService/Matches/MatchRepository.cs
+++ b/W3ChampionsStatisticService/Matches/MatchRepository.cs
@@ -145,11 +145,16 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
     // a (case-insensitive) battleTag fragment and ordered by shared match count.
     // The aggregation only ever touches the player's own matches of that season,
     // so it stays cheap even for very active players.
+    //
+    // MatchCount is scoped to the given game mode (all modes when Undefined), but
+    // opponents are still suggested from every mode: the mode-scoped count can be 0
+    // and the client says so, instead of the opponent silently becoming unfindable.
     public async Task<List<OpponentInfo>> SearchOpponentsFor(
         string playerId,
         string search,
         int season,
         GateWay gateWay = GateWay.Undefined,
+        GameMode gameMode = GameMode.Undefined,
         int limit = 10)
     {
         var mongoCollection = CreateCollection<Matchup>();
@@ -171,20 +176,31 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
             }
         };
 
+        var inModeCount = gameMode == GameMode.Undefined
+            ? (BsonValue)1
+            : new BsonDocument("$cond", new BsonArray
+            {
+                new BsonDocument("$eq", new BsonArray { "$GameMode", (int)gameMode }),
+                1,
+                0
+            });
+
         return await mongoCollection.Aggregate()
             .Match(playerMatchesFilter)
-            // Drop everything but the battleTags before unwinding so the rest of
-            // the pipeline never carries full match documents.
-            .Project(new BsonDocument { { "Teams.Players.BattleTag", 1 } })
+            // Drop everything but the battleTags and mode before unwinding so the
+            // rest of the pipeline never carries full match documents.
+            .Project(new BsonDocument { { "Teams.Players.BattleTag", 1 }, { "GameMode", 1 } })
             .Unwind("Teams")
             .Unwind("Teams.Players")
             .Match(opponentFilter)
             .Group(new BsonDocument
             {
                 { "_id", "$Teams.Players.BattleTag" },
-                { "MatchCount", new BsonDocument("$sum", 1) }
+                { "MatchCount", new BsonDocument("$sum", inModeCount) },
+                { "TotalCount", new BsonDocument("$sum", 1) }
             })
-            .Sort(new BsonDocument { { "MatchCount", -1 }, { "_id", 1 } })
+            // In-mode opponents first, then whoever shares the most matches overall.
+            .Sort(new BsonDocument { { "MatchCount", -1 }, { "TotalCount", -1 }, { "_id", 1 } })
             .Limit(limit)
             .Project(new BsonDocument
             {

--- a/W3ChampionsStatisticService/Matches/MatchRepository.cs
+++ b/W3ChampionsStatisticService/Matches/MatchRepository.cs
@@ -59,6 +59,14 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
                     .Text(x => x.Team2Players)
                     .Text(x => x.Team3Players)
                     .Text(x => x.Team4Players)
+            ),
+
+            // Per-player queries: the match-history list (LoadFor) and the
+            // opponent search both filter by a player's battleTag and season.
+            new CreateIndexModel<Matchup>(
+                Builders<Matchup>.IndexKeys
+                    .Ascending("Teams.Players.BattleTag")
+                    .Descending(x => x.Season)
             )
         };
 
@@ -146,11 +154,13 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
     // The aggregation only ever touches the player's own matches of that season,
     // so it stays cheap even for very active players.
     //
-    // MatchCount is scoped to the given game mode (all modes when Undefined), but
-    // opponents are still suggested from every mode: the mode-scoped count can be 0
-    // and the client says so, instead of the opponent silently becoming unfindable.
+    // MatchCount, Wins and Losses are scoped to the given game mode (all modes
+    // when Undefined), but opponents are still suggested from every mode: the
+    // mode-scoped count can be 0 and the client says so, instead of the opponent
+    // silently becoming unfindable. Wins/Losses are the searched player's record
+    // across the shared matches — allies share the same result.
     public async Task<List<OpponentInfo>> SearchOpponentsFor(
-        string playerId,
+        string battleTag,
         string search,
         int season,
         GateWay gateWay = GateWay.Undefined,
@@ -159,37 +169,74 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
     {
         var mongoCollection = CreateCollection<Matchup>();
         var builder = Builders<Matchup>.Filter;
-        var playerMatchesFilter = builder.Where(m => m.Teams.Any(team => team.Players.Any(player => player.BattleTag == playerId)))
+        var playerMatchesFilter = builder.Where(m => m.Teams.Any(team => team.Players.Any(player => player.BattleTag == battleTag)))
             & builder.Where(m => m.Season == season)
             & builder.Where(m => gateWay == GateWay.Undefined || m.GateWay == gateWay);
 
-        // An empty search matches everyone, i.e. returns the most played opponents.
-        var opponentFilter = new BsonDocument
+        // Everyone the player shared those matches with, except the player
+        // themselves; a non-empty search narrows to a case-insensitive fragment,
+        // an empty one returns the most played opponents.
+        var battleTagCondition = new BsonDocument { { "$ne", battleTag } };
+        if (!string.IsNullOrEmpty(search))
+        {
+            battleTagCondition.Add("$regex", Regex.Escape(search));
+            battleTagCondition.Add("$options", "i");
+        }
+        var opponentFilter = new BsonDocument { { "Teams.Players.BattleTag", battleTagCondition } };
+
+        var inMode = gameMode == GameMode.Undefined
+            ? (BsonValue)true
+            : new BsonDocument("$eq", new BsonArray { "$GameMode", (int)gameMode });
+
+        var inModeCount = new BsonDocument("$cond", new BsonArray { inMode, 1, 0 });
+        var inModeWin = new BsonDocument("$cond", new BsonArray
+        {
+            new BsonDocument("$and", new BsonArray
+            {
+                inMode,
+                new BsonDocument("$eq", new BsonArray { "$PlayerWon", true })
+            }),
+            1,
+            0
+        });
+
+        // Whether the searched player won a match, resolved before the unwinds
+        // while the match still has all its teams.
+        var playerWon = new BsonDocument("$let", new BsonDocument
         {
             {
-                "Teams.Players.BattleTag", new BsonDocument
+                "vars", new BsonDocument("self", new BsonDocument("$arrayElemAt", new BsonArray
                 {
-                    { "$regex", Regex.Escape(search ?? string.Empty) },
-                    { "$options", "i" },
-                    { "$ne", playerId }
-                }
-            }
-        };
-
-        var inModeCount = gameMode == GameMode.Undefined
-            ? (BsonValue)1
-            : new BsonDocument("$cond", new BsonArray
-            {
-                new BsonDocument("$eq", new BsonArray { "$GameMode", (int)gameMode }),
-                1,
-                0
-            });
+                    new BsonDocument("$filter", new BsonDocument
+                    {
+                        {
+                            "input", new BsonDocument("$reduce", new BsonDocument
+                            {
+                                { "input", "$Teams.Players" },
+                                { "initialValue", new BsonArray() },
+                                { "in", new BsonDocument("$concatArrays", new BsonArray { "$$value", "$$this" }) }
+                            })
+                        },
+                        { "as", "player" },
+                        { "cond", new BsonDocument("$eq", new BsonArray { "$$player.BattleTag", battleTag }) }
+                    }),
+                    0
+                }))
+            },
+            { "in", "$$self.Won" }
+        });
 
         return await mongoCollection.Aggregate()
             .Match(playerMatchesFilter)
-            // Drop everything but the battleTags and mode before unwinding so the
-            // rest of the pipeline never carries full match documents.
-            .Project(new BsonDocument { { "Teams.Players.BattleTag", 1 }, { "GameMode", 1 } })
+            // Drop everything but the battleTags, mode and the player's result
+            // before unwinding so the rest of the pipeline never carries full
+            // match documents.
+            .Project(new BsonDocument
+            {
+                { "Teams.Players.BattleTag", 1 },
+                { "GameMode", 1 },
+                { "PlayerWon", playerWon }
+            })
             .Unwind("Teams")
             .Unwind("Teams.Players")
             .Match(opponentFilter)
@@ -197,6 +244,7 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
             {
                 { "_id", "$Teams.Players.BattleTag" },
                 { "MatchCount", new BsonDocument("$sum", inModeCount) },
+                { "Wins", new BsonDocument("$sum", inModeWin) },
                 { "TotalCount", new BsonDocument("$sum", 1) }
             })
             // In-mode opponents first, then whoever shares the most matches overall.
@@ -206,7 +254,9 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
             {
                 { "_id", 0 },
                 { "BattleTag", "$_id" },
-                { "MatchCount", 1 }
+                { "MatchCount", 1 },
+                { "Wins", 1 },
+                { "Losses", new BsonDocument("$subtract", new BsonArray { "$MatchCount", "$Wins" }) }
             })
             .As<OpponentInfo>()
             .ToListAsync();
@@ -342,6 +392,65 @@ public class MatchRepository(MongoClient mongoClient, IOngoingMatchesCache cache
             .ToListAsync();
 
         return mapNames.OrderBy(mapName => mapName).ToList();
+    }
+
+    // Net MMR movement per ladder entry (player + queued race, so random players pool
+    // under RnD) summed from every match a player finished inside the window. The window
+    // is applied on _id because ObjectIds carry the insertion timestamp — matchups are
+    // written when the match finishes, so this rides the _id index instead of needing a
+    // new EndTime index. Placement-grade entries (rank deviation at or above the
+    // obfuscation threshold) are excluded, mirroring what the site is willing to show.
+    public async Task<List<MmrRiser>> LoadMmrRisers(int season, GameMode gameMode, DateTimeOffset since, int top)
+    {
+        var mongoCollection = CreateCollection<Matchup>();
+        var cutoffId = new ObjectId(((int)since.ToUnixTimeSeconds()).ToString("x8") + "0000000000000000");
+
+        var stages = new[]
+        {
+            new BsonDocument("$match", new BsonDocument
+            {
+                { "_id", new BsonDocument("$gte", cutoffId) },
+                { "Season", season },
+                { "GameMode", (int)gameMode },
+            }),
+            // Chronological order so $last below picks each entry's latest state.
+            new BsonDocument("$sort", new BsonDocument("_id", 1)),
+            new BsonDocument("$unwind", "$Teams"),
+            new BsonDocument("$unwind", "$Teams.Players"),
+            new BsonDocument("$match", new BsonDocument
+            {
+                { "Teams.Players.OldMmr", new BsonDocument("$gt", 0) },
+                { "Teams.Players.CurrentMmr", new BsonDocument("$gt", 0) },
+                { "Teams.Players.OldRankDeviation", new BsonDocument("$not", new BsonDocument("$gte", PlayersObfuscator.RankDeviationObfuscationThreshold)) },
+            }),
+            new BsonDocument("$group", new BsonDocument
+            {
+                { "_id", new BsonDocument { { "battleTag", "$Teams.Players.BattleTag" }, { "race", "$Teams.Players.Race" } } },
+                { "mmrGain", new BsonDocument("$sum", new BsonDocument("$subtract", new BsonArray { "$Teams.Players.CurrentMmr", "$Teams.Players.OldMmr" })) },
+                { "games", new BsonDocument("$sum", 1) },
+                { "name", new BsonDocument("$last", "$Teams.Players.Name") },
+                { "currentMmr", new BsonDocument("$last", "$Teams.Players.CurrentMmr") },
+                { "countryCode", new BsonDocument("$last", "$Teams.Players.CountryCode") },
+            }),
+            // A riser has to have climbed; don't pad short lists with net losers.
+            new BsonDocument("$match", new BsonDocument("mmrGain", new BsonDocument("$gt", 0))),
+            new BsonDocument("$sort", new BsonDocument("mmrGain", -1)),
+            new BsonDocument("$limit", top),
+            new BsonDocument("$project", new BsonDocument
+            {
+                { "_id", 0 },
+                { "BattleTag", "$_id.battleTag" },
+                { "Race", "$_id.race" },
+                { "Name", "$name" },
+                { "MmrGain", "$mmrGain" },
+                { "Games", "$games" },
+                { "CurrentMmr", "$currentMmr" },
+                { "CountryCode", "$countryCode" },
+            }),
+        };
+
+        var pipeline = PipelineDefinition<Matchup, MmrRiser>.Create(stages);
+        return await mongoCollection.Aggregate(pipeline).ToListAsync();
     }
 
     public async Task<int> GetFloIdFromId(string gameId)

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -168,6 +168,40 @@ public class MatchesController(
     }
 
 
+    /// <summary>
+    /// Searches the players a given player shares finished matches with,
+    /// e.g. to suggest opponents when filtering a player's match history.
+    /// </summary>
+    /// <param name="playerId">The battleTag whose matches are searched.</param>
+    /// <param name="season">The season filter. If less than 0, uses the latest season.</param>
+    /// <param name="search">Case-insensitive battleTag fragment. Empty returns the most played opponents.</param>
+    /// <param name="gateWay">The gateway filter.</param>
+    /// <param name="limit">The maximum number of results (max 50).</param>
+    /// <returns>
+    /// 200 OK: A list of players ordered by shared match count descending.
+    /// [{ battleTag: string, matchCount: long }]
+    /// </returns>
+    [ProducesResponseType(typeof(List<OpponentInfo>), 200)]
+    [HttpGet("search-opponents")]
+    public async Task<IActionResult> SearchOpponents(
+        string playerId,
+        int season = -1,
+        string search = "",
+        GateWay gateWay = GateWay.Undefined,
+        int limit = 10)
+    {
+        if (string.IsNullOrEmpty(playerId)) return BadRequest("playerId is required");
+        if (season < 0)
+        {
+            var lastSeason = await _matchRepository.LoadLastSeason();
+            season = lastSeason.Id;
+        }
+        if (limit > 50) limit = 50;
+
+        var opponents = await _matchService.SearchOpponentsPerPlayer(playerId, search, season, gateWay, limit);
+        return Ok(opponents);
+    }
+
     [HttpGet("ongoing")]
     public async Task<IActionResult> GetOnGoingMatches(
         int offset = 0,

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -114,6 +114,36 @@ public class MatchesController(
         return Ok(new { matches, count });
     }
 
+    /// <summary>
+    /// Gets the ladder entries (player + race) that gained the most MMR from matches
+    /// finished within the past <paramref name="days"/> days.
+    /// </summary>
+    /// <param name="season">The season filter. Defaults to the latest season.</param>
+    /// <param name="gameMode">The game mode filter.</param>
+    /// <param name="days">Window size in days (1-30).</param>
+    /// <param name="top">Number of risers to return (1-25).</param>
+    /// <returns>
+    /// 200 OK: The array of top risers, biggest MMR gain first
+    /// </returns>
+    [ProducesResponseType(typeof(List<MmrRiser>), 200)]
+    [HttpGet("mmr-risers")]
+    public async Task<IActionResult> GetMmrRisers(
+        int season = -1,
+        GameMode gameMode = GameMode.GM_1v1,
+        int days = 7,
+        int top = 5)
+    {
+        days = Math.Clamp(days, 1, 30);
+        top = Math.Clamp(top, 1, 25);
+        if (season < 0)
+        {
+            var lastSeason = await _matchRepository.LoadLastSeason();
+            season = lastSeason.Id;
+        }
+        var risers = await _matchService.GetMmrRisers(season, gameMode, days, top);
+        return Ok(risers);
+    }
+
     [HttpGet("{id}")]
     public async Task<IActionResult> GetMatchDetails(string id)
     {
@@ -180,8 +210,9 @@ public class MatchesController(
     /// Opponents without matches in that mode are still listed, with matchCount 0.</param>
     /// <param name="limit">The maximum number of results (max 50).</param>
     /// <returns>
-    /// 200 OK: A list of players ordered by shared match count descending.
-    /// [{ battleTag: string, matchCount: long }]
+    /// 200 OK: A list of players ordered by shared match count descending, with the
+    /// searched player's record across those matches (allies share the same result).
+    /// [{ battleTag: string, matchCount: long, wins: long, losses: long }]
     /// </returns>
     [ProducesResponseType(typeof(List<OpponentInfo>), 200)]
     [HttpGet("search-opponents")]

--- a/W3ChampionsStatisticService/Matches/MatchesController.cs
+++ b/W3ChampionsStatisticService/Matches/MatchesController.cs
@@ -176,6 +176,8 @@ public class MatchesController(
     /// <param name="season">The season filter. If less than 0, uses the latest season.</param>
     /// <param name="search">Case-insensitive battleTag fragment. Empty returns the most played opponents.</param>
     /// <param name="gateWay">The gateway filter.</param>
+    /// <param name="gameMode">Scopes matchCount to one game mode (Undefined counts every mode).
+    /// Opponents without matches in that mode are still listed, with matchCount 0.</param>
     /// <param name="limit">The maximum number of results (max 50).</param>
     /// <returns>
     /// 200 OK: A list of players ordered by shared match count descending.
@@ -188,6 +190,7 @@ public class MatchesController(
         int season = -1,
         string search = "",
         GateWay gateWay = GateWay.Undefined,
+        GameMode gameMode = GameMode.Undefined,
         int limit = 10)
     {
         if (string.IsNullOrEmpty(playerId)) return BadRequest("playerId is required");
@@ -198,7 +201,7 @@ public class MatchesController(
         }
         if (limit > 50) limit = 50;
 
-        var opponents = await _matchService.SearchOpponentsPerPlayer(playerId, search, season, gateWay, limit);
+        var opponents = await _matchService.SearchOpponentsPerPlayer(playerId, search, season, gateWay, gameMode, limit);
         return Ok(opponents);
     }
 

--- a/W3ChampionsStatisticService/Matches/OpponentInfo.cs
+++ b/W3ChampionsStatisticService/Matches/OpponentInfo.cs
@@ -1,0 +1,9 @@
+namespace W3ChampionsStatisticService.Matches;
+
+// One result of the player-scoped opponent search: a player who shares
+// finished matches with the searched player, and how many they share.
+public class OpponentInfo
+{
+    public string BattleTag { get; set; }
+    public long MatchCount { get; set; }
+}

--- a/W3ChampionsStatisticService/Matches/OpponentInfo.cs
+++ b/W3ChampionsStatisticService/Matches/OpponentInfo.cs
@@ -1,9 +1,12 @@
 namespace W3ChampionsStatisticService.Matches;
 
 // One result of the player-scoped opponent search: a player who shares
-// finished matches with the searched player, and how many they share.
+// finished matches with the searched player, how many they share, and the
+// searched player's record across them (allies share the same result).
 public class OpponentInfo
 {
     public string BattleTag { get; set; }
     public long MatchCount { get; set; }
+    public long Wins { get; set; }
+    public long Losses { get; set; }
 }

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -52,6 +52,13 @@ public interface IMatchRepository
         bool playerIncludeRandom = false,
         bool opponentIncludeRandom = false);
 
+    Task<List<OpponentInfo>> SearchOpponentsFor(
+        string playerId,
+        string search,
+        int season,
+        GateWay gateWay = GateWay.Undefined,
+        int limit = 10);
+
     Task<MatchupDetail> LoadFinishedMatchDetails(ObjectId id);
     Task<MatchupDetail> LoadFinishedMatchDetailsByMatchId(string id);
     Task<MatchFinishedEvent> LoadMatchFinishedEventByGameName(string gameName);

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -17,6 +17,8 @@ public interface IMatchRepository
 
     Task<List<string>> LoadMapNames(int season, GameMode gameMode);
 
+    Task<List<MmrRiser>> LoadMmrRisers(int season, GameMode gameMode, DateTimeOffset since, int top);
+
     Task<long> Count(
         int season,
         GameMode gameMode,
@@ -53,7 +55,7 @@ public interface IMatchRepository
         bool opponentIncludeRandom = false);
 
     Task<List<OpponentInfo>> SearchOpponentsFor(
-        string playerId,
+        string battleTag,
         string search,
         int season,
         GateWay gateWay = GateWay.Undefined,

--- a/W3ChampionsStatisticService/Ports/IMatchRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IMatchRepository.cs
@@ -57,6 +57,7 @@ public interface IMatchRepository
         string search,
         int season,
         GateWay gateWay = GateWay.Undefined,
+        GameMode gameMode = GameMode.Undefined,
         int limit = 10);
 
     Task<MatchupDetail> LoadFinishedMatchDetails(ObjectId id);

--- a/W3ChampionsStatisticService/Services/MatchService.cs
+++ b/W3ChampionsStatisticService/Services/MatchService.cs
@@ -25,12 +25,14 @@ public class MatchService(
     ICachedDataProvider<List<Matchup>> cachedMatchesProvider,
     ICachedDataProvider<CachedLong> cachedMatchCountProvider,
     ICachedDataProvider<List<string>> cachedMapNamesProvider,
+    ICachedDataProvider<List<OpponentInfo>> cachedOpponentsProvider,
     IPersonalSettingsRepository personalSettingsRepository)
 {
     private readonly IMatchRepository _matchRepository = matchRepository;
     private readonly ICachedDataProvider<List<Matchup>> _cachedMatchesProvider = cachedMatchesProvider;
     private readonly ICachedDataProvider<CachedLong> _cachedMatchCountProvider = cachedMatchCountProvider;
     private readonly ICachedDataProvider<List<string>> _cachedMapNamesProvider = cachedMapNamesProvider;
+    private readonly ICachedDataProvider<List<OpponentInfo>> _cachedOpponentsProvider = cachedOpponentsProvider;
     private readonly IPersonalSettingsRepository _personalSettingsRepository = personalSettingsRepository;
 
     public async Task<List<Matchup>> GetMatchesPerPlayer(
@@ -91,6 +93,21 @@ public class MatchService(
                     opponentRace, season, hero, playerIncludeRandom, opponentIncludeRandom)
             }, cacheKeyCount, TimeSpan.FromSeconds(5));
         return count.Value;
+    }
+
+    public async Task<List<OpponentInfo>> SearchOpponentsPerPlayer(
+        string playerId,
+        string search,
+        int season,
+        GateWay gateWay,
+        int limit)
+    {
+        string cacheKey = $"opponents_{playerId}_{season}_{gateWay}_{limit}_{search?.ToLowerInvariant()}";
+
+        return await _cachedOpponentsProvider.GetCachedOrRequestAsync(
+            async () => await _matchRepository.SearchOpponentsFor(playerId, search, season, gateWay, limit),
+            cacheKey,
+            TimeSpan.FromMinutes(1));
     }
 
     public async Task<List<string>> GetMapNames(int season, GameMode gameMode)

--- a/W3ChampionsStatisticService/Services/MatchService.cs
+++ b/W3ChampionsStatisticService/Services/MatchService.cs
@@ -100,12 +100,13 @@ public class MatchService(
         string search,
         int season,
         GateWay gateWay,
+        GameMode gameMode,
         int limit)
     {
-        string cacheKey = $"opponents_{playerId}_{season}_{gateWay}_{limit}_{search?.ToLowerInvariant()}";
+        string cacheKey = $"opponents_{playerId}_{season}_{gateWay}_{gameMode}_{limit}_{search?.ToLowerInvariant()}";
 
         return await _cachedOpponentsProvider.GetCachedOrRequestAsync(
-            async () => await _matchRepository.SearchOpponentsFor(playerId, search, season, gateWay, limit),
+            async () => await _matchRepository.SearchOpponentsFor(playerId, search, season, gateWay, gameMode, limit),
             cacheKey,
             TimeSpan.FromMinutes(1));
     }

--- a/W3ChampionsStatisticService/Services/MatchService.cs
+++ b/W3ChampionsStatisticService/Services/MatchService.cs
@@ -26,6 +26,7 @@ public class MatchService(
     ICachedDataProvider<CachedLong> cachedMatchCountProvider,
     ICachedDataProvider<List<string>> cachedMapNamesProvider,
     ICachedDataProvider<List<OpponentInfo>> cachedOpponentsProvider,
+    ICachedDataProvider<List<MmrRiser>> cachedMmrRisersProvider,
     IPersonalSettingsRepository personalSettingsRepository)
 {
     private readonly IMatchRepository _matchRepository = matchRepository;
@@ -33,6 +34,7 @@ public class MatchService(
     private readonly ICachedDataProvider<CachedLong> _cachedMatchCountProvider = cachedMatchCountProvider;
     private readonly ICachedDataProvider<List<string>> _cachedMapNamesProvider = cachedMapNamesProvider;
     private readonly ICachedDataProvider<List<OpponentInfo>> _cachedOpponentsProvider = cachedOpponentsProvider;
+    private readonly ICachedDataProvider<List<MmrRiser>> _cachedMmrRisersProvider = cachedMmrRisersProvider;
     private readonly IPersonalSettingsRepository _personalSettingsRepository = personalSettingsRepository;
 
     public async Task<List<Matchup>> GetMatchesPerPlayer(
@@ -96,17 +98,17 @@ public class MatchService(
     }
 
     public async Task<List<OpponentInfo>> SearchOpponentsPerPlayer(
-        string playerId,
+        string battleTag,
         string search,
         int season,
         GateWay gateWay,
         GameMode gameMode,
         int limit)
     {
-        string cacheKey = $"opponents_{playerId}_{season}_{gateWay}_{gameMode}_{limit}_{search?.ToLowerInvariant()}";
+        string cacheKey = $"opponents_{battleTag}_{season}_{gateWay}_{gameMode}_{limit}_{search?.ToLowerInvariant()}";
 
         return await _cachedOpponentsProvider.GetCachedOrRequestAsync(
-            async () => await _matchRepository.SearchOpponentsFor(playerId, search, season, gateWay, gameMode, limit),
+            async () => await _matchRepository.SearchOpponentsFor(battleTag, search, season, gateWay, gameMode, limit),
             cacheKey,
             TimeSpan.FromMinutes(1));
     }
@@ -117,6 +119,16 @@ public class MatchService(
 
         return await _cachedMapNamesProvider.GetCachedOrRequestAsync(
             async () => await _matchRepository.LoadMapNames(season, gameMode),
+            cacheKey,
+            TimeSpan.FromMinutes(10));
+    }
+
+    public async Task<List<MmrRiser>> GetMmrRisers(int season, GameMode gameMode, int days, int top)
+    {
+        string cacheKey = $"mmr_risers_{season}_{gameMode}_{days}_{top}";
+
+        return await _cachedMmrRisersProvider.GetCachedOrRequestAsync(
+            async () => await _matchRepository.LoadMmrRisers(season, gameMode, DateTimeOffset.UtcNow.AddDays(-days), top),
             cacheKey,
             TimeSpan.FromMinutes(10));
     }

--- a/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Helpers/TestDtoHelper.cs
@@ -432,6 +432,7 @@ public static class TestDtoHelper
             new Mock<ICachedDataProvider<List<Matchup>>>().Object,
             new Mock<ICachedDataProvider<CachedLong>>().Object,
             new Mock<ICachedDataProvider<List<string>>>().Object,
+            new Mock<ICachedDataProvider<List<OpponentInfo>>>().Object,
             new PersonalSettingsRepository(mongoClient));
     }
 

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -801,4 +801,60 @@ public class MatchupRepoTests : IntegrationTestBase
         Assert.IsNotNull(result);
         Assert.AreEqual(2, result.Id);
     }
+
+    [Test]
+    public async Task SearchOpponentsFor_MatchesContainedTextSortsByCountAndScopesToPlayerSeasonAndGateway()
+    {
+        var wolfGame1 = TestDtoHelper.CreateFakeEvent();
+        var wolfGame2 = TestDtoHelper.CreateFakeEvent();
+        var wolfmanGame = TestDtoHelper.CreateFakeEvent();
+        var annaGame = TestDtoHelper.CreateFakeEvent();
+        var wolfGameOtherSeason = TestDtoHelper.CreateFakeEvent();
+        var wolfGameWithoutPeter = TestDtoHelper.CreateFakeEvent();
+        // peter#123 and wolf#456 as allies (team 0) vs TEAM2#123/TEAM2#456, on America.
+        var alliedTeamGame = TestDtoHelper.CreateFake2v2AtEvent();
+
+        // Defaults from CreateFakeEvent: peter#123 vs wolf#456, season 0, Europe.
+        wolfmanGame.match.players[1].battleTag = "Wolfman#789";
+        annaGame.match.players[1].battleTag = "anna#111";
+        wolfGameOtherSeason.match.season = 1;
+        wolfGameWithoutPeter.match.players[0].battleTag = "anna#111";
+
+        await matchRepository.Insert(Matchup.Create(wolfGame1));
+        await matchRepository.Insert(Matchup.Create(wolfGame2));
+        await matchRepository.Insert(Matchup.Create(wolfmanGame));
+        await matchRepository.Insert(Matchup.Create(annaGame));
+        await matchRepository.Insert(Matchup.Create(wolfGameOtherSeason));
+        await matchRepository.Insert(Matchup.Create(wolfGameWithoutPeter));
+        await matchRepository.Insert(Matchup.Create(alliedTeamGame));
+
+        // Case-insensitive contains-match, most shared matches first. Allies count
+        // like opponents (wolf: two 1v1s plus the 2v2 played together), while the
+        // season 1 game and the game peter did not play in must not count.
+        var wolfResults = await matchRepository.SearchOpponentsFor("peter#123", "wOlF", 0);
+        Assert.AreEqual(2, wolfResults.Count);
+        Assert.AreEqual("wolf#456", wolfResults[0].BattleTag);
+        Assert.AreEqual(3, wolfResults[0].MatchCount);
+        Assert.AreEqual("Wolfman#789", wolfResults[1].BattleTag);
+        Assert.AreEqual(1, wolfResults[1].MatchCount);
+
+        // Fragments spanning the # separator match too and regex chars are escaped.
+        var tagFragmentResults = await matchRepository.SearchOpponentsFor("peter#123", "lf#4", 0);
+        Assert.AreEqual("wolf#456", tagFragmentResults.Single().BattleTag);
+
+        // An empty search returns everyone peter shared a match with, including the
+        // 2v2 opponents, but never peter himself.
+        var allOpponents = await matchRepository.SearchOpponentsFor("peter#123", "", 0);
+        Assert.AreEqual(5, allOpponents.Count);
+        Assert.IsTrue(allOpponents.Any(opponent => opponent.BattleTag == "TEAM2#123"));
+        Assert.IsFalse(allOpponents.Any(opponent => opponent.BattleTag == "peter#123"));
+
+        // Only the 2v2 was played on America, so only its participants show there.
+        var otherGateway = await matchRepository.SearchOpponentsFor("peter#123", "wolf", 0, GateWay.America);
+        Assert.AreEqual("wolf#456", otherGateway.Single().BattleTag);
+        Assert.AreEqual(1, otherGateway.Single().MatchCount);
+
+        var limited = await matchRepository.SearchOpponentsFor("peter#123", "", 0, GateWay.Undefined, 1);
+        Assert.AreEqual("wolf#456", limited.Single().BattleTag);
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -854,7 +854,21 @@ public class MatchupRepoTests : IntegrationTestBase
         Assert.AreEqual("wolf#456", otherGateway.Single().BattleTag);
         Assert.AreEqual(1, otherGateway.Single().MatchCount);
 
-        var limited = await matchRepository.SearchOpponentsFor("peter#123", "", 0, GateWay.Undefined, 1);
+        // A game-mode scope only affects the count, not who is listed: wolf's
+        // 2v2 with peter counts, Wolfman's 1v1 does not, but he stays findable.
+        var scopedToMode = await matchRepository.SearchOpponentsFor("peter#123", "wolf", 0, GateWay.Undefined, GameMode.GM_2v2);
+        Assert.AreEqual(2, scopedToMode.Count);
+        Assert.AreEqual("wolf#456", scopedToMode[0].BattleTag);
+        Assert.AreEqual(1, scopedToMode[0].MatchCount);
+        Assert.AreEqual("Wolfman#789", scopedToMode[1].BattleTag);
+        Assert.AreEqual(0, scopedToMode[1].MatchCount);
+
+        // With zero in-mode matches everywhere, total shared matches break the tie.
+        var noneInMode = await matchRepository.SearchOpponentsFor("peter#123", "wolf", 0, GateWay.Undefined, GameMode.GM_4v4);
+        Assert.AreEqual("wolf#456", noneInMode[0].BattleTag);
+        Assert.AreEqual(0, noneInMode[0].MatchCount);
+
+        var limited = await matchRepository.SearchOpponentsFor("peter#123", "", 0, GateWay.Undefined, limit: 1);
         Assert.AreEqual("wolf#456", limited.Single().BattleTag);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Matchups/MatchupRepoTests.cs
@@ -814,7 +814,10 @@ public class MatchupRepoTests : IntegrationTestBase
         // peter#123 and wolf#456 as allies (team 0) vs TEAM2#123/TEAM2#456, on America.
         var alliedTeamGame = TestDtoHelper.CreateFake2v2AtEvent();
 
-        // Defaults from CreateFakeEvent: peter#123 vs wolf#456, season 0, Europe.
+        // Defaults from CreateFakeEvent: peter#123 beats wolf#456, season 0, Europe.
+        // Flip one wolf game so peter's record against him is 2-1, not all wins.
+        wolfGame2.match.players[0].won = false;
+        wolfGame2.match.players[1].won = true;
         wolfmanGame.match.players[1].battleTag = "Wolfman#789";
         annaGame.match.players[1].battleTag = "anna#111";
         wolfGameOtherSeason.match.season = 1;
@@ -831,44 +834,130 @@ public class MatchupRepoTests : IntegrationTestBase
         // Case-insensitive contains-match, most shared matches first. Allies count
         // like opponents (wolf: two 1v1s plus the 2v2 played together), while the
         // season 1 game and the game peter did not play in must not count.
+        // Wins/Losses are peter's record across those matches: he lost one 1v1
+        // to wolf but won the 2v2 with him as ally.
         var wolfResults = await matchRepository.SearchOpponentsFor("peter#123", "wOlF", 0);
         Assert.AreEqual(2, wolfResults.Count);
         Assert.AreEqual("wolf#456", wolfResults[0].BattleTag);
         Assert.AreEqual(3, wolfResults[0].MatchCount);
+        Assert.AreEqual(2, wolfResults[0].Wins);
+        Assert.AreEqual(1, wolfResults[0].Losses);
         Assert.AreEqual("Wolfman#789", wolfResults[1].BattleTag);
         Assert.AreEqual(1, wolfResults[1].MatchCount);
+        Assert.AreEqual(1, wolfResults[1].Wins);
+        Assert.AreEqual(0, wolfResults[1].Losses);
 
         // Fragments spanning the # separator match too and regex chars are escaped.
         var tagFragmentResults = await matchRepository.SearchOpponentsFor("peter#123", "lf#4", 0);
         Assert.AreEqual("wolf#456", tagFragmentResults.Single().BattleTag);
 
         // An empty search returns everyone peter shared a match with, including the
-        // 2v2 opponents, but never peter himself.
+        // 2v2 opponents, but never peter himself. The beaten 2v2 opponents carry
+        // peter's win against them.
         var allOpponents = await matchRepository.SearchOpponentsFor("peter#123", "", 0);
         Assert.AreEqual(5, allOpponents.Count);
-        Assert.IsTrue(allOpponents.Any(opponent => opponent.BattleTag == "TEAM2#123"));
+        var teamTwoOpponent = allOpponents.Single(opponent => opponent.BattleTag == "TEAM2#123");
+        Assert.AreEqual(1, teamTwoOpponent.Wins);
+        Assert.AreEqual(0, teamTwoOpponent.Losses);
         Assert.IsFalse(allOpponents.Any(opponent => opponent.BattleTag == "peter#123"));
 
         // Only the 2v2 was played on America, so only its participants show there.
         var otherGateway = await matchRepository.SearchOpponentsFor("peter#123", "wolf", 0, GateWay.America);
         Assert.AreEqual("wolf#456", otherGateway.Single().BattleTag);
         Assert.AreEqual(1, otherGateway.Single().MatchCount);
+        Assert.AreEqual(1, otherGateway.Single().Wins);
+        Assert.AreEqual(0, otherGateway.Single().Losses);
 
-        // A game-mode scope only affects the count, not who is listed: wolf's
-        // 2v2 with peter counts, Wolfman's 1v1 does not, but he stays findable.
+        // A game-mode scope only affects the counts, not who is listed: wolf's
+        // 2v2 with peter counts (a win together), Wolfman's 1v1 does not, but
+        // he stays findable.
         var scopedToMode = await matchRepository.SearchOpponentsFor("peter#123", "wolf", 0, GateWay.Undefined, GameMode.GM_2v2);
         Assert.AreEqual(2, scopedToMode.Count);
         Assert.AreEqual("wolf#456", scopedToMode[0].BattleTag);
         Assert.AreEqual(1, scopedToMode[0].MatchCount);
+        Assert.AreEqual(1, scopedToMode[0].Wins);
+        Assert.AreEqual(0, scopedToMode[0].Losses);
         Assert.AreEqual("Wolfman#789", scopedToMode[1].BattleTag);
         Assert.AreEqual(0, scopedToMode[1].MatchCount);
+        Assert.AreEqual(0, scopedToMode[1].Wins);
+        Assert.AreEqual(0, scopedToMode[1].Losses);
 
-        // With zero in-mode matches everywhere, total shared matches break the tie.
+        // With zero in-mode matches everywhere, total shared matches break the
+        // tie, and the record stays zeroed like the count.
         var noneInMode = await matchRepository.SearchOpponentsFor("peter#123", "wolf", 0, GateWay.Undefined, GameMode.GM_4v4);
         Assert.AreEqual("wolf#456", noneInMode[0].BattleTag);
         Assert.AreEqual(0, noneInMode[0].MatchCount);
+        Assert.AreEqual(0, noneInMode[0].Wins);
+        Assert.AreEqual(0, noneInMode[0].Losses);
 
         var limited = await matchRepository.SearchOpponentsFor("peter#123", "", 0, GateWay.Undefined, limit: 1);
         Assert.AreEqual("wolf#456", limited.Single().BattleTag);
+    }
+
+    private static MatchFinishedEvent CreateRiserEvent(
+        string tag1, int oldMmr1, int newMmr1, Race race1,
+        string tag2, int oldMmr2, int newMmr2, Race race2)
+    {
+        var ev = TestDtoHelper.CreateFakeEvent();
+        var p1 = ev.match.players[0];
+        var p2 = ev.match.players[1];
+        p1.battleTag = tag1;
+        p1.race = race1;
+        p1.mmr = new Mmr { rating = oldMmr1, rd = 30 };
+        p1.updatedMmr = new Mmr { rating = newMmr1, rd = 30 };
+        p1.won = newMmr1 > oldMmr1;
+        p2.battleTag = tag2;
+        p2.race = race2;
+        p2.mmr = new Mmr { rating = oldMmr2, rd = 30 };
+        p2.updatedMmr = new Mmr { rating = newMmr2, rd = 30 };
+        p2.won = newMmr2 > oldMmr2;
+        return ev;
+    }
+
+    [Test]
+    public async Task LoadMmrRisers_SumsGainsPerPlayerAndRace_SkipsUncalibratedAndNetLosers()
+    {
+        // climber#111 wins twice on HU: +30 then +25 => net +55, latest MMR 2055.
+        var ev1 = CreateRiserEvent("climber#111", 2000, 2030, Race.HU, "steady#222", 1800, 1785, Race.OC);
+        var ev2 = CreateRiserEvent("climber#111", 2030, 2055, Race.HU, "steady#222", 1785, 1770, Race.OC);
+        // smallfry#333 gains a little; his opponent gains on a *different race*,
+        // which must stay a separate ladder entry rather than merge with ev1's OC.
+        var ev3 = CreateRiserEvent("smallfry#333", 1500, 1510, Race.UD, "steady#222", 1600, 1620, Race.NE);
+        // A huge gain that doesn't count: rank deviation at the obfuscation
+        // threshold means the site wouldn't even show this player's MMR.
+        var ev4 = CreateRiserEvent("uncalibrated#444", 1500, 1900, Race.NE, "victim#555", 1900, 1880, Race.UD);
+        ev4.match.players[0].mmr.rd = PlayersObfuscator.RankDeviationObfuscationThreshold;
+
+        foreach (var ev in new[] { ev1, ev2, ev3, ev4 })
+        {
+            await matchRepository.Insert(Matchup.Create(ev));
+        }
+
+        var risers = await matchRepository.LoadMmrRisers(0, GameMode.GM_1v1, DateTimeOffset.UtcNow.AddDays(-7), 5);
+
+        Assert.AreEqual(3, risers.Count);
+
+        Assert.AreEqual("climber#111", risers[0].BattleTag);
+        Assert.AreEqual("climber", risers[0].Name);
+        Assert.AreEqual(Race.HU, risers[0].Race);
+        Assert.AreEqual(55, risers[0].MmrGain);
+        Assert.AreEqual(2, risers[0].Games);
+        Assert.AreEqual(2055, risers[0].CurrentMmr);
+
+        Assert.AreEqual("steady#222", risers[1].BattleTag);
+        Assert.AreEqual(Race.NE, risers[1].Race);
+        Assert.AreEqual(20, risers[1].MmrGain);
+        Assert.AreEqual(1, risers[1].Games);
+
+        Assert.AreEqual("smallfry#333", risers[2].BattleTag);
+        Assert.AreEqual(10, risers[2].MmrGain);
+
+        // The cutoff excludes everything: no matches, no risers.
+        var outsideWindow = await matchRepository.LoadMmrRisers(0, GameMode.GM_1v1, DateTimeOffset.UtcNow.AddHours(1), 5);
+        Assert.AreEqual(0, outsideWindow.Count);
+
+        // Top-limit trims from the bottom of the list.
+        var topOne = await matchRepository.LoadMmrRisers(0, GameMode.GM_1v1, DateTimeOffset.UtcNow.AddDays(-7), 1);
+        Assert.AreEqual("climber#111", topOne.Single().BattleTag);
     }
 }


### PR DESCRIPTION
Backs the new match history opponent search on the website: w3champions/website#1103

- `GET api/matches/search-opponents?playerId=&search=&season=&gateWay=&gameMode=&limit=` — returns `[{ battleTag, matchCount, wins, losses }]`, sorted by games together; wins/losses are the searched player's record across those matches (allies share the result), scoped to the game-mode filter like matchCount
- one aggregation scoped to the player's own season matches: resolve the player's result per match, project battleTags + mode → unwind → optional contains-regex → group + count → top 10, so only ~10 tiny docs ever leave mongo
- allies in team games count as shared matches, same semantics as the existing `opponentId` filter — covered in the repo test incl. a 2v2
- results cached 60s; measured ~70–190ms cold on a seeded 4000-game / 600-opponent account, which is faster than the existing history page query on the same data
- `EnsureIndexesAsync` now creates `{ Teams.Players.BattleTag: 1, Season: -1 }` — this endpoint and the existing per-player history query both ride it