### PR TITLE
Add the admin job runner

### DIFF
--- a/W3C.Contracts/Admin/Permission/Permission.cs
+++ b/W3C.Contracts/Admin/Permission/Permission.cs
@@ -23,4 +23,5 @@ public enum EPermission
     SmurfCheckerQueryExplanation = 9,
     SmurfCheckerAdministration = 10,
     Warnings = 11,
+    Jobs = 12,
 }

--- a/W3ChampionsStatisticService/Admin/Jobs/AdminJob.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/AdminJob.cs
@@ -1,0 +1,98 @@
+using System;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using W3C.Domain.Repositories;
+
+namespace W3ChampionsStatisticService.Admin.Jobs;
+
+public enum AdminJobStatus
+{
+    /// <summary>Never run, or the state has been reset.</summary>
+    Idle,
+    Running,
+    Completed,
+    Failed,
+    /// <summary>An admin cancelled it. Resumable from its checkpoint.</summary>
+    Cancelled,
+    /// <summary>
+    /// The process died while it was running (deploy, crash, OOM). Detected at
+    /// startup rather than by heartbeat - see <see cref="AdminJobRunner"/>.
+    /// </summary>
+    Interrupted,
+}
+
+/// <summary>
+/// Current state of one job, keyed by <see cref="IAdminJob.Key"/>. This is state,
+/// not a run log: a re-run overwrites the previous run's details. See
+/// docs/admin-job-runner.md for why there is no run-history collection.
+/// </summary>
+public class AdminJob : IIdentifiable
+{
+    [BsonId]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Stored as a string rather than the codebase-default ordinal. This collection
+    /// exists to be read by a human debugging a stuck job, and it means reordering
+    /// the enum can't silently reinterpret existing documents.
+    /// </summary>
+    [BsonRepresentation(BsonType.String)]
+    public AdminJobStatus Status { get; set; } = AdminJobStatus.Idle;
+
+    public AdminJobProgress Progress { get; set; } = new();
+
+    /// <summary>
+    /// Job-defined resume point, opaque to the runner. Cleared only by an explicit
+    /// reset - a failed or cancelled run keeps it so the next run continues.
+    /// </summary>
+    public BsonDocument Checkpoint { get; set; }
+
+    /// <summary>
+    /// Start of the current leg. Reset on every resume, so this is not when the run as
+    /// a whole began - <see cref="DurationMs"/> is the figure to display.
+    /// </summary>
+    public DateTimeOffset? StartedAt { get; set; }
+
+    /// <summary>Set on every terminal status, not just <see cref="AdminJobStatus.Completed"/>.</summary>
+    public DateTimeOffset? FinishedAt { get; set; }
+
+    /// <summary>
+    /// Time this run spent actually working in legs before the current one. A job that
+    /// is stopped and resumed - including "paused", which is cancel plus run - would
+    /// otherwise report all the idle time in between as runtime.
+    /// </summary>
+    public long ActiveMs { get; set; }
+
+    /// <summary>
+    /// Total time worked across every leg of the current or most recent run, excluding
+    /// time spent stopped. Denormalised so the UI does not recompute it.
+    /// <para>
+    /// Milliseconds rather than a <see cref="TimeSpan"/> deliberately: the driver
+    /// serialises TimeSpan as a formatted string, and its numeric representation is
+    /// ticks, which has already caused unit confusion elsewhere in this collection's
+    /// neighbourhood. A plain number of milliseconds is unambiguous in the database
+    /// and directly usable in JSON.
+    /// </para>
+    /// </summary>
+    public long? DurationMs { get; set; }
+
+    /// <summary>Job-defined unit (matches, players, ...). Accumulates across resumes.</summary>
+    public long ItemsProcessed { get; set; }
+
+    /// <summary>BattleTag of the admin who triggered the current or most recent run.</summary>
+    public string TriggeredBy { get; set; }
+
+    public int RunCount { get; set; }
+
+    public string Error { get; set; }
+}
+
+public class AdminJobProgress
+{
+    public long Current { get; set; }
+
+    /// <summary>Zero when the job cannot know the total up front.</summary>
+    public long Total { get; set; }
+
+    public string Message { get; set; }
+}

--- a/W3ChampionsStatisticService/Admin/Jobs/AdminJobContext.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/AdminJobContext.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+
+namespace W3ChampionsStatisticService.Admin.Jobs;
+
+/// <summary>
+/// Buffers a job's progress and writes it at most once per <see cref="WriteInterval"/>.
+/// <para>
+/// Throttling lives here rather than in each job so that a job reporting per record
+/// does not spend more time writing progress than working. The cost is that an abrupt
+/// death can lose up to one interval of checkpoint progress, so jobs must be safe to
+/// redo the work since their last checkpoint - which resumability already requires.
+/// </para>
+/// </summary>
+public class AdminJobContext(string key, IAdminJobRepository repository, AdminJob job) : IAdminJobContext
+{
+    public static readonly TimeSpan WriteInterval = TimeSpan.FromSeconds(2);
+
+    private readonly AdminJobProgress _progress = job.Progress ?? new AdminJobProgress();
+    private readonly Stopwatch _sinceLastWrite = Stopwatch.StartNew();
+    private BsonDocument _pendingCheckpoint;
+    private bool _dirty;
+
+    public BsonDocument Checkpoint { get; } = job.Checkpoint;
+
+    public long ItemsProcessed { get; private set; } = job.ItemsProcessed;
+
+    public Task Report(long current, long total, string message = null, BsonDocument checkpoint = null)
+    {
+        _progress.Current = current;
+        _progress.Total = total;
+        _progress.Message = message ?? _progress.Message;
+        _pendingCheckpoint = checkpoint ?? _pendingCheckpoint;
+        _dirty = true;
+
+        return _sinceLastWrite.Elapsed < WriteInterval ? Task.CompletedTask : Flush();
+    }
+
+    public void AddItems(long count)
+    {
+        ItemsProcessed += count;
+        _dirty = true;
+    }
+
+    /// <summary>
+    /// Writes buffered progress regardless of the throttle. The runner calls this once
+    /// the job returns - however it returns - so the final state and the last reported
+    /// checkpoint are always persisted.
+    /// </summary>
+    public async Task Flush()
+    {
+        if (!_dirty)
+        {
+            return;
+        }
+
+        // Reset before the write, not after: a slow write should not immediately owe
+        // another one.
+        _sinceLastWrite.Restart();
+        _dirty = false;
+
+        var checkpoint = _pendingCheckpoint;
+        _pendingCheckpoint = null;
+
+        try
+        {
+            await repository.ReportProgress(key, _progress, checkpoint, ItemsProcessed);
+        }
+        catch
+        {
+            // Put the checkpoint back so a transient write failure doesn't silently
+            // cost the job its resume point. The job itself will fail on this.
+            _pendingCheckpoint ??= checkpoint;
+            _dirty = true;
+            throw;
+        }
+    }
+}

--- a/W3ChampionsStatisticService/Admin/Jobs/AdminJobContext.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/AdminJobContext.cs
@@ -15,8 +15,12 @@ namespace W3ChampionsStatisticService.Admin.Jobs;
 /// redo the work since their last checkpoint - which resumability already requires.
 /// </para>
 /// </summary>
-public class AdminJobContext(string key, IAdminJobRepository repository, AdminJob job, double maxDutyCycle)
-    : IAdminJobContext
+public class AdminJobContext(
+    string key,
+    IAdminJobRepository repository,
+    AdminJob job,
+    double fallbackDutyCycle,
+    IPressureProbe pressureProbe) : IAdminJobContext
 {
     public static readonly TimeSpan WriteInterval = TimeSpan.FromSeconds(2);
 
@@ -26,12 +30,42 @@ public class AdminJobContext(string key, IAdminJobRepository repository, AdminJo
     /// </summary>
     public static readonly TimeSpan MaxPause = TimeSpan.FromSeconds(30);
 
-    private readonly double _dutyCycle = Math.Clamp(maxDutyCycle, 0.01, 1.0);
+    /// <summary>
+    /// How often the pressure signals are re-read. Sampling costs a serverStatus round
+    /// trip, and these signals do not move meaningfully faster than this.
+    /// </summary>
+    public static readonly TimeSpan SampleInterval = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Thresholds at which a signal counts as pressure. Deliberately named rather than
+    /// inlined: they are judgement calls and will want tuning against real load.
+    /// </summary>
+    private const double DirtyCacheLimit = 0.10;         // WiredTiger panics at 0.20
+    private const double WriteTicketLimit = 0.50;
+    private const long QueuedWriterLimit = 2;
+    private const double ProcessCpuLimit = 0.70;         // leave headroom for API traffic
+
+    /// <summary>Pause length as a multiple of the last batch, while pressure persists.</summary>
+    private const double MaxBackoff = 32;
+
+    private readonly double _fallbackDutyCycle = Math.Clamp(fallbackDutyCycle, 0.01, 1.0);
     private readonly AdminJobProgress _progress = job.Progress ?? new AdminJobProgress();
     private readonly Stopwatch _sinceLastWrite = Stopwatch.StartNew();
     private readonly Stopwatch _sinceLastPace = Stopwatch.StartNew();
     private BsonDocument _pendingCheckpoint;
     private bool _dirty;
+
+    private PressureSample _lastSample;
+    private double _backoff;
+
+    /// <summary>
+    /// False until proven otherwise, so a job paces conservatively for its first second
+    /// rather than sprinting before the first reading lands.
+    /// </summary>
+    private bool _databaseAvailable;
+
+    /// <summary>Why the job last slowed down, surfaced in the progress message.</summary>
+    public string LastPressureReason { get; private set; }
 
     public BsonDocument Checkpoint { get; } = job.Checkpoint;
 
@@ -55,16 +89,15 @@ public class AdminJobContext(string key, IAdminJobRepository repository, AdminJo
     }
 
     /// <summary>
-    /// Sleeps for however long it takes to bring the job back under its duty cycle,
-    /// measuring from the last call - so at 25%, a batch that took one second is
-    /// followed by three seconds of quiet.
+    /// Runs the job as fast as the database and this service will tolerate, pausing only
+    /// when something says to slow down.
     /// <para>
-    /// This paces against observed latency rather than any server-side health metric,
-    /// which is deliberate: when the database is under pressure - from this job or
-    /// anything else - batches take longer, so the pauses grow in step without the
-    /// runner needing to interpret Mongo's internals or know the deployment topology.
-    /// A fixed inter-batch delay does the opposite, running hardest exactly when the
-    /// server is coping best and never backing off when it is struggling.
+    /// A fixed duty cycle is the fallback, not the plan: it makes every job slow whether
+    /// or not that is needed, and picking the number is guesswork. When the pressure
+    /// signals are readable the job runs flat out and backs off on evidence instead -
+    /// growing the pause while pressure persists and decaying it once things recover.
+    /// If the database signal cannot be read at all the fixed pace comes back, because
+    /// running flat out blind is the one genuinely dangerous option.
     /// </para>
     /// </summary>
     public async Task Pace(CancellationToken cancellationToken)
@@ -72,17 +105,131 @@ public class AdminJobContext(string key, IAdminJobRepository repository, AdminJo
         cancellationToken.ThrowIfCancellationRequested();
 
         var busy = _sinceLastPace.Elapsed;
-        var pause = _dutyCycle >= 1.0
+
+        // Only re-evaluate when there is a fresh reading. Paces in between keep the
+        // current backoff: decaying on every pace would let a job outrun the sampling
+        // interval and talk itself out of a backoff it still needs.
+        var delta = await TakeSample(cancellationToken);
+        if (delta != null)
+        {
+            var reason = Evaluate(delta);
+
+            // Doubling on pressure and halving on relief reacts within a couple of
+            // samples without thrashing between flat out and stopped.
+            _backoff = reason != null
+                ? Math.Min(Math.Max(_backoff * 2, 1), MaxBackoff)
+                : _backoff / 2;
+
+            if (_backoff < 0.25)
+            {
+                _backoff = 0;
+            }
+
+            LastPressureReason = reason;
+        }
+
+        // Without a database signal, hold the job to a fixed share of wall clock
+        // instead. The CPU brake still applies on top of it.
+        var blindPace = _databaseAvailable || _fallbackDutyCycle >= 1.0
             ? TimeSpan.Zero
-            : busy * ((1.0 / _dutyCycle) - 1.0);
+            : busy * ((1.0 / _fallbackDutyCycle) - 1.0);
+
+        var pause = Max(busy * _backoff, blindPace);
+        if (pause > MaxPause)
+        {
+            pause = MaxPause;
+        }
 
         if (pause > TimeSpan.Zero)
         {
-            await Task.Delay(pause < MaxPause ? pause : MaxPause, cancellationToken);
+            await Task.Delay(pause, cancellationToken);
         }
 
         _sinceLastPace.Restart();
     }
+
+    /// <summary>
+    /// Returns the change since the previous reading, or null if it is too soon to
+    /// sample again or this is the first reading - counters need a baseline before a
+    /// difference means anything.
+    /// </summary>
+    private async Task<PressureDelta> TakeSample(CancellationToken cancellationToken)
+    {
+        if (_lastSample != null && DateTimeOffset.UtcNow - _lastSample.TakenAt < SampleInterval)
+        {
+            return null;
+        }
+
+        var sample = await pressureProbe.Sample(cancellationToken);
+        var previous = _lastSample;
+
+        _lastSample = sample;
+        _databaseAvailable = sample.DatabaseAvailable;
+
+        if (previous == null)
+        {
+            return null;
+        }
+
+        var wallSeconds = (sample.TakenAt - previous.TakenAt).TotalSeconds;
+        var cpuSeconds = (sample.ProcessCpuTime - previous.ProcessCpuTime).TotalSeconds;
+
+        return new PressureDelta(
+            DirtyTriggerReached: sample.DirtyTriggerReached - previous.DirtyTriggerReached,
+            ApplicationThreadEvictions: sample.ApplicationThreadEvictions - previous.ApplicationThreadEvictions,
+            DirtyCacheFraction: sample.DirtyCacheFraction,
+            WriteTicketUtilisation: sample.WriteTicketUtilisation,
+            QueuedWriters: sample.QueuedWriters,
+            CpuFraction: wallSeconds > 0 ? cpuSeconds / (wallSeconds * sample.ProcessorCount) : 0);
+    }
+
+    /// <summary>Counters as rates and gauges as they came, ready to threshold.</summary>
+    private sealed record PressureDelta(
+        long DirtyTriggerReached,
+        long ApplicationThreadEvictions,
+        double DirtyCacheFraction,
+        double WriteTicketUtilisation,
+        long QueuedWriters,
+        double CpuFraction);
+
+    /// <summary>Returns why the job should slow down, or null if nothing objects.</summary>
+    private static string Evaluate(PressureDelta delta)
+    {
+        // mongod forcing its own query threads to evict, or hitting the dirty trigger,
+        // means writes are outrunning what it can absorb. These are the strongest
+        // signals available on a standalone server, and being counters they need no
+        // threshold - any movement at all is the server complaining.
+        if (delta.ApplicationThreadEvictions > 0)
+        {
+            return "mongod is evicting on application threads";
+        }
+
+        if (delta.DirtyTriggerReached > 0)
+        {
+            return "mongod hit its dirty cache trigger";
+        }
+
+        if (delta.DirtyCacheFraction > DirtyCacheLimit)
+        {
+            return $"dirty cache at {delta.DirtyCacheFraction:P0}";
+        }
+
+        if (delta.WriteTicketUtilisation > WriteTicketLimit)
+        {
+            return $"write tickets {delta.WriteTicketUtilisation:P0} used";
+        }
+
+        if (delta.QueuedWriters >= QueuedWriterLimit)
+        {
+            return $"{delta.QueuedWriters} writers queued";
+        }
+
+        // Jobs share a process with the API, so a pegged CPU degrades the site even when
+        // the database is perfectly happy.
+        return delta.CpuFraction > ProcessCpuLimit ? $"service CPU at {delta.CpuFraction:P0}" : null;
+    }
+
+    private static TimeSpan Max(TimeSpan a, TimeSpan b) => a > b ? a : b;
 
     /// <summary>
     /// Writes buffered progress regardless of the throttle. The runner calls this once

--- a/W3ChampionsStatisticService/Admin/Jobs/AdminJobContext.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/AdminJobContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 
@@ -14,12 +15,21 @@ namespace W3ChampionsStatisticService.Admin.Jobs;
 /// redo the work since their last checkpoint - which resumability already requires.
 /// </para>
 /// </summary>
-public class AdminJobContext(string key, IAdminJobRepository repository, AdminJob job) : IAdminJobContext
+public class AdminJobContext(string key, IAdminJobRepository repository, AdminJob job, double maxDutyCycle)
+    : IAdminJobContext
 {
     public static readonly TimeSpan WriteInterval = TimeSpan.FromSeconds(2);
 
+    /// <summary>
+    /// Ceiling on a single pause, so one pathological batch cannot stall the job for
+    /// hours and make it look hung.
+    /// </summary>
+    public static readonly TimeSpan MaxPause = TimeSpan.FromSeconds(30);
+
+    private readonly double _dutyCycle = Math.Clamp(maxDutyCycle, 0.01, 1.0);
     private readonly AdminJobProgress _progress = job.Progress ?? new AdminJobProgress();
     private readonly Stopwatch _sinceLastWrite = Stopwatch.StartNew();
+    private readonly Stopwatch _sinceLastPace = Stopwatch.StartNew();
     private BsonDocument _pendingCheckpoint;
     private bool _dirty;
 
@@ -42,6 +52,36 @@ public class AdminJobContext(string key, IAdminJobRepository repository, AdminJo
     {
         ItemsProcessed += count;
         _dirty = true;
+    }
+
+    /// <summary>
+    /// Sleeps for however long it takes to bring the job back under its duty cycle,
+    /// measuring from the last call - so at 25%, a batch that took one second is
+    /// followed by three seconds of quiet.
+    /// <para>
+    /// This paces against observed latency rather than any server-side health metric,
+    /// which is deliberate: when the database is under pressure - from this job or
+    /// anything else - batches take longer, so the pauses grow in step without the
+    /// runner needing to interpret Mongo's internals or know the deployment topology.
+    /// A fixed inter-batch delay does the opposite, running hardest exactly when the
+    /// server is coping best and never backing off when it is struggling.
+    /// </para>
+    /// </summary>
+    public async Task Pace(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var busy = _sinceLastPace.Elapsed;
+        var pause = _dutyCycle >= 1.0
+            ? TimeSpan.Zero
+            : busy * ((1.0 / _dutyCycle) - 1.0);
+
+        if (pause > TimeSpan.Zero)
+        {
+            await Task.Delay(pause < MaxPause ? pause : MaxPause, cancellationToken);
+        }
+
+        _sinceLastPace.Restart();
     }
 
     /// <summary>

--- a/W3ChampionsStatisticService/Admin/Jobs/AdminJobDto.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/AdminJobDto.cs
@@ -1,0 +1,47 @@
+using System;
+using W3C.Contracts.Admin.Permission;
+
+namespace W3ChampionsStatisticService.Admin.Jobs;
+
+/// <summary>A job definition merged with its current state, as the admin UI needs it.</summary>
+public class AdminJobDto
+{
+    public string Key { get; set; }
+    public string Name { get; set; }
+    public string Description { get; set; }
+    public EPermission RequiredPermission { get; set; }
+    public bool RequiresConfirmation { get; set; }
+
+    public AdminJobStatus Status { get; set; }
+    public AdminJobProgress Progress { get; set; }
+    public DateTimeOffset? StartedAt { get; set; }
+    public DateTimeOffset? FinishedAt { get; set; }
+    public long? DurationMs { get; set; }
+    public long ItemsProcessed { get; set; }
+    public string TriggeredBy { get; set; }
+    public int RunCount { get; set; }
+    public string Error { get; set; }
+
+    /// <summary>Whether a resume point exists, without exposing its job-defined shape.</summary>
+    public bool HasCheckpoint { get; set; }
+
+    public static AdminJobDto From(IAdminJob definition, AdminJob state) => new()
+    {
+        Key = definition.Key,
+        Name = definition.Name,
+        Description = definition.Description,
+        RequiredPermission = definition.RequiredPermission,
+        RequiresConfirmation = definition.RequiresConfirmation,
+
+        Status = state?.Status ?? AdminJobStatus.Idle,
+        Progress = state?.Progress ?? new AdminJobProgress(),
+        StartedAt = state?.StartedAt,
+        FinishedAt = state?.FinishedAt,
+        DurationMs = state?.DurationMs,
+        ItemsProcessed = state?.ItemsProcessed ?? 0,
+        TriggeredBy = state?.TriggeredBy,
+        RunCount = state?.RunCount ?? 0,
+        Error = state?.Error,
+        HasCheckpoint = state?.Checkpoint != null,
+    };
+}

--- a/W3ChampionsStatisticService/Admin/Jobs/AdminJobRepository.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/AdminJobRepository.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
+
+namespace W3ChampionsStatisticService.Admin.Jobs;
+
+[Trace]
+public class AdminJobRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IAdminJobRepository
+{
+    private IMongoCollection<AdminJob> Jobs => CreateCollection<AdminJob>();
+
+    /// <summary>
+    /// Statuses a job may be started from. <see cref="AdminJobStatus.Completed"/> is
+    /// excluded so a finished job is not re-run by a stray click; <c>force</c> adds it.
+    /// </summary>
+    private static readonly AdminJobStatus[] StartableStatuses =
+    [
+        AdminJobStatus.Idle,
+        AdminJobStatus.Failed,
+        AdminJobStatus.Cancelled,
+        AdminJobStatus.Interrupted,
+    ];
+
+    public Task<List<AdminJob>> LoadAll() => LoadAll<AdminJob>();
+
+    public Task<AdminJob> Load(string key) => LoadFirst<AdminJob>(key);
+
+    public async Task<AdminJob> TryClaim(string key, string battleTag, bool force, bool reset)
+    {
+        // Make sure a document exists before the conditional update below. This can't
+        // be folded into that update as an upsert: when the document exists but its
+        // status excludes it from the filter, Mongo would attempt an insert and fail
+        // on the duplicate _id rather than reporting "not startable".
+        await Jobs.UpdateOneAsync(
+            j => j.Id == key,
+            Builders<AdminJob>.Update
+                .SetOnInsert(j => j.Status, AdminJobStatus.Idle)
+                .SetOnInsert(j => j.RunCount, 0),
+            new UpdateOptions { IsUpsert = true });
+
+        AdminJobStatus[] startable = force
+            ? [.. StartableStatuses, AdminJobStatus.Completed]
+            : StartableStatuses;
+
+        // Single atomic transition. With one service instance this can't currently
+        // race, but it is also what stops two admins clicking Run at the same moment.
+        var before = await Jobs.FindOneAndUpdateAsync(
+            Builders<AdminJob>.Filter.And(
+                Builders<AdminJob>.Filter.Eq(j => j.Id, key),
+                Builders<AdminJob>.Filter.In(j => j.Status, startable)),
+            Builders<AdminJob>.Update
+                .Set(j => j.Status, AdminJobStatus.Running)
+                .Set(j => j.TriggeredBy, battleTag)
+                .Set(j => j.FinishedAt, null)
+                .Set(j => j.DurationMs, null)
+                .Set(j => j.Error, null)
+                .Inc(j => j.RunCount, 1),
+            new FindOneAndUpdateOptions<AdminJob> { ReturnDocument = ReturnDocument.Before });
+
+        if (before == null)
+        {
+            return null;
+        }
+
+        // A run either continues where the last one stopped or starts over. Continuing
+        // keeps the checkpoint, the item count and the accumulated runtime, so a job
+        // that survived a deploy - or was paused, which is a cancel plus a run - still
+        // reports its true totals. Completed is always a fresh run: reaching it via
+        // `force` means the admin asked for the whole thing again.
+        var resuming = !reset
+            && before.Checkpoint != null
+            && before.Status is AdminJobStatus.Failed or AdminJobStatus.Cancelled or AdminJobStatus.Interrupted;
+
+        var startedAt = DateTimeOffset.UtcNow;
+        var update = Builders<AdminJob>.Update.Set(j => j.StartedAt, startedAt);
+
+        if (resuming)
+        {
+            // Bank the previous leg and restart the clock, so the gap while the job sat
+            // stopped is not counted as runtime.
+            var previousLeg = before.StartedAt is { } previousStart
+                ? (long)((before.FinishedAt ?? startedAt) - previousStart).TotalMilliseconds
+                : 0;
+            update = update.Set(j => j.ActiveMs, before.ActiveMs + Math.Max(previousLeg, 0));
+        }
+        else
+        {
+            update = update
+                .Set(j => j.ActiveMs, 0L)
+                .Set(j => j.ItemsProcessed, 0L)
+                .Set(j => j.Progress, new AdminJobProgress())
+                .Set(j => j.Checkpoint, null);
+        }
+
+        await Jobs.UpdateOneAsync(j => j.Id == key, update);
+
+        return await Load(key);
+    }
+
+    public Task ReportProgress(string key, AdminJobProgress progress, BsonDocument checkpoint, long itemsProcessed)
+    {
+        var update = Builders<AdminJob>.Update
+            .Set(j => j.Progress, progress)
+            .Set(j => j.ItemsProcessed, itemsProcessed);
+
+        // A null checkpoint means "unchanged", not "clear it" - only a reset clears.
+        if (checkpoint != null)
+        {
+            update = update.Set(j => j.Checkpoint, checkpoint);
+        }
+
+        return Jobs.UpdateOneAsync(j => j.Id == key, update);
+    }
+
+    public async Task Finish(string key, AdminJobStatus status, string error)
+    {
+        var finishedAt = DateTimeOffset.UtcNow;
+        var job = await Load(key);
+        var durationMs = job?.StartedAt is { } startedAt
+            ? job.ActiveMs + (long)(finishedAt - startedAt).TotalMilliseconds
+            : (long?)null;
+
+        await Jobs.UpdateOneAsync(
+            j => j.Id == key,
+            Builders<AdminJob>.Update
+                .Set(j => j.Status, status)
+                .Set(j => j.FinishedAt, finishedAt)
+                .Set(j => j.DurationMs, durationMs)
+                .Set(j => j.Error, error));
+    }
+
+    public async Task<List<string>> MarkRunningAsInterrupted()
+    {
+        var running = Builders<AdminJob>.Filter.Eq(j => j.Status, AdminJobStatus.Running);
+
+        var keys = await Jobs.Find(running).Project(j => j.Id).ToListAsync();
+        if (keys.Count == 0)
+        {
+            return keys;
+        }
+
+        await Jobs.UpdateManyAsync(
+            running,
+            Builders<AdminJob>.Update
+                .Set(j => j.Status, AdminJobStatus.Interrupted)
+                .Set(j => j.FinishedAt, DateTimeOffset.UtcNow)
+                .Set(j => j.Error, "Interrupted - the service stopped while this job was running."));
+
+        return keys;
+    }
+}

--- a/W3ChampionsStatisticService/Admin/Jobs/AdminJobRunner.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/AdminJobRunner.cs
@@ -98,14 +98,23 @@ public class AdminJobRunner(IServiceScopeFactory scopeFactory) : IHostedService
         // runs, and the job may hold its dependencies for hours.
         using var scope = scopeFactory.CreateScope();
         var repository = scope.ServiceProvider.GetRequiredService<IAdminJobRepository>();
-        var context = new AdminJobContext(key, repository, claimed);
+
+        // Resolved before the context so the context knows the job's duty cycle. Null
+        // is unreachable in practice - TryStart already found it in an identical
+        // container - but is handled as a job failure rather than an unobserved throw.
+        var job = FindJob(scope.ServiceProvider, key);
+        var context = new AdminJobContext(key, repository, claimed, job?.MaxDutyCycle ?? 1.0);
 
         var status = AdminJobStatus.Completed;
         string error = null;
 
         try
         {
-            var job = FindJob(scope.ServiceProvider, key);
+            if (job == null)
+            {
+                throw new InvalidOperationException($"Admin job '{key}' is no longer registered.");
+            }
+
             Log.Information("Admin job {JobKey} starting (run {RunCount})", key, claimed.RunCount);
 
             await job.RunAsync(context, running.Cancellation.Token);

--- a/W3ChampionsStatisticService/Admin/Jobs/AdminJobRunner.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/AdminJobRunner.cs
@@ -103,7 +103,12 @@ public class AdminJobRunner(IServiceScopeFactory scopeFactory) : IHostedService
         // is unreachable in practice - TryStart already found it in an identical
         // container - but is handled as a job failure rather than an unobserved throw.
         var job = FindJob(scope.ServiceProvider, key);
-        var context = new AdminJobContext(key, repository, claimed, job?.MaxDutyCycle ?? 1.0);
+        var context = new AdminJobContext(
+            key,
+            repository,
+            claimed,
+            job?.FallbackDutyCycle ?? 1.0,
+            scope.ServiceProvider.GetRequiredService<IPressureProbe>());
 
         var status = AdminJobStatus.Completed;
         string error = null;

--- a/W3ChampionsStatisticService/Admin/Jobs/AdminJobRunner.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/AdminJobRunner.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using W3C.Domain.Tracing;
+
+namespace W3ChampionsStatisticService.Admin.Jobs;
+
+/// <summary>
+/// Starts, tracks and cancels admin jobs in-process.
+/// <para>
+/// <b>This assumes the service runs as a single instance.</b> There is no queue and no
+/// polling loop: the API calls <see cref="TryStart"/> directly and the job runs here.
+/// The assumption is only actually baked into <see cref="StartAsync"/> - see the
+/// comment there before scaling out.
+/// </para>
+/// </summary>
+[Trace]
+public class AdminJobRunner(IServiceScopeFactory scopeFactory) : IHostedService
+{
+    private readonly ConcurrentDictionary<string, RunningJob> _running = new();
+
+    /// <summary>Cancels every running job when the host shuts down.</summary>
+    private readonly CancellationTokenSource _shutdown = new();
+
+    private sealed record RunningJob(CancellationTokenSource Cancellation)
+    {
+        /// <summary>Completes when the job has finished and written its final state.</summary>
+        public TaskCompletionSource Finished { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public async Task<AdminJobStartResult> TryStart(string key, string battleTag, bool force, bool reset)
+    {
+        // A scope of the runner's own, not the caller's: the request scope is disposed
+        // when the HTTP response completes, which would tear scoped services out from
+        // under a job that outlives the request.
+        using var scope = scopeFactory.CreateScope();
+
+        var job = FindJob(scope.ServiceProvider, key);
+        if (job == null)
+        {
+            return AdminJobStartResult.NotFound;
+        }
+
+        var repository = scope.ServiceProvider.GetRequiredService<IAdminJobRepository>();
+        var claimed = await repository.TryClaim(key, battleTag, force, reset);
+        if (claimed == null)
+        {
+            return AdminJobStartResult.NotStartable;
+        }
+
+        var running = new RunningJob(CancellationTokenSource.CreateLinkedTokenSource(_shutdown.Token));
+        if (!_running.TryAdd(key, running))
+        {
+            // The database said the job was startable but we already track it running.
+            // Only reachable if state drifted; refuse rather than run it twice.
+            running.Cancellation.Dispose();
+            Log.Warning("Admin job {JobKey} was claimed but is already tracked as running", key);
+            return AdminJobStartResult.NotStartable;
+        }
+
+        // Deliberately not awaited - the HTTP request returns immediately and the job
+        // continues in the background. Exceptions are handled inside Execute.
+        _ = Execute(key, claimed, running);
+
+        return AdminJobStartResult.Started;
+    }
+
+    public bool Cancel(string key)
+    {
+        if (!_running.TryGetValue(key, out var running))
+        {
+            return false;
+        }
+
+        Log.Information("Admin job {JobKey} cancellation requested", key);
+        running.Cancellation.Cancel();
+        return true;
+    }
+
+    public bool IsRunning(string key) => _running.ContainsKey(key);
+
+    /// <summary>
+    /// Completes once the job has finished and written its final state, or immediately
+    /// if it is not running.
+    /// </summary>
+    public Task WhenFinished(string key) =>
+        _running.TryGetValue(key, out var running) ? running.Finished.Task : Task.CompletedTask;
+
+    private async Task Execute(string key, AdminJob claimed, RunningJob running)
+    {
+        // A fresh scope for the job itself. TryStart's scope is gone by the time this
+        // runs, and the job may hold its dependencies for hours.
+        using var scope = scopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<IAdminJobRepository>();
+        var context = new AdminJobContext(key, repository, claimed);
+
+        var status = AdminJobStatus.Completed;
+        string error = null;
+
+        try
+        {
+            var job = FindJob(scope.ServiceProvider, key);
+            Log.Information("Admin job {JobKey} starting (run {RunCount})", key, claimed.RunCount);
+
+            await job.RunAsync(context, running.Cancellation.Token);
+
+            Log.Information("Admin job {JobKey} completed, {ItemsProcessed} items", key, context.ItemsProcessed);
+        }
+        catch (OperationCanceledException) when (running.Cancellation.IsCancellationRequested)
+        {
+            // Shutdown counts as Interrupted rather than Cancelled: nobody chose to stop
+            // it, and the distinction is what an admin looking at the row needs. Both
+            // resume from the checkpoint identically.
+            status = _shutdown.IsCancellationRequested ? AdminJobStatus.Interrupted : AdminJobStatus.Cancelled;
+            Log.Information("Admin job {JobKey} stopped as {Status} after {ItemsProcessed} items",
+                key, status, context.ItemsProcessed);
+        }
+        catch (Exception ex)
+        {
+            status = AdminJobStatus.Failed;
+            error = ex.Message;
+            Log.Error(ex, "Admin job {JobKey} failed", key);
+        }
+        finally
+        {
+            try
+            {
+                // Persist whatever the job last reported before recording the outcome,
+                // so a resumed run picks up from its real position.
+                await context.Flush();
+                await repository.Finish(key, status, error);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Admin job {JobKey} finished as {Status} but its state could not be saved", key, status);
+            }
+
+            // Stop tracking only once the final state is written. Dropping it earlier
+            // would leave a window where the job reads as not running while the database
+            // still says Running, and a new start could be accepted against it.
+            _running.TryRemove(key, out _);
+            running.Cancellation.Dispose();
+            running.Finished.TrySetResult();
+        }
+    }
+
+    private static IAdminJob FindJob(IServiceProvider services, string key) =>
+        services.GetServices<IAdminJob>().FirstOrDefault(j => j.Key == key);
+
+    public static List<IAdminJob> AllJobs(IServiceProvider services) =>
+        services.GetServices<IAdminJob>().OrderBy(j => j.Name).ToList();
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<IAdminJobRepository>();
+
+        // Anything still marked Running belongs to a process that no longer exists, so
+        // it is safe to mark it Interrupted and let an admin resume it. This is the one
+        // place the single-instance assumption is load-bearing: with a second replica,
+        // a booting replica would mark a job legitimately running elsewhere as dead.
+        // Adding replicas therefore means adding an owner id and a heartbeat here.
+        try
+        {
+            var interrupted = await repository.MarkRunningAsInterrupted();
+            if (interrupted.Count > 0)
+            {
+                Log.Warning("Marked admin jobs as interrupted after restart: {JobKeys}", string.Join(", ", interrupted));
+            }
+        }
+        catch (Exception ex)
+        {
+            // Never block startup for this - the worst case is a stale Running row that
+            // an admin can reset.
+            Log.Error(ex, "Could not sweep interrupted admin jobs at startup");
+        }
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await _shutdown.CancelAsync();
+
+        // Give running jobs the chance to write their checkpoint on the way out, so a
+        // routine deploy resumes from where it stopped instead of redoing a batch.
+        // cancellationToken is the host's shutdown timeout (5s by default) - once it
+        // fires, the process is going away regardless and the startup sweep will pick
+        // up whatever was left marked Running.
+        var pending = _running.Values.Select(r => r.Finished.Task).ToArray();
+        if (pending.Length == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await Task.WhenAll(pending).WaitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            Log.Warning("Shutdown timed out with {Count} admin job(s) still stopping", pending.Length);
+        }
+    }
+}
+
+public enum AdminJobStartResult
+{
+    Started,
+    NotFound,
+
+    /// <summary>Already running, or completed and <c>force</c> was not passed.</summary>
+    NotStartable,
+}

--- a/W3ChampionsStatisticService/Admin/Jobs/AdminJobServiceExtensions.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/AdminJobServiceExtensions.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
+using W3ChampionsStatisticService.Extensions;
+
+namespace W3ChampionsStatisticService.Admin.Jobs;
+
+public static class AdminJobServiceExtensions
+{
+    public static IServiceCollection AddAdminJobs(this IServiceCollection services)
+    {
+        services.AddInterceptedScoped<IAdminJobRepository, AdminJobRepository>();
+
+        // Singleton because it owns the cancellation tokens of everything running, and
+        // a hosted service resolving to that same instance so shutdown reaches them.
+        services.AddSingleton<AdminJobRunner>();
+        services.AddHostedService(sp => sp.GetRequiredService<AdminJobRunner>());
+
+        // Job registrations. Discovered by the runner and the controller as IAdminJob.
+        return services;
+    }
+}

--- a/W3ChampionsStatisticService/Admin/Jobs/AdminJobServiceExtensions.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/AdminJobServiceExtensions.cs
@@ -9,6 +9,10 @@ public static class AdminJobServiceExtensions
     {
         services.AddInterceptedScoped<IAdminJobRepository, AdminJobRepository>();
 
+        // Singleton so the "serverStatus is not permitted" warning is logged once for
+        // the process rather than once per job run.
+        services.AddSingleton<IPressureProbe, PressureProbe>();
+
         // Singleton because it owns the cancellation tokens of everything running, and
         // a hosted service resolving to that same instance so shutdown reaches them.
         services.AddSingleton<AdminJobRunner>();

--- a/W3ChampionsStatisticService/Admin/Jobs/AdminJobsController.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/AdminJobsController.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
+using W3C.Contracts.Admin.Permission;
+using W3C.Domain.Common.Services;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.WebApi.ActionFilters;
+
+namespace W3ChampionsStatisticService.Admin.Jobs;
+
+/// <summary>
+/// Manual trigger for operational jobs, so one-offs like the MMR timeline backfill do
+/// not need shell access to the environment. See docs/admin-job-runner.md.
+/// </summary>
+[ApiController]
+[Route("api/admin/jobs")]
+[Trace]
+public class AdminJobsController(
+    IEnumerable<IAdminJob> jobs,
+    IAdminJobRepository jobRepository,
+    AdminJobRunner runner,
+    IAuditLogService auditLogService) : ControllerBase
+{
+    private const string AuditCategory = "JOB";
+
+    private readonly List<IAdminJob> _jobs = jobs.OrderBy(j => j.Name).ToList();
+
+    [HttpGet]
+    [BearerHasPermissionFilter(Permission = EPermission.Jobs)]
+    public async Task<IActionResult> GetJobs()
+    {
+        var states = (await jobRepository.LoadAll()).ToDictionary(j => j.Id);
+
+        return Ok(_jobs
+            .Select(job => AdminJobDto.From(job, states.GetValueOrDefault(job.Key)))
+            .ToList());
+    }
+
+    [HttpPost("{key}/run")]
+    [BearerHasPermissionFilter(Permission = EPermission.Jobs)]
+    public async Task<IActionResult> RunJob(
+        string key,
+        string battleTag,
+        [FromQuery] bool force = false,
+        [FromQuery] bool reset = false)
+    {
+        var job = _jobs.FirstOrDefault(j => j.Key == key);
+        if (job == null)
+        {
+            return NotFound(new { error = "unknown_job", key });
+        }
+
+        if (!CallerHasJobPermission(job))
+        {
+            return StatusCode(403, new { error = "permission_missing", permission = job.RequiredPermission.ToString() });
+        }
+
+        var result = await runner.TryStart(key, battleTag, force, reset);
+        if (result == AdminJobStartResult.NotFound)
+        {
+            return NotFound(new { error = "unknown_job", key });
+        }
+
+        if (result == AdminJobStartResult.NotStartable)
+        {
+            // Either it is already running, or it has completed and the caller did not
+            // ask to run it again.
+            return Conflict(new { error = "job_not_startable", key });
+        }
+
+        await auditLogService.LogAction(
+            battleTag,
+            AuditCategory,
+            reset ? "RUN_RESET" : force ? "RUN_FORCE" : "RUN",
+            nameof(AdminJob),
+            key);
+
+        return Ok(await LoadDto(job));
+    }
+
+    [HttpPost("{key}/cancel")]
+    [BearerHasPermissionFilter(Permission = EPermission.Jobs)]
+    public async Task<IActionResult> CancelJob(string key, string battleTag)
+    {
+        var job = _jobs.FirstOrDefault(j => j.Key == key);
+        if (job == null)
+        {
+            return NotFound(new { error = "unknown_job", key });
+        }
+
+        if (!CallerHasJobPermission(job))
+        {
+            return StatusCode(403, new { error = "permission_missing", permission = job.RequiredPermission.ToString() });
+        }
+
+        if (!runner.Cancel(key))
+        {
+            return Conflict(new { error = "job_not_running", key });
+        }
+
+        await auditLogService.LogAction(battleTag, AuditCategory, "CANCEL", nameof(AdminJob), key);
+
+        // Cancellation is cooperative, so the job is still winding down here. The client
+        // sees the terminal status on its next poll.
+        return Ok(await LoadDto(job));
+    }
+
+    private async Task<AdminJobDto> LoadDto(IAdminJob job) =>
+        AdminJobDto.From(job, await jobRepository.Load(job.Key));
+
+    /// <summary>
+    /// A job may require more than <see cref="EPermission.Jobs"/>, which is all the
+    /// filter attribute can express - it is static, and the job is only known per
+    /// request. Re-reads the caller's token rather than trusting anything from the
+    /// route.
+    /// </summary>
+    private bool CallerHasJobPermission(IAdminJob job)
+    {
+        if (job.RequiredPermission == EPermission.Jobs)
+        {
+            return true;
+        }
+
+        var token = BearerHasPermissionFilter.GetToken(Request.Headers[HeaderNames.Authorization]);
+        var user = new W3CAuthenticationService().GetUserByToken(token, true);
+        return user.Permissions.Contains(job.RequiredPermission);
+    }
+}

--- a/W3ChampionsStatisticService/Admin/Jobs/IAdminJob.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/IAdminJob.cs
@@ -37,14 +37,15 @@ public interface IAdminJob
     bool RequiresConfirmation => false;
 
     /// <summary>
-    /// The largest share of wall-clock time this job may spend working, enforced by
-    /// <see cref="IAdminJobContext.Pace"/>. 1.0 lets it run flat out; the default leaves
-    /// the database idle three quarters of the time.
+    /// Share of wall-clock time this job may spend working <b>when the database pressure
+    /// signals cannot be read</b> - normally it runs as fast as those signals allow and
+    /// this does not apply. 1.0 disables the fallback entirely.
     /// <para>
-    /// Only has an effect if the job actually calls <c>Pace</c> between batches.
+    /// Only has an effect if the job actually calls
+    /// <see cref="IAdminJobContext.Pace"/> between batches.
     /// </para>
     /// </summary>
-    double MaxDutyCycle => 0.25;
+    double FallbackDutyCycle => 0.25;
 
     Task RunAsync(IAdminJobContext context, CancellationToken cancellationToken);
 }
@@ -80,9 +81,10 @@ public interface IAdminJobContext
     void AddItems(long count);
 
     /// <summary>
-    /// Call between batches to keep the job within its <see cref="IAdminJob.MaxDutyCycle"/>.
-    /// Sleeps in proportion to how long the batch just took, and throws if the job has
-    /// been cancelled - so this doubles as the natural cancellation point of a work loop.
+    /// Call between batches. Returns immediately while the database and this service
+    /// have headroom, and pauses in proportion to the last batch when they do not.
+    /// Throws if the job has been cancelled, so this doubles as the natural cancellation
+    /// point of a work loop.
     /// </summary>
     Task Pace(CancellationToken cancellationToken);
 }

--- a/W3ChampionsStatisticService/Admin/Jobs/IAdminJob.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/IAdminJob.cs
@@ -1,0 +1,71 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using W3C.Contracts.Admin.Permission;
+
+namespace W3ChampionsStatisticService.Admin.Jobs;
+
+/// <summary>
+/// A manually-triggered operational job. Register implementations with
+/// <c>AddInterceptedScoped&lt;IAdminJob, MyJob&gt;()</c>; the runner discovers them from DI
+/// the same way <c>IRequiresIndexes</c> repositories are discovered.
+/// <para>
+/// Implementations must be resumable: a job may be started again after being
+/// interrupted, cancelled or failed, and is handed back the checkpoint it last
+/// reported. Up to a few seconds of checkpoint progress can be lost on an abrupt
+/// death (see <see cref="AdminJobContext"/>), so work between checkpoints must be
+/// safe to redo.
+/// </para>
+/// </summary>
+public interface IAdminJob
+{
+    /// <summary>Stable identifier, used as the document id and in the API route.</summary>
+    string Key { get; }
+
+    string Name { get; }
+
+    string Description { get; }
+
+    /// <summary>
+    /// Checked in addition to <see cref="EPermission.Jobs"/>, which gates the jobs
+    /// API as a whole. Lets an individual job be restricted further without changing
+    /// the runner.
+    /// </summary>
+    EPermission RequiredPermission => EPermission.Jobs;
+
+    /// <summary>When true the UI makes the admin type the job name before running it.</summary>
+    bool RequiresConfirmation => false;
+
+    Task RunAsync(IAdminJobContext context, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// How a job reads its resume point and reports progress back. Writes are throttled
+/// by the implementation, so jobs may call <see cref="Report"/> freely.
+/// </summary>
+public interface IAdminJobContext
+{
+    /// <summary>
+    /// The checkpoint reported by the previous run, or null on a fresh run. The job
+    /// defines the shape.
+    /// </summary>
+    BsonDocument Checkpoint { get; }
+
+    /// <summary>Count carried over from a previous run, so a resumed job keeps counting up.</summary>
+    long ItemsProcessed { get; }
+
+    /// <summary>
+    /// Records progress. Returns a completed task when the write is throttled away,
+    /// so this is cheap to call in a tight loop, but it must still be awaited - it
+    /// performs the write when the throttle interval has elapsed.
+    /// </summary>
+    /// <param name="total">Zero if unknown.</param>
+    /// <param name="checkpoint">
+    /// When supplied, replaces the resume point. Persisted with the next write, which
+    /// may not be this call.
+    /// </param>
+    Task Report(long current, long total, string message = null, BsonDocument checkpoint = null);
+
+    /// <summary>Adds to <see cref="ItemsProcessed"/>.</summary>
+    void AddItems(long count);
+}

--- a/W3ChampionsStatisticService/Admin/Jobs/IAdminJob.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/IAdminJob.cs
@@ -36,6 +36,16 @@ public interface IAdminJob
     /// <summary>When true the UI makes the admin type the job name before running it.</summary>
     bool RequiresConfirmation => false;
 
+    /// <summary>
+    /// The largest share of wall-clock time this job may spend working, enforced by
+    /// <see cref="IAdminJobContext.Pace"/>. 1.0 lets it run flat out; the default leaves
+    /// the database idle three quarters of the time.
+    /// <para>
+    /// Only has an effect if the job actually calls <c>Pace</c> between batches.
+    /// </para>
+    /// </summary>
+    double MaxDutyCycle => 0.25;
+
     Task RunAsync(IAdminJobContext context, CancellationToken cancellationToken);
 }
 
@@ -68,4 +78,11 @@ public interface IAdminJobContext
 
     /// <summary>Adds to <see cref="ItemsProcessed"/>.</summary>
     void AddItems(long count);
+
+    /// <summary>
+    /// Call between batches to keep the job within its <see cref="IAdminJob.MaxDutyCycle"/>.
+    /// Sleeps in proportion to how long the batch just took, and throws if the job has
+    /// been cancelled - so this doubles as the natural cancellation point of a work loop.
+    /// </summary>
+    Task Pace(CancellationToken cancellationToken);
 }

--- a/W3ChampionsStatisticService/Admin/Jobs/IAdminJobRepository.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/IAdminJobRepository.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+
+namespace W3ChampionsStatisticService.Admin.Jobs;
+
+public interface IAdminJobRepository
+{
+    Task<List<AdminJob>> LoadAll();
+
+    Task<AdminJob> Load(string key);
+
+    /// <summary>
+    /// Atomically moves a job into <see cref="AdminJobStatus.Running"/>, returning the
+    /// claimed document, or null if its current status does not allow starting.
+    /// </summary>
+    /// <param name="force">Also allow starting a job that has already completed.</param>
+    /// <param name="reset">Discard the checkpoint and counters and start over.</param>
+    Task<AdminJob> TryClaim(string key, string battleTag, bool force, bool reset);
+
+    Task ReportProgress(string key, AdminJobProgress progress, BsonDocument checkpoint, long itemsProcessed);
+
+    /// <param name="error">Null unless <paramref name="status"/> is <see cref="AdminJobStatus.Failed"/>.</param>
+    Task Finish(string key, AdminJobStatus status, string error);
+
+    /// <summary>
+    /// Marks every job left <see cref="AdminJobStatus.Running"/> as
+    /// <see cref="AdminJobStatus.Interrupted"/>. Returns the keys affected.
+    /// </summary>
+    Task<List<string>> MarkRunningAsInterrupted();
+}

--- a/W3ChampionsStatisticService/Admin/Jobs/PressureProbe.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/PressureProbe.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Serilog;
+
+namespace W3ChampionsStatisticService.Admin.Jobs;
+
+/// <summary>
+/// One reading of how hard the database and this service are currently working.
+/// <para>
+/// Counter fields are cumulative since start and only mean anything as the difference
+/// between two samples; gauge fields stand on their own. Interpreting them is
+/// <see cref="AdminJobContext"/>'s job, so that a probe stays stateless and can be
+/// shared by concurrently running jobs.
+/// </para>
+/// </summary>
+public record PressureSample(
+    DateTimeOffset TakenAt,
+    TimeSpan ProcessCpuTime,
+    int ProcessorCount,
+    bool DatabaseAvailable,
+    long DirtyTriggerReached,
+    long ApplicationThreadEvictions,
+    double DirtyCacheFraction,
+    double WriteTicketUtilisation,
+    long QueuedWriters);
+
+public interface IPressureProbe
+{
+    Task<PressureSample> Sample(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Samples two independent back-pressure signals: how loaded the database is, and how
+/// much CPU this service is burning.
+/// <para>
+/// <b>Database.</b> This deployment is a single mongod, so there is no replication lag
+/// to watch. The equivalent signal is WiredTiger eviction pressure - replica lag is
+/// really a proxy for "writes are piling up faster than they can be durably absorbed",
+/// and on a standalone server that condition shows up as a growing dirty cache and,
+/// past a point, as mongod conscripting query threads into doing eviction work.
+/// </para>
+/// <para>
+/// <b>CPU.</b> Jobs run inside the same process as the API, so a job that pegs the CPU
+/// degrades every request the site serves even if the database is perfectly happy. This
+/// measures the whole process rather than the job, which is the point: what matters is
+/// whether there is headroom left for normal traffic.
+/// </para>
+/// </summary>
+public class PressureProbe(MongoClient mongoClient) : IPressureProbe
+{
+    /// <summary>
+    /// Sections we never read. serverStatus is cheap but not free, and metrics and locks
+    /// are the bulky ones.
+    /// </summary>
+    private static readonly BsonDocument ServerStatusCommand = new()
+    {
+        { "serverStatus", 1 },
+        { "metrics", 0 },
+        { "locks", 0 },
+        { "tcmalloc", 0 },
+        { "opLatencies", 0 },
+    };
+
+    private bool _loggedUnavailable;
+
+    public async Task<PressureSample> Sample(CancellationToken cancellationToken)
+    {
+        var process = Process.GetCurrentProcess();
+
+        // ProcessorCount honours the container's CPU limit, so this stays a fraction of
+        // what we are actually allowed to use rather than of the host's hardware.
+        var local = new PressureSample(
+            TakenAt: DateTimeOffset.UtcNow,
+            ProcessCpuTime: process.TotalProcessorTime,
+            ProcessorCount: Math.Max(Environment.ProcessorCount, 1),
+            DatabaseAvailable: false,
+            DirtyTriggerReached: 0,
+            ApplicationThreadEvictions: 0,
+            DirtyCacheFraction: 0,
+            WriteTicketUtilisation: 0,
+            QueuedWriters: 0);
+
+        BsonDocument status;
+        try
+        {
+            status = await mongoClient
+                .GetDatabase("admin")
+                .RunCommandAsync<BsonDocument>(ServerStatusCommand, cancellationToken: cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            if (!_loggedUnavailable)
+            {
+                // Most likely the user lacks clusterMonitor. Say so once; jobs fall back
+                // to a fixed conservative pace and keep the CPU brake.
+                _loggedUnavailable = true;
+                Log.Warning(ex, "Cannot read MongoDB pressure (serverStatus); admin jobs will pace themselves blindly");
+            }
+
+            return local;
+        }
+
+        var cache = Get(status, "wiredTiger", "cache");
+        if (cache == null)
+        {
+            return local;
+        }
+
+        var maxBytes = GetNumber(cache, "maximum bytes configured") ?? 0;
+        var dirtyBytes = GetNumber(cache, "tracked dirty bytes in the cache") ?? 0;
+
+        var writeQueue = Get(status, "queues", "execution", "write");
+        var totalTickets = GetNumber(writeQueue, "totalTickets") ?? 0;
+        var ticketsOut = GetNumber(writeQueue, "out") ?? 0;
+
+        return local with
+        {
+            DatabaseAvailable = true,
+            DirtyTriggerReached = (long)(GetNumber(cache, "number of times dirty trigger was reached") ?? 0),
+            ApplicationThreadEvictions = (long)(GetNumber(cache, "application threads page write from cache to disk count") ?? 0),
+            DirtyCacheFraction = maxBytes > 0 ? dirtyBytes / maxBytes : 0,
+            WriteTicketUtilisation = totalTickets > 0 ? ticketsOut / totalTickets : 0,
+            QueuedWriters = (long)(GetNumber(Get(status, "globalLock", "currentQueue"), "writers") ?? 0),
+        };
+    }
+
+    private static BsonDocument Get(BsonDocument document, params string[] path)
+    {
+        foreach (var step in path)
+        {
+            if (document == null || !document.TryGetValue(step, out var value) || !value.IsBsonDocument)
+            {
+                return null;
+            }
+
+            document = value.AsBsonDocument;
+        }
+
+        return document;
+    }
+
+    private static double? GetNumber(BsonDocument document, string field) =>
+        document != null && document.TryGetValue(field, out var value) && value.IsNumeric
+            ? value.ToDouble()
+            : null;
+}

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -19,6 +19,7 @@ using W3C.Domain.Repositories;
 using W3C.Domain.UpdateService;
 
 using W3ChampionsStatisticService.Admin;
+using W3ChampionsStatisticService.Admin.Jobs;
 using W3ChampionsStatisticService.Admin.Logs;
 using W3ChampionsStatisticService.Cache;
 using W3ChampionsStatisticService.Clans;
@@ -259,6 +260,9 @@ builder.Services.AddCommonServices();
 
 // Rewards services
 builder.Services.AddRewardServices();
+
+// Manually-triggered operational jobs (see docs/admin-job-runner.md)
+builder.Services.AddAdminJobs();
 
 // MongoDB index initialization service - runs once at startup
 builder.Services.AddHostedService<W3ChampionsStatisticService.Common.Services.MongoIndexInitializationService>();

--- a/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/AdminJobPacingTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/AdminJobPacingTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using W3ChampionsStatisticService.Admin.Jobs;
+
+namespace WC3ChampionsStatisticService.Tests.Admin.Jobs;
+
+/// <summary>
+/// Covers how <see cref="AdminJobContext.Pace"/> reacts to the pressure signals. These
+/// spin for a little over <see cref="AdminJobContext.SampleInterval"/> because the
+/// counters need two readings before a difference means anything.
+/// </summary>
+[TestFixture]
+public class AdminJobPacingTests
+{
+    private FakePressureProbe _probe;
+    private AdminJobContext _context;
+
+    [SetUp]
+    public void Setup()
+    {
+        _probe = new FakePressureProbe();
+        _context = new AdminJobContext(
+            "paced",
+            new FakeAdminJobRepository(),
+            new AdminJob { Id = "paced" },
+            fallbackDutyCycle: 0.25,
+            _probe);
+    }
+
+    /// <summary>
+    /// Paces in a tight loop until a second reading has been taken. Individual pauses
+    /// stay negligible because each batch is near-instant.
+    /// </summary>
+    private async Task PaceUntilSampled(int samples)
+    {
+        var deadline = DateTimeOffset.UtcNow + AdminJobContext.SampleInterval * (samples + 1);
+        while (_probe.Samples < samples && DateTimeOffset.UtcNow < deadline)
+        {
+            await _context.Pace(CancellationToken.None);
+        }
+
+        Assert.That(_probe.Samples, Is.GreaterThanOrEqualTo(samples), "the probe was never sampled enough times");
+    }
+
+    [Test]
+    public async Task AHealthyServerReportsNoReasonToSlowDown()
+    {
+        await PaceUntilSampled(2);
+
+        Assert.That(_context.LastPressureReason, Is.Null);
+    }
+
+    [Test]
+    public async Task EvictionOnApplicationThreadsIsTreatedAsPressure()
+    {
+        await PaceUntilSampled(1);
+
+        // Any movement at all on this counter means mongod is conscripting query threads
+        // into eviction, so no threshold is applied to it.
+        _probe.ApplicationThreadEvictions = 1;
+        await PaceUntilSampled(2);
+
+        Assert.That(_context.LastPressureReason, Does.Contain("application threads"));
+    }
+
+    [Test]
+    public async Task ADirtyCacheOverTheLimitIsTreatedAsPressure()
+    {
+        _probe.DirtyCacheFraction = 0.15;
+
+        await PaceUntilSampled(2);
+
+        Assert.That(_context.LastPressureReason, Does.Contain("dirty cache"));
+    }
+
+    [Test]
+    public async Task PressureClearingLetsTheJobSpeedBackUp()
+    {
+        await PaceUntilSampled(1);
+        _probe.DirtyCacheFraction = 0.15;
+        await PaceUntilSampled(2);
+        Assert.That(_context.LastPressureReason, Is.Not.Null, "precondition: the job should have backed off");
+
+        _probe.DirtyCacheFraction = 0.01;
+        await PaceUntilSampled(3);
+
+        Assert.That(_context.LastPressureReason, Is.Null);
+    }
+
+    [Test]
+    public async Task ASignalThatCannotBeReadDoesNotLookLikeHeadroom()
+    {
+        _probe.DatabaseAvailable = false;
+
+        // One measurable batch, then a pace: with no signal the 25% fallback applies, so
+        // roughly 100ms of work owes roughly 300ms of pause.
+        await _context.Pace(CancellationToken.None);
+        await Task.Delay(100);
+
+        var start = DateTimeOffset.UtcNow;
+        await _context.Pace(CancellationToken.None);
+        var paused = DateTimeOffset.UtcNow - start;
+
+        Assert.That(paused, Is.GreaterThan(TimeSpan.FromMilliseconds(150)));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/AdminJobRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/AdminJobRepositoryTests.cs
@@ -1,0 +1,176 @@
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using NUnit.Framework;
+using W3ChampionsStatisticService.Admin.Jobs;
+
+namespace WC3ChampionsStatisticService.Tests.Admin.Jobs;
+
+[TestFixture]
+public class AdminJobRepositoryTests : IntegrationTestBase
+{
+    private AdminJobRepository _repository;
+
+    [SetUp]
+    public void SetupRepository()
+    {
+        _repository = new AdminJobRepository(MongoClient);
+    }
+
+    private Task<AdminJob> Claim(bool force = false, bool reset = false) =>
+        _repository.TryClaim("job", "peon#1", force, reset);
+
+    private async Task<AdminJob> FinishAs(AdminJobStatus status, BsonDocument checkpoint = null, long items = 0)
+    {
+        if (checkpoint != null || items > 0)
+        {
+            await _repository.ReportProgress("job", new AdminJobProgress { Current = items }, checkpoint, items);
+        }
+
+        await _repository.Finish("job", status, status == AdminJobStatus.Failed ? "boom" : null);
+        return await _repository.Load("job");
+    }
+
+    [Test]
+    public async Task FirstClaimCreatesTheDocument()
+    {
+        var claimed = await Claim();
+
+        Assert.That(claimed, Is.Not.Null);
+        Assert.That(claimed.Status, Is.EqualTo(AdminJobStatus.Running));
+        Assert.That(claimed.TriggeredBy, Is.EqualTo("peon#1"));
+        Assert.That(claimed.RunCount, Is.EqualTo(1));
+        Assert.That(claimed.StartedAt, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task ARunningJobCannotBeClaimedAgain()
+    {
+        await Claim();
+
+        Assert.That(await Claim(), Is.Null);
+        Assert.That(await Claim(force: true), Is.Null, "force is for re-running a finished job, not stealing a running one");
+    }
+
+    [Test]
+    public async Task ACompletedJobNeedsForceToRunAgain()
+    {
+        await Claim();
+        await FinishAs(AdminJobStatus.Completed);
+
+        Assert.That(await Claim(), Is.Null);
+
+        var forced = await Claim(force: true);
+        Assert.That(forced, Is.Not.Null);
+        Assert.That(forced.RunCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task AFailedJobCanBeRunAgainWithoutForce()
+    {
+        await Claim();
+        await FinishAs(AdminJobStatus.Failed);
+
+        var again = await Claim();
+
+        Assert.That(again, Is.Not.Null);
+        Assert.That(again.Error, Is.Null, "the previous run's error should not linger on a new run");
+    }
+
+    [Test]
+    public async Task CancelledJobResumesFromItsCheckpointAndKeepsCounting()
+    {
+        await Claim();
+        await FinishAs(AdminJobStatus.Cancelled, new BsonDocument("day", 12), items: 900);
+
+        var resumed = await Claim();
+
+        Assert.That(resumed.Checkpoint, Is.EqualTo(new BsonDocument("day", 12)));
+        Assert.That(resumed.ItemsProcessed, Is.EqualTo(900));
+    }
+
+    [Test]
+    public async Task ResetDiscardsTheCheckpointAndCounters()
+    {
+        await Claim();
+        await FinishAs(AdminJobStatus.Cancelled, new BsonDocument("day", 12), items: 900);
+
+        var restarted = await Claim(reset: true);
+
+        Assert.That(restarted.Checkpoint, Is.Null);
+        Assert.That(restarted.ItemsProcessed, Is.Zero);
+        Assert.That(restarted.Progress.Current, Is.Zero);
+    }
+
+    [Test]
+    public async Task ForcingACompletedJobStartsOverEvenThoughACheckpointRemains()
+    {
+        await Claim();
+        await FinishAs(AdminJobStatus.Completed, new BsonDocument("day", 30), items: 5000);
+
+        var forced = await Claim(force: true);
+
+        Assert.That(forced.Checkpoint, Is.Null, "force on a completed job means run the whole thing again");
+        Assert.That(forced.ItemsProcessed, Is.Zero);
+    }
+
+    [Test]
+    public async Task DurationCountsWorkingTimeOnlyAcrossAPauseAndResume()
+    {
+        await Claim();
+        await Task.Delay(60);
+        await FinishAs(AdminJobStatus.Cancelled, new BsonDocument("day", 1), items: 10);
+        var firstLeg = (await _repository.Load("job")).DurationMs;
+
+        // Stand in for a job left paused: the gap before the resume must not be counted.
+        await Task.Delay(250);
+
+        await Claim();
+        var finished = await FinishAs(AdminJobStatus.Completed);
+
+        Assert.That(firstLeg, Is.GreaterThan(0));
+        Assert.That(finished.DurationMs, Is.GreaterThanOrEqualTo(firstLeg));
+        Assert.That(finished.DurationMs, Is.LessThan(firstLeg + 250),
+            "the idle time between the two legs leaked into the reported duration");
+    }
+
+    [Test]
+    public async Task ReportProgressLeavesTheCheckpointAloneWhenNoneIsGiven()
+    {
+        await Claim();
+        await _repository.ReportProgress("job", new AdminJobProgress { Current = 1 }, new BsonDocument("day", 3), 1);
+        await _repository.ReportProgress("job", new AdminJobProgress { Current = 2 }, null, 2);
+
+        var state = await _repository.Load("job");
+
+        Assert.That(state.Checkpoint, Is.EqualTo(new BsonDocument("day", 3)));
+        Assert.That(state.ItemsProcessed, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task InterruptedSweepOnlyTouchesRunningJobs()
+    {
+        await _repository.TryClaim("running", "peon#1", false, false);
+        await _repository.TryClaim("finished", "peon#1", false, false);
+        await _repository.Finish("finished", AdminJobStatus.Completed, null);
+
+        var swept = await _repository.MarkRunningAsInterrupted();
+
+        Assert.That(swept, Is.EquivalentTo(new[] { "running" }));
+        Assert.That((await _repository.Load("running")).Status, Is.EqualTo(AdminJobStatus.Interrupted));
+        Assert.That((await _repository.Load("finished")).Status, Is.EqualTo(AdminJobStatus.Completed));
+    }
+
+    [Test]
+    public async Task AnInterruptedJobResumesRatherThanStartingOver()
+    {
+        await Claim();
+        await _repository.ReportProgress("job", new AdminJobProgress { Current = 5 }, new BsonDocument("day", 5), 500);
+        await _repository.MarkRunningAsInterrupted();
+
+        var resumed = await Claim();
+
+        Assert.That(resumed.Status, Is.EqualTo(AdminJobStatus.Running));
+        Assert.That(resumed.Checkpoint, Is.EqualTo(new BsonDocument("day", 5)));
+        Assert.That(resumed.ItemsProcessed, Is.EqualTo(500));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/AdminJobRunnerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/AdminJobRunnerTests.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Bson;
+using NUnit.Framework;
+using W3ChampionsStatisticService.Admin.Jobs;
+
+namespace WC3ChampionsStatisticService.Tests.Admin.Jobs;
+
+[TestFixture]
+public class AdminJobRunnerTests
+{
+    private FakeAdminJobRepository _repository;
+
+    [SetUp]
+    public void Setup()
+    {
+        _repository = new FakeAdminJobRepository();
+    }
+
+    private AdminJobRunner CreateRunner(params IAdminJob[] jobs)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IAdminJobRepository>(_repository);
+        foreach (var job in jobs)
+        {
+            services.AddSingleton(job);
+        }
+
+        return new AdminJobRunner(services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>());
+    }
+
+    [Test]
+    public async Task RunToCompletion_RecordsCompleted()
+    {
+        var job = new FakeAdminJob("done", (_, _) => Task.CompletedTask);
+        var runner = CreateRunner(job);
+
+        var result = await runner.TryStart("done", "peon#1", force: false, reset: false);
+        await runner.WhenFinished("done");
+
+        Assert.That(result, Is.EqualTo(AdminJobStartResult.Started));
+        Assert.That(_repository.Finishes, Is.EquivalentTo(new[] { ("done", AdminJobStatus.Completed, (string)null) }));
+    }
+
+    [Test]
+    public async Task UnknownKey_IsNotFound()
+    {
+        var runner = CreateRunner();
+
+        var result = await runner.TryStart("nope", "peon#1", force: false, reset: false);
+
+        Assert.That(result, Is.EqualTo(AdminJobStartResult.NotFound));
+        Assert.That(_repository.Finishes, Is.Empty);
+    }
+
+    [Test]
+    public async Task ThrowingJob_IsRecordedAsFailedWithItsMessage()
+    {
+        var job = new FakeAdminJob("boom", (_, _) => throw new InvalidOperationException("it broke"));
+        var runner = CreateRunner(job);
+
+        await runner.TryStart("boom", "peon#1", force: false, reset: false);
+        await runner.WhenFinished("boom");
+
+        Assert.That(_repository.Finishes, Is.EquivalentTo(new[] { ("boom", AdminJobStatus.Failed, "it broke") }));
+    }
+
+    [Test]
+    public async Task AlreadyRunning_IsRefusedRatherThanRunTwice()
+    {
+        var release = new TaskCompletionSource();
+        var job = new FakeAdminJob("slow", (_, _) => release.Task);
+        var runner = CreateRunner(job);
+
+        var first = await runner.TryStart("slow", "peon#1", force: false, reset: false);
+        var second = await runner.TryStart("slow", "peon#2", force: false, reset: false);
+
+        Assert.That(first, Is.EqualTo(AdminJobStartResult.Started));
+        Assert.That(second, Is.EqualTo(AdminJobStartResult.NotStartable));
+
+        release.SetResult();
+        await runner.WhenFinished("slow");
+    }
+
+    [Test]
+    public async Task Cancel_StopsTheJobAndRecordsCancelled()
+    {
+        var started = new TaskCompletionSource();
+        var job = new FakeAdminJob("cancellable", async (_, token) =>
+        {
+            started.SetResult();
+            await Task.Delay(Timeout.Infinite, token);
+        });
+        var runner = CreateRunner(job);
+
+        await runner.TryStart("cancellable", "peon#1", force: false, reset: false);
+        await started.Task;
+
+        Assert.That(runner.Cancel("cancellable"), Is.True);
+        await runner.WhenFinished("cancellable");
+
+        Assert.That(_repository.Finishes, Is.EquivalentTo(new[] { ("cancellable", AdminJobStatus.Cancelled, (string)null) }));
+    }
+
+    [Test]
+    public void Cancel_WhenNotRunning_ReportsNothingToCancel()
+    {
+        var runner = CreateRunner(new FakeAdminJob("idle", (_, _) => Task.CompletedTask));
+
+        Assert.That(runner.Cancel("idle"), Is.False);
+    }
+
+    [Test]
+    public async Task CheckpointIsFlushedEvenWhenTheJobIsCancelled()
+    {
+        var started = new TaskCompletionSource();
+        var job = new FakeAdminJob("checkpointing", async (context, token) =>
+        {
+            // Reported inside the throttle window, so only the runner's final flush can
+            // get it to the database - which is exactly what a resume depends on.
+            await context.Report(1, 10, "day 1", new BsonDocument("day", 1));
+            started.SetResult();
+            await Task.Delay(Timeout.Infinite, token);
+        });
+        var runner = CreateRunner(job);
+
+        await runner.TryStart("checkpointing", "peon#1", force: false, reset: false);
+        await started.Task;
+        runner.Cancel("checkpointing");
+        await runner.WhenFinished("checkpointing");
+
+        var state = await _repository.Load("checkpointing");
+        Assert.That(state.Checkpoint, Is.EqualTo(new BsonDocument("day", 1)));
+        Assert.That(state.Progress.Current, Is.EqualTo(1));
+        Assert.That(state.Progress.Message, Is.EqualTo("day 1"));
+    }
+
+    [Test]
+    public async Task ResumedJobSeesItsPreviousCheckpointAndCount()
+    {
+        var job = new FakeAdminJob("resumable", (_, _) => Task.CompletedTask);
+        _repository.Seed("resumable", new AdminJob
+        {
+            Status = AdminJobStatus.Interrupted,
+            Checkpoint = new BsonDocument("day", 7),
+            ItemsProcessed = 4200,
+        });
+        var runner = CreateRunner(job);
+
+        await runner.TryStart("resumable", "peon#1", force: false, reset: false);
+        await runner.WhenFinished("resumable");
+
+        Assert.That(job.ObservedCheckpoint, Is.EqualTo(new BsonDocument("day", 7)));
+        Assert.That(job.ObservedItemsProcessed, Is.EqualTo(4200));
+    }
+
+    [Test]
+    public async Task ShutdownCancelsRunningJobsAndRecordsThemAsInterrupted()
+    {
+        var started = new TaskCompletionSource();
+        var job = new FakeAdminJob("long", async (_, token) =>
+        {
+            started.SetResult();
+            await Task.Delay(Timeout.Infinite, token);
+        });
+        var runner = CreateRunner(job);
+
+        await runner.TryStart("long", "peon#1", force: false, reset: false);
+        await started.Task;
+        await runner.StopAsync(CancellationToken.None);
+
+        // Interrupted rather than Cancelled: nobody chose to stop it.
+        Assert.That(_repository.Finishes, Is.EquivalentTo(new[] { ("long", AdminJobStatus.Interrupted, (string)null) }));
+    }
+
+    [Test]
+    public async Task StartupSweepMarksJobsLeftRunningByADeadProcess()
+    {
+        _repository.Seed("stale", new AdminJob { Status = AdminJobStatus.Running });
+        var runner = CreateRunner();
+
+        await runner.StartAsync(CancellationToken.None);
+
+        Assert.That((await _repository.Load("stale")).Status, Is.EqualTo(AdminJobStatus.Interrupted));
+    }
+
+    [Test]
+    public async Task ProgressWritesAreThrottled()
+    {
+        var job = new FakeAdminJob("chatty", async (context, _) =>
+        {
+            for (var i = 0; i < 500; i++)
+            {
+                await context.Report(i, 500);
+            }
+        });
+        var runner = CreateRunner(job);
+
+        await runner.TryStart("chatty", "peon#1", force: false, reset: false);
+        await runner.WhenFinished("chatty");
+
+        // 500 reports must not be 500 writes. Normally this collapses to the runner's
+        // single closing flush; the bound is loose so a slow machine crossing a 2s
+        // window does not fail the test.
+        Assert.That(_repository.ProgressWrites, Is.LessThan(5));
+        Assert.That((await _repository.Load("chatty")).Progress.Current, Is.EqualTo(499));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/AdminJobRunnerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/AdminJobRunnerTests.cs
@@ -12,17 +12,20 @@ namespace WC3ChampionsStatisticService.Tests.Admin.Jobs;
 public class AdminJobRunnerTests
 {
     private FakeAdminJobRepository _repository;
+    private FakePressureProbe _probe;
 
     [SetUp]
     public void Setup()
     {
         _repository = new FakeAdminJobRepository();
+        _probe = new FakePressureProbe();
     }
 
     private AdminJobRunner CreateRunner(params IAdminJob[] jobs)
     {
         var services = new ServiceCollection();
         services.AddSingleton<IAdminJobRepository>(_repository);
+        services.AddSingleton<IPressureProbe>(_probe);
         foreach (var job in jobs)
         {
             services.AddSingleton(job);
@@ -187,8 +190,9 @@ public class AdminJobRunnerTests
     }
 
     [Test]
-    public async Task PacingHoldsAJobToItsDutyCycle()
+    public async Task WithNoPressureSignalTheJobFallsBackToItsDutyCycle()
     {
+        _probe.DatabaseAvailable = false;
         var job = new FakeAdminJob("paced", async (context, token) =>
         {
             for (var i = 0; i < 3; i++)
@@ -197,7 +201,7 @@ public class AdminJobRunnerTests
                 await context.Pace(token);
             }
         })
-        { MaxDutyCycle = 0.25 };
+        { FallbackDutyCycle = 0.25 };
         var runner = CreateRunner(job);
 
         var start = DateTimeOffset.UtcNow;
@@ -212,8 +216,33 @@ public class AdminJobRunnerTests
     }
 
     [Test]
+    public async Task AHealthyDatabaseIsNotPacedAtAll()
+    {
+        var job = new FakeAdminJob("unpaced", async (context, token) =>
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                await Task.Delay(50, token);
+                await context.Pace(token);
+            }
+        })
+        { FallbackDutyCycle = 0.25 };
+        var runner = CreateRunner(job);
+
+        var start = DateTimeOffset.UtcNow;
+        await runner.TryStart("unpaced", "peon#1", force: false, reset: false);
+        await runner.WhenFinished("unpaced");
+        var elapsed = DateTimeOffset.UtcNow - start;
+
+        // The whole point of reading pressure: with headroom the duty cycle does not
+        // apply, so 150ms of work takes about 150ms rather than 600ms.
+        Assert.That(elapsed, Is.LessThan(TimeSpan.FromMilliseconds(400)));
+    }
+
+    [Test]
     public async Task PacingObservesCancellation()
     {
+        _probe.DatabaseAvailable = false;
         var started = new TaskCompletionSource();
         var job = new FakeAdminJob("paced-cancel", async (context, token) =>
         {
@@ -224,7 +253,7 @@ public class AdminJobRunnerTests
                 await context.Pace(token);
             }
         })
-        { MaxDutyCycle = 0.01 };
+        { FallbackDutyCycle = 0.01 };
         var runner = CreateRunner(job);
 
         await runner.TryStart("paced-cancel", "peon#1", force: false, reset: false);

--- a/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/AdminJobRunnerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/AdminJobRunnerTests.cs
@@ -187,6 +187,57 @@ public class AdminJobRunnerTests
     }
 
     [Test]
+    public async Task PacingHoldsAJobToItsDutyCycle()
+    {
+        var job = new FakeAdminJob("paced", async (context, token) =>
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                await Task.Delay(50, token);
+                await context.Pace(token);
+            }
+        })
+        { MaxDutyCycle = 0.25 };
+        var runner = CreateRunner(job);
+
+        var start = DateTimeOffset.UtcNow;
+        await runner.TryStart("paced", "peon#1", force: false, reset: false);
+        await runner.WhenFinished("paced");
+        var elapsed = DateTimeOffset.UtcNow - start;
+
+        // 150ms of work at a 25% duty cycle owes roughly 450ms of pause. Asserting well
+        // under that only proves it paced at all, without depending on timer accuracy.
+        Assert.That(elapsed, Is.GreaterThan(TimeSpan.FromMilliseconds(300)));
+        Assert.That(_repository.Finishes[0].Status, Is.EqualTo(AdminJobStatus.Completed));
+    }
+
+    [Test]
+    public async Task PacingObservesCancellation()
+    {
+        var started = new TaskCompletionSource();
+        var job = new FakeAdminJob("paced-cancel", async (context, token) =>
+        {
+            started.SetResult();
+            while (true)
+            {
+                await Task.Delay(20, token);
+                await context.Pace(token);
+            }
+        })
+        { MaxDutyCycle = 0.01 };
+        var runner = CreateRunner(job);
+
+        await runner.TryStart("paced-cancel", "peon#1", force: false, reset: false);
+        await started.Task;
+        runner.Cancel("paced-cancel");
+        await runner.WhenFinished("paced-cancel");
+
+        // A job asleep inside Pace must still stop promptly rather than serving out its
+        // pause, or cancel would take up to MaxPause to take effect.
+        Assert.That(_repository.Finishes[0].Status, Is.EqualTo(AdminJobStatus.Cancelled));
+    }
+
+    [Test]
     public async Task ProgressWritesAreThrottled()
     {
         var job = new FakeAdminJob("chatty", async (context, _) =>

--- a/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/FakeAdminJob.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/FakeAdminJob.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using W3C.Contracts.Admin.Permission;
+using W3ChampionsStatisticService.Admin.Jobs;
+
+namespace WC3ChampionsStatisticService.Tests.Admin.Jobs;
+
+/// <summary>A job whose body the test supplies.</summary>
+public class FakeAdminJob(string key, Func<IAdminJobContext, CancellationToken, Task> body) : IAdminJob
+{
+    public string Key { get; } = key;
+    public string Name { get; set; } = key;
+    public string Description { get; set; } = "fake";
+    public EPermission RequiredPermission { get; set; } = EPermission.Jobs;
+    public bool RequiresConfirmation { get; set; }
+
+    /// <summary>The checkpoint the job was handed, captured so tests can assert on resume.</summary>
+    public BsonDocument ObservedCheckpoint { get; private set; }
+    public long ObservedItemsProcessed { get; private set; }
+
+    public Task RunAsync(IAdminJobContext context, CancellationToken cancellationToken)
+    {
+        ObservedCheckpoint = context.Checkpoint;
+        ObservedItemsProcessed = context.ItemsProcessed;
+        return body(context, cancellationToken);
+    }
+}
+
+/// <summary>
+/// In-memory <see cref="IAdminJobRepository"/> for runner tests. Claim semantics are
+/// covered against real Mongo in AdminJobRepositoryTests; this only needs to record
+/// what the runner asked for.
+/// </summary>
+public class FakeAdminJobRepository : IAdminJobRepository
+{
+    private readonly Dictionary<string, AdminJob> _jobs = [];
+
+    public List<(string Key, AdminJobStatus Status, string Error)> Finishes { get; } = [];
+    public int ProgressWrites { get; private set; }
+
+    public AdminJob Seed(string key, AdminJob job)
+    {
+        job.Id = key;
+        _jobs[key] = job;
+        return job;
+    }
+
+    public Task<List<AdminJob>> LoadAll() => Task.FromResult(_jobs.Values.ToList());
+
+    public Task<AdminJob> Load(string key) => Task.FromResult(_jobs.GetValueOrDefault(key));
+
+    public Task<AdminJob> TryClaim(string key, string battleTag, bool force, bool reset)
+    {
+        var job = _jobs.GetValueOrDefault(key) ?? Seed(key, new AdminJob());
+        if (job.Status == AdminJobStatus.Running)
+        {
+            return Task.FromResult<AdminJob>(null);
+        }
+
+        job.Status = AdminJobStatus.Running;
+        job.TriggeredBy = battleTag;
+        job.StartedAt = DateTimeOffset.UtcNow;
+        job.RunCount++;
+        if (reset)
+        {
+            job.Checkpoint = null;
+            job.ItemsProcessed = 0;
+        }
+
+        return Task.FromResult(job);
+    }
+
+    public Task ReportProgress(string key, AdminJobProgress progress, BsonDocument checkpoint, long itemsProcessed)
+    {
+        ProgressWrites++;
+        var job = _jobs[key];
+        job.Progress = progress;
+        job.ItemsProcessed = itemsProcessed;
+        if (checkpoint != null)
+        {
+            job.Checkpoint = checkpoint;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task Finish(string key, AdminJobStatus status, string error)
+    {
+        Finishes.Add((key, status, error));
+        var job = _jobs[key];
+        job.Status = status;
+        job.Error = error;
+        job.FinishedAt = DateTimeOffset.UtcNow;
+        return Task.CompletedTask;
+    }
+
+    public Task<List<string>> MarkRunningAsInterrupted()
+    {
+        var keys = _jobs.Values.Where(j => j.Status == AdminJobStatus.Running).Select(j => j.Id).ToList();
+        foreach (var key in keys)
+        {
+            _jobs[key].Status = AdminJobStatus.Interrupted;
+        }
+
+        return Task.FromResult(keys);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/FakeAdminJob.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/FakeAdminJob.cs
@@ -19,7 +19,7 @@ public class FakeAdminJob(string key, Func<IAdminJobContext, CancellationToken, 
     public bool RequiresConfirmation { get; set; }
 
     /// <summary>Flat out by default so tests are not paced; overridden where that is the point.</summary>
-    public double MaxDutyCycle { get; set; } = 1.0;
+    public double FallbackDutyCycle { get; set; } = 1.0;
 
     /// <summary>The checkpoint the job was handed, captured so tests can assert on resume.</summary>
     public BsonDocument ObservedCheckpoint { get; private set; }
@@ -30,6 +30,36 @@ public class FakeAdminJob(string key, Func<IAdminJobContext, CancellationToken, 
         ObservedCheckpoint = context.Checkpoint;
         ObservedItemsProcessed = context.ItemsProcessed;
         return body(context, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Pressure readings the test dictates. Counters are cumulative, as the real probe's
+/// are, so a test raises them to simulate the server complaining.
+/// </summary>
+public class FakePressureProbe : IPressureProbe
+{
+    public bool DatabaseAvailable { get; set; } = true;
+    public long DirtyTriggerReached { get; set; }
+    public long ApplicationThreadEvictions { get; set; }
+    public double DirtyCacheFraction { get; set; }
+    public double WriteTicketUtilisation { get; set; }
+    public long QueuedWriters { get; set; }
+    public int Samples { get; private set; }
+
+    public Task<PressureSample> Sample(CancellationToken cancellationToken)
+    {
+        Samples++;
+        return Task.FromResult(new PressureSample(
+            TakenAt: DateTimeOffset.UtcNow,
+            ProcessCpuTime: TimeSpan.Zero,
+            ProcessorCount: 8,
+            DatabaseAvailable: DatabaseAvailable,
+            DirtyTriggerReached: DirtyTriggerReached,
+            ApplicationThreadEvictions: ApplicationThreadEvictions,
+            DirtyCacheFraction: DirtyCacheFraction,
+            WriteTicketUtilisation: WriteTicketUtilisation,
+            QueuedWriters: QueuedWriters));
     }
 }
 

--- a/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/FakeAdminJob.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/FakeAdminJob.cs
@@ -18,6 +18,9 @@ public class FakeAdminJob(string key, Func<IAdminJobContext, CancellationToken, 
     public EPermission RequiredPermission { get; set; } = EPermission.Jobs;
     public bool RequiresConfirmation { get; set; }
 
+    /// <summary>Flat out by default so tests are not paced; overridden where that is the point.</summary>
+    public double MaxDutyCycle { get; set; } = 1.0;
+
     /// <summary>The checkpoint the job was handed, captured so tests can assert on resume.</summary>
     public BsonDocument ObservedCheckpoint { get; private set; }
     public long ObservedItemsProcessed { get; private set; }

--- a/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/PressureProbeTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/PressureProbeTests.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using W3ChampionsStatisticService.Admin.Jobs;
+
+namespace WC3ChampionsStatisticService.Tests.Admin.Jobs;
+
+[TestFixture]
+public class PressureProbeTests : IntegrationTestBase
+{
+    /// <summary>
+    /// The probe reads WiredTiger statistics by their exact names, which are not a
+    /// stable API and have moved between MongoDB releases. If they move again the probe
+    /// silently reports no pressure and jobs run flat out - so this asserts against a
+    /// real server rather than a fixture.
+    /// </summary>
+    [Test]
+    public async Task ReadsTheServersActualStatistics()
+    {
+        var probe = new PressureProbe(MongoClient);
+
+        var sample = await probe.Sample(CancellationToken.None);
+
+        Assert.That(sample.DatabaseAvailable, Is.True,
+            "serverStatus was readable but the WiredTiger cache statistics were not found - the field names have probably changed");
+        Assert.That(sample.DirtyCacheFraction, Is.InRange(0.0, 1.0));
+        Assert.That(sample.WriteTicketUtilisation, Is.InRange(0.0, 1.0));
+        Assert.That(sample.ProcessorCount, Is.GreaterThan(0));
+        Assert.That(sample.ProcessCpuTime, Is.GreaterThan(System.TimeSpan.Zero));
+    }
+}

--- a/docs/admin-job-runner.md
+++ b/docs/admin-job-runner.md
@@ -112,7 +112,40 @@ runner.TryStart(key, battleTag, force, reset)   // false if already running
 runner.Cancel(key)                              // in-process CancellationTokenSource
 ```
 
-Two implementation notes that are easy to get wrong:
+### Back-pressure
+
+Jobs call `context.Pace()` between batches. Rather than holding them to a fixed
+share of wall clock, this reads whether the system actually has headroom and
+runs flat out when it does, doubling the pause while pressure persists and
+halving it once things recover.
+
+Two signals, sampled once a second:
+
+- **Database.** This is a single mongod - no transactions or change streams
+  anywhere in the solution, both of which need a replica set, and every
+  connection string is single-host - so there is no replication lag to watch.
+  The equivalent is WiredTiger eviction pressure: replica lag is really a proxy
+  for "writes are piling up faster than they can be durably absorbed", and on a
+  standalone server that shows up as a growing dirty cache and, past a point, as
+  mongod conscripting query threads into eviction. The two counters
+  (`number of times dirty trigger was reached`,
+  `application threads page write from cache to disk count`) need no threshold -
+  any movement is the server complaining. Dirty-cache fraction, write-ticket
+  utilisation and queued writers are gauges and do have thresholds, which are
+  named constants and want tuning against real load.
+- **CPU.** Jobs run in the same process as the API, so a job that pegs the CPU
+  degrades every request the site serves even when the database is happy.
+
+`FallbackDutyCycle` (25%) applies only when `serverStatus` cannot be read -
+most likely a user without `clusterMonitor`. Running flat out blind is the one
+genuinely dangerous option, so that case pays the fixed pace.
+
+The WiredTiger statistic names are not a stable API and have moved between
+releases; if they move again the probe reports no pressure and jobs run flat
+out. `PressureProbeTests` asserts against a real server rather than a fixture
+for exactly that reason.
+
+Two further implementation notes that are easy to get wrong:
 
 - **The job runs in a DI scope the runner creates**, not the request's. Scoped
   services are disposed when the HTTP response completes, so a job inheriting

--- a/docs/admin-job-runner.md
+++ b/docs/admin-job-runner.md
@@ -1,0 +1,225 @@
+# Admin job runner — spec
+
+Status: proposed, not built. Written after the lifetime-stats work, which needs
+the first job.
+
+## Why
+
+Operational one-offs currently need shell access to the environment, which not
+everyone maintaining the site has. The immediate need is a backfill of the MMR
+timeline read model (below), but the same problem recurs — there is already a
+`W3ChampionsStatisticService.Tools/MapMetadataBackfill` command that has to be
+run out of band.
+
+A job triggered from the admin UI also gets progress, an audit trail, and a
+record of having been run, which a CLI invocation does not.
+
+Scope is a job **runner**, not a scheduler. No cron, no retry/backoff, no
+chaining, no arbitrary parameters, no log streaming. Each is a reasonable
+follow-up; none is needed for the backfill, and together they are the difference
+between a contained feature and a framework.
+
+## What this builds on
+
+Nothing here is novel infrastructure; it is mostly assembly.
+
+| Piece | Where |
+| --- | --- |
+| Background services | `Program.cs` registers three via `AddHostedService` |
+| Permission filter | `WebApi/ActionFilters/BearerHasPermissionFilter.cs` — also injects the caller into `context.ActionArguments["battleTag"]`, so an action taking a `battleTag` parameter receives the acting admin |
+| Audit log | `IAuditLogRepository.Create(AuditLogEntry)`; entry carries `AdminBattleTag`, `Action`, `Category`, `EntityType`, `EntityId`, `Reason` |
+| Mongo repositories | `MongoDbRepositoryBase`, plus `IRequiresIndexes` for index declaration |
+| Admin menu | `AdminNavigation.vue` renders from a `navItems` array of `{ title, icon, permission, component, routeName }` |
+
+## Single instance
+
+**The service runs as one instance.** That is assumed throughout and is what
+keeps this small. Specifically it means:
+
+- No polling loop. The API starts the job in-process; there is no second replica
+  that needs to discover queued work. (Polling loops do exist in this codebase —
+  `ReadModelBase/AsyncServiceBase.cs` polls every 5s — but those consume a
+  continuous event stream, which is a different problem.)
+- No heartbeat, no stale-reclaim window, no owner/instance id. Those exist only
+  to answer "is the other replica still alive?".
+- Crash recovery is simpler and *more* reliable than a heartbeat: any job still
+  marked `Running` at startup is definitionally dead, so the runner marks it
+  `Interrupted` on boot and its checkpoint lets it resume.
+
+The one place this is baked in is that startup sweep. With a second replica,
+a booting replica would mark a job legitimately running elsewhere as
+interrupted. It should carry a comment saying so, so that scaling out is a
+conscious change rather than a silent breakage.
+
+The status transition should still be an atomic `FindOneAndUpdate` on `Status`
+rather than read-then-write. It is one line, it guards two admins clicking at
+once, and it fails safe rather than double-running if the assumption ever
+changes.
+
+## Data model
+
+One document per job key in an `AdminJob` collection — current state, not a run
+log. Per-run history goes to the audit log.
+
+```
+_id              string   job key, e.g. "timeline-backfill"
+Status           enum     Idle | Pending | Running | Completed | Failed | Cancelled | Interrupted
+Progress         { Current, Total, Message }
+Checkpoint       BsonDocument   job-defined resume point
+StartedAt        DateTimeOffset?
+FinishedAt       DateTimeOffset?
+TriggeredBy      string   admin battleTag
+RunCount         int
+Error            string
+```
+
+## Runner
+
+A singleton `AdminJobRunner`, registered as both a singleton and a hosted
+service. The hosted-service half only sweeps interrupted jobs on startup and
+cancels on shutdown; the API drives everything else directly.
+
+```csharp
+runner.TryStart(key, battleTag, force, reset)   // false if already running
+runner.Cancel(key)                              // in-process CancellationTokenSource
+```
+
+Two implementation notes that are easy to get wrong:
+
+- **The job runs in a DI scope the runner creates**, not the request's. Scoped
+  services are disposed when the HTTP response completes, so a job inheriting
+  the request scope dies partway with a confusing `ObjectDisposedException`.
+- **Progress writes are throttled inside the context**, not by each job. A job
+  reporting per record should not spend more time writing progress than working.
+
+## Job contract
+
+Discovered from DI the same way `IRequiresIndexes` implementations are.
+
+```csharp
+public interface IAdminJob
+{
+    string Key { get; }
+    string Name { get; }
+    string Description { get; }
+    EPermission RequiredPermission { get; }   // defaults to Jobs
+    bool RequiresConfirmation { get; }        // UI demands the job name be typed
+    Task RunAsync(IAdminJobContext context, CancellationToken cancellationToken);
+}
+
+public interface IAdminJobContext
+{
+    BsonDocument Checkpoint { get; }
+    Task Report(int current, int total, string message, BsonDocument checkpoint = null);
+}
+```
+
+## API
+
+On the admin controller, all behind `[BearerHasPermissionFilter(Permission = EPermission.Jobs)]`:
+
+```
+GET    /api/admin/jobs                 definitions + current state
+POST   /api/admin/jobs/{key}/run       ?force=true  ?reset=true
+POST   /api/admin/jobs/{key}/cancel
+```
+
+`run` returns 409 when the job is already running, or when it has completed and
+`force` was not passed. `reset` clears the checkpoint so a resumable job starts
+over. Every trigger writes an audit entry with `Category = "JOB"` and
+`EntityId = key`.
+
+A job's own `RequiredPermission` is checked inside the action, since the filter
+attribute is static.
+
+## Permission
+
+`EPermission.Jobs = 12`. The enum is mirrored by hand and must be added in
+**both** places:
+
+- `W3C.Contracts/Admin/Permission/Permission.cs`
+- `../website/src/store/admin/permission/types.ts`
+
+## Frontend
+
+`AdminJobs.vue` plus one `navItems` entry gated on `EPermission.Jobs`. A table
+of jobs with status chip, progress bar, last run and Run/Cancel buttons, polling
+the list every ~2s while anything is running and every ~15s otherwise. That is
+UI refresh, unrelated to the runner. SSE is not worth it for a handful of rows.
+
+Jobs with `RequiresConfirmation` open a dialog requiring the job name to be
+typed.
+
+## First job: timeline backfill
+
+Populates `Rd`, `Games` and `DailyMaxMmr` on historical `PlayerMmrRpTimeline`
+entries and raises their `SchemaVersion`, so the lifetime endpoint can report a
+calibration-aware peak. Until it runs, peaks are withheld for every player whose
+history predates those fields.
+
+The data needed is already persisted — `PlayerOverviewMatches` carries `Race`,
+`CurrentMmr`, `OldRankDeviation`, `Won` and `Ranking`, and `Matchup` carries
+`EndTime`, `Season`, `GameMode` and `GateWay` — so this is a query over the
+matches collection, not an event replay.
+
+**Batch by day, not by season.** A season is ~1M matches and ~15k active
+players; holding a season's timelines in memory is a few hundred MB per mode. A
+day is ~6k matches and ~4k players, which is flat regardless of how much history
+is processed.
+
+**Range by `_id`, not by date.** There is no index on `EndTime`, but `Matchup.Id`
+is an `ObjectId`, whose leading bytes are a creation timestamp — so a day's
+matches can be selected with `_id >= ObjectId(day) && _id < ObjectId(day + 1)`,
+served by the always-present `_id` index. `MatchRepository.LoadFor` already
+relies on this ordering when it sorts by `_id` descending.
+
+There is deliberately **no index on `Teams.Players.BattleTag`**, and this design
+avoids needing one: it never queries by player, it reads every match once in
+order. Adding that index would otherwise stall startup, because
+`MongoIndexInitializationService` awaits `EnsureIndexesAsync` during boot and
+`createIndexes` does not return until the build completes.
+
+Other properties:
+
+- **Checkpoint** is the last completed day; progress is days done / total.
+- **Idempotent per day.** Insertion order approximates but does not equal
+  `EndTime`, so bucket on `EndTime` and query a slightly wider `_id` range than
+  the day. Clear the day's entries before rewriting them so a resumed run
+  redoes a day cleanly.
+- **Throttle.** This is the job that can starve production; it needs a delay
+  between batches and to respect cancellation promptly.
+- Re-runnable, but requires `force` once completed.
+
+Note the rebuild recomputes each series from matches under today's rules, so it
+may not reproduce existing points exactly — the live handler skipped arranged
+teams and matches without `updatedMmr`, and applied rules that have changed.
+Mostly that is a fix, but some players' charts will visibly shift. Worth being
+deliberate about rather than surprised by.
+
+## Later jobs
+
+**`season-reset`** — the reset lives in the matchmaking service, not here:
+`POST /admin/reset` in `matchmaking-service/src/app/apis/admin.api.ts`, guarded
+by `requireAdmin` plus a hardcoded secret in the body. `resetManager.resetSeason()`
+loops every player and team entity with no progress output and no resumability.
+
+A job here would trigger it through `MatchmakingServiceClient` (needs a method
+adding) and poll `GET /admin/server-state` for `seasonIsResetting` to clear,
+which `server-state.ts` already exposes. That yields a button, an audit trail
+and a coarse running/finished state without touching the reset logic. Finer
+progress would need matchmaking to report a counter.
+
+Should be `RequiresConfirmation = true`, and arguably its own permission rather
+than sharing `Jobs` with routine backfills.
+
+**`create-index`** — adding a large index safely, out of band from startup, with
+real progress read from Mongo's `currentOp`.
+
+## Open questions
+
+1. Should `season-reset` have its own permission, separate from routine data
+   jobs? Recommendation: yes.
+2. Is the audit log enough for run history, or is a separate `AdminJobRun`
+   collection wanted for duration/outcome over time? Audit log is less code.
+3. The backfill's rebuild may shift some existing charts (above). Accept, or
+   preserve existing points where they disagree?

--- a/docs/admin-job-runner.md
+++ b/docs/admin-job-runner.md
@@ -58,8 +58,9 @@ changes.
 
 ## Data model
 
-One document per job key in an `AdminJob` collection — current state, not a run
-log. Per-run history goes to the audit log.
+One document per job key in an `AdminJob` collection — current state plus a
+summary of the most recent run. A re-run overwrites the previous run's details;
+there is deliberately no history (see "Why no run-history collection" below).
 
 ```
 _id              string   job key, e.g. "timeline-backfill"
@@ -67,11 +68,38 @@ Status           enum     Idle | Pending | Running | Completed | Failed | Cancel
 Progress         { Current, Total, Message }
 Checkpoint       BsonDocument   job-defined resume point
 StartedAt        DateTimeOffset?
-FinishedAt       DateTimeOffset?
+FinishedAt       DateTimeOffset?   set on every terminal status, not just Completed
+Duration         TimeSpan?         FinishedAt - StartedAt, denormalised for display
+ItemsProcessed   long              job-defined unit, carried across resumes
 TriggeredBy      string   admin battleTag
 RunCount         int
 Error            string
 ```
+
+`StartedAt`/`Duration`/`ItemsProcessed` describe the latest run only. On a
+resume (`Interrupted` -> `Running`) they continue accumulating rather than
+resetting, so a job that survived a deploy still reports its true total; a
+`reset` or `force` re-run clears them.
+
+### Why no run-history collection
+
+The obvious alternative is to reuse `IAuditLogRepository` for per-run history.
+Worth knowing before choosing that: **the audit log is currently write-only.**
+`IAuditLogRepository` exposes `GetRecent`, `GetByAdmin`, `GetByAffectedUser`,
+`GetByCategory` and `GetByEntity`, and nothing in the solution calls any of
+them. The writers are the rewards controllers and `ApiTokenController`; there is
+no admin page and no API endpoint reading it back, and no TTL index, so entries
+accumulate and are only reachable by querying Mongo directly.
+
+So the audit log is the right place to record *that an admin triggered a job*
+(accountability, consistent with how other admin actions are recorded), but not
+a practical place to read run outcomes from — a reader would have to be built
+from scratch either way. Keeping last-run info on the job document means the
+existing `GET /api/admin/jobs` response already carries everything the UI needs.
+
+If run-over-run history is wanted later, a separate `AdminJobRun` collection can
+be added without changing this document's shape; the fields above become a
+denormalised copy of the latest run.
 
 ## Runner
 
@@ -191,10 +219,15 @@ Other properties:
 - Re-runnable, but requires `force` once completed.
 
 Note the rebuild recomputes each series from matches under today's rules, so it
-may not reproduce existing points exactly — the live handler skipped arranged
+will not reproduce existing points exactly — the live handler skipped arranged
 teams and matches without `updatedMmr`, and applied rules that have changed.
-Mostly that is a fix, but some players' charts will visibly shift. Worth being
-deliberate about rather than surprised by.
+Some players' charts will visibly shift as a result.
+
+**This is intended.** The backfill correcting existing points is a wanted side
+effect, not just a tolerated one: the alternative (add the new fields, leave
+existing `Mmr` values alone) would leave each timeline internally inconsistent,
+with backfilled days computed one way and live-written days another. The job
+should therefore rewrite each day it touches, not merge into it.
 
 ## Later jobs
 
@@ -215,11 +248,17 @@ than sharing `Jobs` with routine backfills.
 **`create-index`** — adding a large index safely, out of band from startup, with
 real progress read from Mongo's `currentOp`.
 
+## Decisions taken
+
+- **Run history**: last-run summary on the job document, no history collection.
+  See "Why no run-history collection".
+- **Chart shift from the backfill**: accepted, and treated as a fix. See the
+  backfill section.
+
 ## Open questions
 
-1. Should `season-reset` have its own permission, separate from routine data
-   jobs? Recommendation: yes.
-2. Is the audit log enough for run history, or is a separate `AdminJobRun`
-   collection wanted for duration/outcome over time? Audit log is less code.
-3. The backfill's rebuild may shift some existing charts (above). Accept, or
-   preserve existing points where they disagree?
+1. Which permission each job should require. Deliberately left open — because
+   `RequiredPermission` is a property of the job rather than of the runner,
+   individual jobs can be moved to a stricter permission later without touching
+   the runner or the API. `season-reset` is the likeliest candidate for one of
+   its own.


### PR DESCRIPTION
Lets operational one-offs be triggered from the admin UI instead of needing shell access to the environment. The immediate need is the MMR timeline backfill (separate PR), but the problem recurs — there is already a `W3ChampionsStatisticService.Tools/MapMetadataBackfill` command that has to be run out of band.

The first commit is a design doc (`docs/admin-job-runner.md`) written before the code; it carries the reasoning behind the decisions below and is the thing to read first.

**No jobs are registered in this PR** — `GET /api/admin/jobs` returns an empty list until the backfill lands.

### Scope

A job **runner**, not a scheduler. No cron, no retry/backoff, no chaining, no arbitrary parameters, no log streaming. Each is a reasonable follow-up; none is needed yet, and together they are the difference between a contained feature and a framework.

### Single instance

The service runs as one instance, and that assumption is what keeps this small: no queue, no polling loop, no heartbeat, no owner id. The API calls the runner directly.

Polling loops *do* exist in this codebase (`AsyncServiceBase.cs:48`), but those consume a continuous event stream — a different problem from "start this job now".

The assumption is load-bearing in exactly one place: the startup sweep that marks anything still `Running` as `Interrupted`. With a second replica, a booting replica would declare a job running elsewhere dead. That is commented where it lives, so scaling out is a conscious change rather than a silent breakage.

Starting a job is still a single atomic `FindOneAndUpdate` on its status — one line, and it is what stops two admins clicking Run at the same moment.

### Pause

There isn't one, deliberately. Cancel writes the checkpoint and Run resumes from it, so pause/resume is those two operations under different labels. A real in-memory pause would add a second, weaker resumption path — a job safe to interrupt is automatically safe to pause, but not the reverse — and could not survive a deploy anyway.

Resuming keeps the checkpoint, item count and accumulated runtime. `ActiveMs` banks each leg so a job left stopped overnight doesn't report twelve hours of runtime.

### Back-pressure

Jobs call `context.Pace()` between batches. Rather than a fixed duty cycle, this reads whether the system has headroom and runs flat out when it does, doubling the pause while pressure persists and halving it on recovery.

Two signals, sampled once a second:

- **Database.** This is a single mongod — no transactions or change streams anywhere in the solution, both of which need a replica set — so there is no replication lag to watch. The standalone equivalent is WiredTiger eviction pressure: replica lag is really a proxy for "writes are piling up faster than they can be durably absorbed", which here shows up as a growing dirty cache and, past a point, as mongod conscripting query threads into eviction. Those two counters need no threshold; any movement is the server complaining.
- **CPU.** Jobs share a process with the API, so one that pegs the CPU degrades every request the site serves even when the database is happy.

`FallbackDutyCycle` (25%) applies only when `serverStatus` cannot be read — most likely a user without `clusterMonitor`. Running flat out blind is the one genuinely dangerous option.

### Two traps worth knowing about

- The job runs in a DI scope the runner creates, not the request's. Inheriting the request scope disposes the job's services when the HTTP response completes.
- Progress writes are throttled in the context, so a job reporting per record does not spend more time writing progress than working.

### Test plan

- 24 tests. 13 against fakes (completion, failure, cancel, shutdown-vs-cancel, startup sweep, throttling, pacing) and 11 against real Mongo (claim/force/reset semantics, resume, duration across a pause).
- `PressureProbeTests` runs against a real server rather than a fixture, because WiredTiger statistic names are not a stable API and have moved between releases — if they move again the probe silently reports no pressure and jobs run flat out.
- Pre-existing `Mongo2Go` failures are unrelated.

### Open question for reviewers

Which permission each job should require. `RequiredPermission` is a property of the job, so individual jobs can be tightened later without touching the runner; `season-reset` is the likeliest candidate for one of its own. The three pressure thresholds are also judgement calls and want tuning against real load — the counter signals should carry most of the weight in practice.

### Not verified

The pressure thresholds have never been exercised under real load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
