### PR TITLE
Add the lifetime MMR/RP timeline endpoint

### DIFF
--- a/W3C.Domain/GameModes/GameModesHelper.cs
+++ b/W3C.Domain/GameModes/GameModesHelper.cs
@@ -16,6 +16,22 @@ public class GameModesHelper
         GameMode.GM_4v4_AT,
     ];
 
+    /// <summary>
+    /// Modes with a separate rating per race, mirroring splitLadderByRace on the
+    /// matchmaking service's game modes. Every other mode carries one rating that
+    /// follows the player whatever race they pick, so the race a match was
+    /// recorded under says nothing about which rating it belongs to.
+    /// </summary>
+    public readonly static List<GameMode> RaceSplitGameModes = [
+        GameMode.GM_1v1,
+        GameMode.GM_PTR_1ON1,
+    ];
+
+    public static bool IsRaceSplitGameMode(GameMode gameMode)
+    {
+        return RaceSplitGameModes.Contains(gameMode);
+    }
+
     public static bool IsFfaGameMode(GameMode gameMode)
     {
         return FfaGameModes.Contains(gameMode);

--- a/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerLifetimeTimeline.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerLifetimeTimeline.cs
@@ -51,7 +51,7 @@ public class PlayerLifetimeTimeline
         foreach (var group in grouped)
         {
             var entries = group
-                .SelectMany(x => x.Timeline.MmrRpAtDates.Select(entry => (Season: x.Season, SchemaVersion: x.Timeline.SchemaVersion, Entry: entry)))
+                .SelectMany(x => x.Timeline.MmrRpAtDates.Select(entry => (Season: x.Season, Entry: entry)))
                 .OrderBy(x => x.Entry.Date)
                 .ToList();
 
@@ -64,7 +64,7 @@ public class PlayerLifetimeTimeline
                     Date = x.Entry.Date,
                     Mmr = x.Entry.Mmr,
                     Rp = x.Entry.Rp,
-                    Games = x.Entry.GamesOrDefault(x.SchemaVersion),
+                    Games = x.Entry.GamesOrDefault,
                 }).ToList(),
                 Peak = FindPeak(entries),
             });
@@ -78,18 +78,17 @@ public class PlayerLifetimeTimeline
     /// <summary>
     /// The highest rating the player held once the system was confident in it.
     ///
-    /// Null when any of the underlying documents predates the fields this needs.
-    /// Reporting an ungated peak for those would be worse than reporting none:
-    /// ratings start at 1500, so a player whose true rating is below that would
-    /// show 1500 as their lifetime best forever.
+    /// Placement entries are excluded via <see cref="MmrRpAtDate.WasCalibrating"/>,
+    /// which reads the stored Rd. Entries written before Rd was recorded have none and
+    /// so read as settled - they can therefore contribute a placement-era rating to the
+    /// peak. The backfill rebuilds every day from the events and restores Rd, so this
+    /// only affects days a completed run never reached; the tab is not shown until it
+    /// has run.
+    ///
+    /// Null when the player has no settled entries at all.
     /// </summary>
-    private static LifetimePeak FindPeak(List<(int Season, int SchemaVersion, MmrRpAtDate Entry)> entries)
+    private static LifetimePeak FindPeak(List<(int Season, MmrRpAtDate Entry)> entries)
     {
-        if (entries.Any(x => x.SchemaVersion < PlayerMmrRpTimeline.CurrentSchemaVersion))
-        {
-            return null;
-        }
-
         var settled = entries.Where(x => !x.Entry.WasCalibrating).ToList();
         if (settled.Count == 0) return null;
 
@@ -137,7 +136,7 @@ public class LifetimeRaceSeries
     public GateWay GateWay { get; set; }
     public List<LifetimePoint> Points { get; set; } = [];
 
-    /// <summary>Null when the history is too old to tell placement games apart.</summary>
+    /// <summary>Null when the player has no settled entries in this series.</summary>
     public LifetimePeak Peak { get; set; }
 }
 
@@ -147,8 +146,8 @@ public class LifetimePoint
     public int Mmr { get; set; }
     public double? Rp { get; set; }
 
-    /// <summary>Null on entries recorded before games were counted.</summary>
-    public int? Games { get; set; }
+    /// <summary>Games played that day.</summary>
+    public int Games { get; set; }
 }
 
 public class LifetimePeak

--- a/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerLifetimeTimeline.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerLifetimeTimeline.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
+using W3C.Domain.GameModes;
 
 namespace W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 
@@ -25,9 +26,16 @@ public class PlayerLifetimeTimeline
     /// </summary>
     public static PlayerLifetimeTimeline Build(GameMode gameMode, IEnumerable<SeasonTimeline> seasonTimelines)
     {
-        var byRace = seasonTimelines
-            .Where(x => x.Timeline?.MmrRpAtDates is { Count: > 0 })
-            .GroupBy(x => x.Race);
+        var withData = seasonTimelines.Where(x => x.Timeline?.MmrRpAtDates is { Count: > 0 });
+
+        // Outside the race-split modes a player has one rating that follows them
+        // across race changes, and the race a match was filed under is incidental.
+        // Grouping by it there would cut one continuous history into unrelated
+        // lines, each with its own bogus peak.
+        var raceSplit = GameModesHelper.IsRaceSplitGameMode(gameMode);
+        var byRace = raceSplit
+            ? withData.GroupBy(x => x.Race)
+            : withData.GroupBy(_ => Race.Total);
 
         var lifetime = new PlayerLifetimeTimeline { GameMode = gameMode };
 

--- a/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerLifetimeTimeline.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerLifetimeTimeline.cs
@@ -33,24 +33,32 @@ public class PlayerLifetimeTimeline
         // Grouping by it there would cut one continuous history into unrelated
         // lines, each with its own bogus peak.
         var raceSplit = GameModesHelper.IsRaceSplitGameMode(gameMode);
-        var byRace = raceSplit
-            ? withData.GroupBy(x => x.Race)
-            : withData.GroupBy(_ => Race.Total);
+
+        // Europe and America were separate ladders up to season 5, so a player who
+        // ranked on both has two unrelated ratings for the same season and race.
+        // Interleaving them by date draws one line zigzagging between two histories.
+        // Split only when there is genuinely more than one, so the ordinary
+        // single-gateway player still gets a single series.
+        var gateWays = withData.Select(x => x.GateWay).Distinct().ToList();
+        var splitByGateWay = gateWays.Count > 1;
+
+        var grouped = withData.GroupBy(x => (
+            Race: raceSplit ? x.Race : Race.Total,
+            GateWay: splitByGateWay ? x.GateWay : gateWays.FirstOrDefault()));
 
         var lifetime = new PlayerLifetimeTimeline { GameMode = gameMode };
 
-        foreach (var raceGroup in byRace)
+        foreach (var group in grouped)
         {
-            // A player can appear on both gateways in the seasons that had them,
-            // so order by date across the whole set rather than by season.
-            var entries = raceGroup
+            var entries = group
                 .SelectMany(x => x.Timeline.MmrRpAtDates.Select(entry => (Season: x.Season, SchemaVersion: x.Timeline.SchemaVersion, Entry: entry)))
                 .OrderBy(x => x.Entry.Date)
                 .ToList();
 
             lifetime.Series.Add(new LifetimeRaceSeries
             {
-                Race = raceGroup.Key,
+                Race = group.Key.Race,
+                GateWay = group.Key.GateWay,
                 Points = entries.Select(x => new LifetimePoint
                 {
                     Date = x.Entry.Date,
@@ -62,7 +70,7 @@ public class PlayerLifetimeTimeline
             });
         }
 
-        lifetime.Series = [.. lifetime.Series.OrderBy(s => s.Race)];
+        lifetime.Series = [.. lifetime.Series.OrderBy(s => s.Race).ThenBy(s => s.GateWay)];
         lifetime.Seasons = BuildSeasons(seasonTimelines);
         return lifetime;
     }
@@ -115,11 +123,18 @@ public class PlayerLifetimeTimeline
 }
 
 /// <summary>One stored timeline together with the coordinates it was loaded for.</summary>
-public record SeasonTimeline(int Season, Race Race, PlayerMmrRpTimeline Timeline);
+public record SeasonTimeline(int Season, Race Race, GateWay GateWay, PlayerMmrRpTimeline Timeline);
 
 public class LifetimeRaceSeries
 {
     public Race Race { get; set; }
+
+    /// <summary>
+    /// Which ladder this line belongs to. Up to and including season 5 Europe and
+    /// America were separate ratings, so a player active on both has two unrelated
+    /// histories and gets one series each. Everyone else gets a single series.
+    /// </summary>
+    public GateWay GateWay { get; set; }
     public List<LifetimePoint> Points { get; set; } = [];
 
     /// <summary>Null when the history is too old to tell placement games apart.</summary>

--- a/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerLifetimeTimeline.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/MmrRankingStats/PlayerLifetimeTimeline.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+
+namespace W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
+
+/// <summary>
+/// A player's rating history for one game mode across every season they played.
+///
+/// This is a response shape rather than a stored one. The per-season timelines
+/// it is built from carry an Rd that must never leave the service, so the two
+/// are kept as separate types instead of annotating the stored one and hoping
+/// nobody removes the annotation.
+/// </summary>
+public class PlayerLifetimeTimeline
+{
+    public GameMode GameMode { get; set; }
+    public List<LifetimeRaceSeries> Series { get; set; } = [];
+    public List<LifetimeSeason> Seasons { get; set; } = [];
+
+    /// <summary>
+    /// Assembles the per-season, per-race timelines into one series per race.
+    /// </summary>
+    public static PlayerLifetimeTimeline Build(GameMode gameMode, IEnumerable<SeasonTimeline> seasonTimelines)
+    {
+        var byRace = seasonTimelines
+            .Where(x => x.Timeline?.MmrRpAtDates is { Count: > 0 })
+            .GroupBy(x => x.Race);
+
+        var lifetime = new PlayerLifetimeTimeline { GameMode = gameMode };
+
+        foreach (var raceGroup in byRace)
+        {
+            // A player can appear on both gateways in the seasons that had them,
+            // so order by date across the whole set rather than by season.
+            var entries = raceGroup
+                .SelectMany(x => x.Timeline.MmrRpAtDates.Select(entry => (Season: x.Season, SchemaVersion: x.Timeline.SchemaVersion, Entry: entry)))
+                .OrderBy(x => x.Entry.Date)
+                .ToList();
+
+            lifetime.Series.Add(new LifetimeRaceSeries
+            {
+                Race = raceGroup.Key,
+                Points = entries.Select(x => new LifetimePoint
+                {
+                    Date = x.Entry.Date,
+                    Mmr = x.Entry.Mmr,
+                    Rp = x.Entry.Rp,
+                    Games = x.Entry.GamesOrDefault(x.SchemaVersion),
+                }).ToList(),
+                Peak = FindPeak(entries),
+            });
+        }
+
+        lifetime.Series = [.. lifetime.Series.OrderBy(s => s.Race)];
+        lifetime.Seasons = BuildSeasons(seasonTimelines);
+        return lifetime;
+    }
+
+    /// <summary>
+    /// The highest rating the player held once the system was confident in it.
+    ///
+    /// Null when any of the underlying documents predates the fields this needs.
+    /// Reporting an ungated peak for those would be worse than reporting none:
+    /// ratings start at 1500, so a player whose true rating is below that would
+    /// show 1500 as their lifetime best forever.
+    /// </summary>
+    private static LifetimePeak FindPeak(List<(int Season, int SchemaVersion, MmrRpAtDate Entry)> entries)
+    {
+        if (entries.Any(x => x.SchemaVersion < PlayerMmrRpTimeline.CurrentSchemaVersion))
+        {
+            return null;
+        }
+
+        var settled = entries.Where(x => !x.Entry.WasCalibrating).ToList();
+        if (settled.Count == 0) return null;
+
+        var best = settled.MaxBy(x => x.Entry.PeakMmr);
+        return new LifetimePeak
+        {
+            Mmr = best.Entry.PeakMmr,
+            Date = best.Entry.Date,
+            Season = best.Season,
+        };
+    }
+
+    /// <summary>
+    /// When each season ran, taken from the data itself. Season carries only an
+    /// id, so there is nowhere else to get this from.
+    /// </summary>
+    private static List<LifetimeSeason> BuildSeasons(IEnumerable<SeasonTimeline> seasonTimelines)
+    {
+        return seasonTimelines
+            .Where(x => x.Timeline?.MmrRpAtDates is { Count: > 0 })
+            .GroupBy(x => x.Season)
+            .Select(g => new LifetimeSeason
+            {
+                Season = g.Key,
+                Start = g.Min(x => x.Timeline.MmrRpAtDates.First().Date),
+                End = g.Max(x => x.Timeline.MmrRpAtDates.Last().Date),
+            })
+            .OrderBy(s => s.Season)
+            .ToList();
+    }
+}
+
+/// <summary>One stored timeline together with the coordinates it was loaded for.</summary>
+public record SeasonTimeline(int Season, Race Race, PlayerMmrRpTimeline Timeline);
+
+public class LifetimeRaceSeries
+{
+    public Race Race { get; set; }
+    public List<LifetimePoint> Points { get; set; } = [];
+
+    /// <summary>Null when the history is too old to tell placement games apart.</summary>
+    public LifetimePeak Peak { get; set; }
+}
+
+public class LifetimePoint
+{
+    public DateTimeOffset Date { get; set; }
+    public int Mmr { get; set; }
+    public double? Rp { get; set; }
+
+    /// <summary>Null on entries recorded before games were counted.</summary>
+    public int? Games { get; set; }
+}
+
+public class LifetimePeak
+{
+    public int Mmr { get; set; }
+    public DateTimeOffset Date { get; set; }
+    public int Season { get; set; }
+}
+
+public class LifetimeSeason
+{
+    public int Season { get; set; }
+    public DateTimeOffset Start { get; set; }
+    public DateTimeOffset End { get; set; }
+}

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
@@ -263,6 +263,35 @@ public class PlayerRepository(MongoClient mongoClient) : MongoDbRepositoryBase(m
         return result.MatchedCount == 1;
     }
 
+    public async Task<List<SeasonTimeline>> LoadPlayerMmrRpTimelines(
+        string battleTag,
+        IReadOnlyCollection<Race> races,
+        IReadOnlyCollection<GateWay> gateWays,
+        IReadOnlyCollection<int> seasons,
+        GameMode gameMode)
+    {
+        // The id encodes every coordinate, so the whole set can be fetched with
+        // one $in on _id rather than a request per season and race. There is no
+        // index on the individual values to query them any other way.
+        var wanted = new Dictionary<string, (int Season, Race Race)>();
+        foreach (var season in seasons)
+        {
+            foreach (var race in races)
+            {
+                foreach (var gateWay in gateWays)
+                {
+                    wanted[$"{season}_{battleTag}_@{gateWay}_{race}_{gameMode}"] = (season, race);
+                }
+            }
+        }
+
+        var timelines = await LoadAll<PlayerMmrRpTimeline>(t => wanted.Keys.Contains(t.Id));
+
+        return timelines
+            .Select(t => new SeasonTimeline(wanted[t.Id].Season, wanted[t.Id].Race, t))
+            .ToList();
+    }
+
     public Task<PlayerGameLength> LoadGameLengthForPlayerStats(string battleTag, int season)
     {
         var compoundId = PlayerGameLength.CompoundId(battleTag, season);

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayerRepository.cs
@@ -273,14 +273,14 @@ public class PlayerRepository(MongoClient mongoClient) : MongoDbRepositoryBase(m
         // The id encodes every coordinate, so the whole set can be fetched with
         // one $in on _id rather than a request per season and race. There is no
         // index on the individual values to query them any other way.
-        var wanted = new Dictionary<string, (int Season, Race Race)>();
+        var wanted = new Dictionary<string, (int Season, Race Race, GateWay GateWay)>();
         foreach (var season in seasons)
         {
             foreach (var race in races)
             {
                 foreach (var gateWay in gateWays)
                 {
-                    wanted[$"{season}_{battleTag}_@{gateWay}_{race}_{gameMode}"] = (season, race);
+                    wanted[$"{season}_{battleTag}_@{gateWay}_{race}_{gameMode}"] = (season, race, gateWay);
                 }
             }
         }
@@ -288,7 +288,7 @@ public class PlayerRepository(MongoClient mongoClient) : MongoDbRepositoryBase(m
         var timelines = await LoadAll<PlayerMmrRpTimeline>(t => wanted.Keys.Contains(t.Id));
 
         return timelines
-            .Select(t => new SeasonTimeline(wanted[t.Id].Season, wanted[t.Id].Race, t))
+            .Select(t => new SeasonTimeline(wanted[t.Id].Season, wanted[t.Id].Race, wanted[t.Id].GateWay, t))
             .ToList();
     }
 

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
@@ -5,6 +5,7 @@ using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.PlayerProfiles.ChatDetails;
 using W3ChampionsStatisticService.PlayerProfiles.GameModeStats;
+using W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.Services;
 using W3C.Contracts.GameObjects;
@@ -165,6 +166,42 @@ public class PlayersController(
         var playerMmrRpTimeline = await _playerRepository.LoadPlayerMmrRpTimeline(battleTag, race, gateWay, season, gameMode);
         return Ok(playerMmrRpTimeline);
     }
+
+    /// <summary>
+    /// Rating history for one game mode across every season the player took
+    /// part in, one series per race.
+    /// </summary>
+    [HttpGet("{battleTag}/mmr-rp-timeline/lifetime")]
+    public async Task<IActionResult> GetPlayerLifetimeMmrRpTimeline(
+        [FromRoute] string battleTag,
+        GameMode gameMode = GameMode.GM_1v1)
+    {
+        var overallStats = await _playerRepository.LoadPlayerOverallStats(battleTag);
+        if (overallStats == null)
+        {
+            return NotFound();
+        }
+
+        // The seasons the player actually appeared in, so the id list stays as
+        // small as possible rather than covering every season that ever ran.
+        var seasons = overallStats.ParticipatedInSeasons.Select(s => s.Id).ToList();
+
+        var timelines = await _playerRepository.LoadPlayerMmrRpTimelines(
+            battleTag,
+            LifetimeRaces,
+            LifetimeGateWays,
+            seasons,
+            gameMode);
+
+        return Ok(PlayerLifetimeTimeline.Build(gameMode, timelines));
+    }
+
+    private static readonly Race[] LifetimeRaces = [Race.HU, Race.OC, Race.NE, Race.UD, Race.RnD];
+
+    // Both gateways, because seasons up to 5 were split across them and a player
+    // may have entries under either. Merging is invisible to the caller; from
+    // season 6 on the America ids simply find nothing.
+    private static readonly GateWay[] LifetimeGateWays = [GateWay.Europe, GateWay.America];
 
     [HttpGet("{battleTag}/aka")]
     public async Task<IActionResult> GetPlayerAka([FromRoute] string battleTag)

--- a/W3ChampionsStatisticService/Ports/IPlayerRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IPlayerRepository.cs
@@ -32,6 +32,8 @@ public interface IPlayerRepository
     Task<PlayerMmrRpTimeline> LoadPlayerMmrRpTimeline(string battleTag, Race race, GateWay gateWay, int season, GameMode gameMode);
     Task UpsertPlayerMmrRpTimeline(PlayerMmrRpTimeline mmrRpTimeline);
     Task<bool> TryUpsertPlayerMmrRpTimeline(PlayerMmrRpTimeline mmrRpTimeline, int? expectedRevision);
+
+    Task<List<SeasonTimeline>> LoadPlayerMmrRpTimelines(string battleTag, IReadOnlyCollection<Race> races, IReadOnlyCollection<GateWay> gateWays, IReadOnlyCollection<int> seasons, GameMode gameMode);
     Task<List<PlayerOverview>> LoadOverviews(int season);
     Task<Dictionary<string, PlayerOverallStats>> GetPlayerBattleTagsAsync(ICollection<string> personalSettingIds);
     Task<PlayerGameLength> LoadGameLengthForPlayerStats(string battleTag, int season);

--- a/WC3ChampionsStatisticService.UnitTests/Player/PlayerLifetimeTimelineTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Player/PlayerLifetimeTimelineTests.cs
@@ -12,9 +12,12 @@ public class PlayerLifetimeTimelineTests
 {
     private static readonly DateTimeOffset Day = new(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
 
-    private static SeasonTimeline Season(int season, Race race, int schemaVersion, params MmrRpAtDate[] entries)
+    private static SeasonTimeline Season(int season, Race race, int schemaVersion, params MmrRpAtDate[] entries) =>
+        Season(GameMode.GM_1v1, season, race, schemaVersion, entries);
+
+    private static SeasonTimeline Season(GameMode gameMode, int season, Race race, int schemaVersion, params MmrRpAtDate[] entries)
     {
-        var timeline = new PlayerMmrRpTimeline("peter#123", race, GateWay.Europe, season, GameMode.GM_1v1)
+        var timeline = new PlayerMmrRpTimeline("peter#123", race, GateWay.Europe, season, gameMode)
         {
             SchemaVersion = schemaVersion,
         };
@@ -112,6 +115,36 @@ public class PlayerLifetimeTimelineTests
 
         Assert.IsNull(lifetime.Series.Single().Peak,
             "a peak over the migrated part only would silently ignore the older seasons");
+    }
+
+    [Test]
+    public void Build_MergesRacesOutsideRaceSplitModes()
+    {
+        // Direct Strike carries one rating whatever race is picked, so a race
+        // change mid-season must not split the history in two.
+        var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_DS,
+        [
+            Season(GameMode.GM_DS, 25, Race.UD, 1, Entry(0, 2800), Entry(1, 3057)),
+            Season(GameMode.GM_DS, 25, Race.RnD, 1, Entry(2, 3103), Entry(3, 3069)),
+        ]);
+
+        Assert.AreEqual(1, lifetime.Series.Count, "one rating means one line");
+        var series = lifetime.Series.Single();
+        Assert.AreEqual(Race.Total, series.Race, "the combined series is not attributed to a race");
+        CollectionAssert.AreEqual(new[] { 2800, 3057, 3103, 3069 }, series.Points.Select(p => p.Mmr).ToList());
+        Assert.AreEqual(3103, series.Peak.Mmr, "the peak spans the race change");
+    }
+
+    [Test]
+    public void Build_KeepsRacesApartInRaceSplitModes()
+    {
+        var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
+        [
+            Season(1, Race.OC, 1, Entry(0, 2000)),
+            Season(1, Race.HU, 1, Entry(1, 1800)),
+        ]);
+
+        Assert.AreEqual(2, lifetime.Series.Count, "1v1 rates each race separately");
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/Player/PlayerLifetimeTimelineTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Player/PlayerLifetimeTimelineTests.cs
@@ -12,18 +12,15 @@ public class PlayerLifetimeTimelineTests
 {
     private static readonly DateTimeOffset Day = new(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
 
-    private static SeasonTimeline Season(int season, Race race, int schemaVersion, params MmrRpAtDate[] entries) =>
-        Season(GameMode.GM_1v1, season, race, schemaVersion, entries);
+    private static SeasonTimeline Season(int season, Race race, params MmrRpAtDate[] entries) =>
+        Season(GameMode.GM_1v1, season, race, entries);
 
-    private static SeasonTimeline Season(GameMode gameMode, int season, Race race, int schemaVersion, params MmrRpAtDate[] entries) =>
-        Season(gameMode, season, race, GateWay.Europe, schemaVersion, entries);
+    private static SeasonTimeline Season(GameMode gameMode, int season, Race race, params MmrRpAtDate[] entries) =>
+        Season(gameMode, season, race, GateWay.Europe, entries);
 
-    private static SeasonTimeline Season(GameMode gameMode, int season, Race race, GateWay gateWay, int schemaVersion, params MmrRpAtDate[] entries)
+    private static SeasonTimeline Season(GameMode gameMode, int season, Race race, GateWay gateWay, params MmrRpAtDate[] entries)
     {
-        var timeline = new PlayerMmrRpTimeline("peter#123", race, gateWay, season, gameMode)
-        {
-            SchemaVersion = schemaVersion,
-        };
+        var timeline = new PlayerMmrRpTimeline("peter#123", race, gateWay, season, gameMode);
         timeline.MmrRpAtDates.AddRange(entries);
         return new SeasonTimeline(season, race, gateWay, timeline);
     }
@@ -36,9 +33,9 @@ public class PlayerLifetimeTimelineTests
     {
         var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
         [
-            Season(2, Race.OC, 1, Entry(10, 1600)),
-            Season(1, Race.OC, 1, Entry(0, 1500), Entry(1, 1550)),
-            Season(1, Race.HU, 1, Entry(0, 1400)),
+            Season(2, Race.OC, Entry(10, 1600)),
+            Season(1, Race.OC, Entry(0, 1500), Entry(1, 1550)),
+            Season(1, Race.HU, Entry(0, 1400)),
         ]);
 
         Assert.AreEqual(2, lifetime.Series.Count);
@@ -54,8 +51,8 @@ public class PlayerLifetimeTimelineTests
     {
         var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
         [
-            Season(1, Race.OC, 1, Entry(0, 1500), Entry(5, 1550)),
-            Season(2, Race.OC, 1, Entry(10, 1600), Entry(20, 1650)),
+            Season(1, Race.OC, Entry(0, 1500), Entry(5, 1550)),
+            Season(2, Race.OC, Entry(10, 1600), Entry(20, 1650)),
         ]);
 
         Assert.AreEqual(2, lifetime.Seasons.Count);
@@ -70,7 +67,7 @@ public class PlayerLifetimeTimelineTests
         // The highest rating was set while the system was still unsure of it.
         var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
         [
-            Season(1, Race.OC, 1,
+            Season(1, Race.OC,
                 Entry(0, 2000, rd: 400),
                 Entry(1, 1800),
                 Entry(2, 1900)),
@@ -87,37 +84,40 @@ public class PlayerLifetimeTimelineTests
     {
         var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
         [
-            Season(1, Race.OC, 1, Entry(0, 1800, dailyMax: 1950)),
+            Season(1, Race.OC, Entry(0, 1800, dailyMax: 1950)),
         ]);
 
         Assert.AreEqual(1950, lifetime.Series.Single().Peak.Mmr);
     }
 
     [Test]
-    public void Build_ReportsNoPeakWhenHistoryPredatesCalibrationData()
+    public void Build_TreatsEntriesWithoutCalibrationDataAsSettled()
     {
-        // Without rd there is no way to tell placement games apart, and ratings
-        // start at 1500, so an ungated peak would be wrong rather than rough.
+        // Entries written before rd was recorded have none, so WasCalibrating reads
+        // false and they count towards the peak. Optimistic on purpose: the backfill
+        // restores rd for every day it rebuilds, and the tab is not shown until it has
+        // run, so the only entries this can flatter are ones a completed run missed.
         var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
         [
-            Season(1, Race.OC, 0, Entry(0, 1500), Entry(1, 1400)),
+            Season(1, Race.OC, Entry(0, 1500), Entry(1, 1400)),
         ]);
 
-        Assert.IsNull(lifetime.Series.Single().Peak);
-        Assert.AreEqual(2, lifetime.Series.Single().Points.Count, "the series itself is still returned");
+        Assert.AreEqual(1500, lifetime.Series.Single().Peak.Mmr);
+        Assert.AreEqual(2, lifetime.Series.Single().Points.Count);
     }
 
     [Test]
-    public void Build_ReportsNoPeakWhenOnlyPartOfTheHistoryIsMigrated()
+    public void Build_PeaksAcrossTheWholeHistory()
     {
         var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
         [
-            Season(1, Race.OC, 0, Entry(0, 2500)),
-            Season(2, Race.OC, 1, Entry(10, 1600)),
+            Season(1, Race.OC, Entry(0, 2500)),
+            Season(2, Race.OC, Entry(10, 1600)),
         ]);
 
-        Assert.IsNull(lifetime.Series.Single().Peak,
-            "a peak over the migrated part only would silently ignore the older seasons");
+        var peak = lifetime.Series.Single().Peak;
+        Assert.AreEqual(2500, peak.Mmr, "the peak spans every season, not just the recent ones");
+        Assert.AreEqual(1, peak.Season);
     }
 
     [Test]
@@ -127,8 +127,8 @@ public class PlayerLifetimeTimelineTests
         // change mid-season must not split the history in two.
         var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_DS,
         [
-            Season(GameMode.GM_DS, 25, Race.UD, 1, Entry(0, 2800), Entry(1, 3057)),
-            Season(GameMode.GM_DS, 25, Race.RnD, 1, Entry(2, 3103), Entry(3, 3069)),
+            Season(GameMode.GM_DS, 25, Race.UD, Entry(0, 2800), Entry(1, 3057)),
+            Season(GameMode.GM_DS, 25, Race.RnD, Entry(2, 3103), Entry(3, 3069)),
         ]);
 
         Assert.AreEqual(1, lifetime.Series.Count, "one rating means one line");
@@ -143,8 +143,8 @@ public class PlayerLifetimeTimelineTests
     {
         var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
         [
-            Season(1, Race.OC, 1, Entry(0, 2000)),
-            Season(1, Race.HU, 1, Entry(1, 1800)),
+            Season(1, Race.OC, Entry(0, 2000)),
+            Season(1, Race.HU, Entry(1, 1800)),
         ]);
 
         Assert.AreEqual(2, lifetime.Series.Count, "1v1 rates each race separately");
@@ -155,8 +155,8 @@ public class PlayerLifetimeTimelineTests
     {
         var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
         [
-            Season(1, Race.OC, 1),
-            Season(2, Race.OC, 1, Entry(0, 1500)),
+            Season(1, Race.OC),
+            Season(2, Race.OC, Entry(0, 1500)),
         ]);
 
         Assert.AreEqual(1, lifetime.Series.Count);
@@ -170,7 +170,7 @@ public class PlayerLifetimeTimelineTests
         // The ordinary case: nothing to disambiguate, so no gateway split.
         var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
         [
-            Season(GameMode.GM_1v1, 1, Race.HU, GateWay.Europe, 1, Entry(0, 1500), Entry(1, 1600)),
+            Season(GameMode.GM_1v1, 1, Race.HU, GateWay.Europe, Entry(0, 1500), Entry(1, 1600)),
         ]);
 
         Assert.That(lifetime.Series, Has.Count.EqualTo(1));
@@ -186,8 +186,8 @@ public class PlayerLifetimeTimelineTests
         // be taken across both ladders as though it were one.
         var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
         [
-            Season(GameMode.GM_1v1, 1, Race.HU, GateWay.Europe, 1, Entry(0, 1500), Entry(2, 1600)),
-            Season(GameMode.GM_1v1, 1, Race.HU, GateWay.America, 1, Entry(1, 900), Entry(3, 1000)),
+            Season(GameMode.GM_1v1, 1, Race.HU, GateWay.Europe, Entry(0, 1500), Entry(2, 1600)),
+            Season(GameMode.GM_1v1, 1, Race.HU, GateWay.America, Entry(1, 900), Entry(3, 1000)),
         ]);
 
         Assert.That(lifetime.Series, Has.Count.EqualTo(2));
@@ -208,9 +208,9 @@ public class PlayerLifetimeTimelineTests
         // gateways, and both races collapse into Race.Total on each side.
         var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_DOTA_5ON5,
         [
-            Season(GameMode.GM_DOTA_5ON5, 1, Race.HU, GateWay.Europe, 1, Entry(0, 1500)),
-            Season(GameMode.GM_DOTA_5ON5, 1, Race.UD, GateWay.Europe, 1, Entry(1, 1550)),
-            Season(GameMode.GM_DOTA_5ON5, 1, Race.HU, GateWay.America, 1, Entry(2, 900)),
+            Season(GameMode.GM_DOTA_5ON5, 1, Race.HU, GateWay.Europe, Entry(0, 1500)),
+            Season(GameMode.GM_DOTA_5ON5, 1, Race.UD, GateWay.Europe, Entry(1, 1550)),
+            Season(GameMode.GM_DOTA_5ON5, 1, Race.HU, GateWay.America, Entry(2, 900)),
         ]);
 
         Assert.That(lifetime.Series, Has.Count.EqualTo(2));

--- a/WC3ChampionsStatisticService.UnitTests/Player/PlayerLifetimeTimelineTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Player/PlayerLifetimeTimelineTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
+
+namespace WC3ChampionsStatisticService.Tests.Player;
+
+[TestFixture]
+public class PlayerLifetimeTimelineTests
+{
+    private static readonly DateTimeOffset Day = new(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static SeasonTimeline Season(int season, Race race, int schemaVersion, params MmrRpAtDate[] entries)
+    {
+        var timeline = new PlayerMmrRpTimeline("peter#123", race, GateWay.Europe, season, GameMode.GM_1v1)
+        {
+            SchemaVersion = schemaVersion,
+        };
+        timeline.MmrRpAtDates.AddRange(entries);
+        return new SeasonTimeline(season, race, timeline);
+    }
+
+    private static MmrRpAtDate Entry(int dayOffset, int mmr, double? rd = null, int? dailyMax = null) =>
+        new(mmr, rp: null, date: Day.AddDays(dayOffset), rd: rd, games: null, dailyMaxMmr: dailyMax);
+
+    [Test]
+    public void Build_JoinsSeasonsIntoOneSeriesPerRace()
+    {
+        var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
+        [
+            Season(2, Race.OC, 1, Entry(10, 1600)),
+            Season(1, Race.OC, 1, Entry(0, 1500), Entry(1, 1550)),
+            Season(1, Race.HU, 1, Entry(0, 1400)),
+        ]);
+
+        Assert.AreEqual(2, lifetime.Series.Count);
+
+        var orc = lifetime.Series.Single(s => s.Race == Race.OC);
+        Assert.AreEqual(3, orc.Points.Count, "both seasons feed one continuous series");
+        CollectionAssert.AreEqual(new[] { 1500, 1550, 1600 }, orc.Points.Select(p => p.Mmr).ToList(),
+            "ordered by date, not by the order the seasons were loaded");
+    }
+
+    [Test]
+    public void Build_DerivesSeasonBoundariesFromTheData()
+    {
+        var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
+        [
+            Season(1, Race.OC, 1, Entry(0, 1500), Entry(5, 1550)),
+            Season(2, Race.OC, 1, Entry(10, 1600), Entry(20, 1650)),
+        ]);
+
+        Assert.AreEqual(2, lifetime.Seasons.Count);
+        Assert.AreEqual(Day, lifetime.Seasons[0].Start);
+        Assert.AreEqual(Day.AddDays(5), lifetime.Seasons[0].End);
+        Assert.AreEqual(Day.AddDays(20), lifetime.Seasons[1].End);
+    }
+
+    [Test]
+    public void Build_ExcludesCalibratingEntriesFromThePeak()
+    {
+        // The highest rating was set while the system was still unsure of it.
+        var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
+        [
+            Season(1, Race.OC, 1,
+                Entry(0, 2000, rd: 400),
+                Entry(1, 1800),
+                Entry(2, 1900)),
+        ]);
+
+        var peak = lifetime.Series.Single().Peak;
+        Assert.AreEqual(1900, peak.Mmr, "2000 was a placement rating");
+        Assert.AreEqual(Day.AddDays(2), peak.Date);
+        Assert.AreEqual(1, peak.Season);
+    }
+
+    [Test]
+    public void Build_PrefersTheIntraDayPeakOverTheClosingRating()
+    {
+        var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
+        [
+            Season(1, Race.OC, 1, Entry(0, 1800, dailyMax: 1950)),
+        ]);
+
+        Assert.AreEqual(1950, lifetime.Series.Single().Peak.Mmr);
+    }
+
+    [Test]
+    public void Build_ReportsNoPeakWhenHistoryPredatesCalibrationData()
+    {
+        // Without rd there is no way to tell placement games apart, and ratings
+        // start at 1500, so an ungated peak would be wrong rather than rough.
+        var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
+        [
+            Season(1, Race.OC, 0, Entry(0, 1500), Entry(1, 1400)),
+        ]);
+
+        Assert.IsNull(lifetime.Series.Single().Peak);
+        Assert.AreEqual(2, lifetime.Series.Single().Points.Count, "the series itself is still returned");
+    }
+
+    [Test]
+    public void Build_ReportsNoPeakWhenOnlyPartOfTheHistoryIsMigrated()
+    {
+        var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
+        [
+            Season(1, Race.OC, 0, Entry(0, 2500)),
+            Season(2, Race.OC, 1, Entry(10, 1600)),
+        ]);
+
+        Assert.IsNull(lifetime.Series.Single().Peak,
+            "a peak over the migrated part only would silently ignore the older seasons");
+    }
+
+    [Test]
+    public void Build_IgnoresEmptyTimelines()
+    {
+        var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
+        [
+            Season(1, Race.OC, 1),
+            Season(2, Race.OC, 1, Entry(0, 1500)),
+        ]);
+
+        Assert.AreEqual(1, lifetime.Series.Count);
+        Assert.AreEqual(1, lifetime.Seasons.Count);
+        Assert.AreEqual(2, lifetime.Seasons.Single().Season);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Player/PlayerLifetimeTimelineTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Player/PlayerLifetimeTimelineTests.cs
@@ -15,14 +15,17 @@ public class PlayerLifetimeTimelineTests
     private static SeasonTimeline Season(int season, Race race, int schemaVersion, params MmrRpAtDate[] entries) =>
         Season(GameMode.GM_1v1, season, race, schemaVersion, entries);
 
-    private static SeasonTimeline Season(GameMode gameMode, int season, Race race, int schemaVersion, params MmrRpAtDate[] entries)
+    private static SeasonTimeline Season(GameMode gameMode, int season, Race race, int schemaVersion, params MmrRpAtDate[] entries) =>
+        Season(gameMode, season, race, GateWay.Europe, schemaVersion, entries);
+
+    private static SeasonTimeline Season(GameMode gameMode, int season, Race race, GateWay gateWay, int schemaVersion, params MmrRpAtDate[] entries)
     {
-        var timeline = new PlayerMmrRpTimeline("peter#123", race, GateWay.Europe, season, gameMode)
+        var timeline = new PlayerMmrRpTimeline("peter#123", race, gateWay, season, gameMode)
         {
             SchemaVersion = schemaVersion,
         };
         timeline.MmrRpAtDates.AddRange(entries);
-        return new SeasonTimeline(season, race, timeline);
+        return new SeasonTimeline(season, race, gateWay, timeline);
     }
 
     private static MmrRpAtDate Entry(int dayOffset, int mmr, double? rd = null, int? dailyMax = null) =>
@@ -159,5 +162,60 @@ public class PlayerLifetimeTimelineTests
         Assert.AreEqual(1, lifetime.Series.Count);
         Assert.AreEqual(1, lifetime.Seasons.Count);
         Assert.AreEqual(2, lifetime.Seasons.Single().Season);
+    }
+
+    [Test]
+    public void Build_KeepsOneSeriesWhenOnlyOneGatewayWasPlayed()
+    {
+        // The ordinary case: nothing to disambiguate, so no gateway split.
+        var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
+        [
+            Season(GameMode.GM_1v1, 1, Race.HU, GateWay.Europe, 1, Entry(0, 1500), Entry(1, 1600)),
+        ]);
+
+        Assert.That(lifetime.Series, Has.Count.EqualTo(1));
+        Assert.That(lifetime.Series[0].GateWay, Is.EqualTo(GateWay.Europe));
+        Assert.That(lifetime.Series[0].Points, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void Build_SplitsGatewaysIntoSeparateSeries()
+    {
+        // Up to season 5 the two gateways were independent ratings. Interleaving them
+        // draws one line zigzagging between two unrelated histories, and the peak would
+        // be taken across both ladders as though it were one.
+        var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_1v1,
+        [
+            Season(GameMode.GM_1v1, 1, Race.HU, GateWay.Europe, 1, Entry(0, 1500), Entry(2, 1600)),
+            Season(GameMode.GM_1v1, 1, Race.HU, GateWay.America, 1, Entry(1, 900), Entry(3, 1000)),
+        ]);
+
+        Assert.That(lifetime.Series, Has.Count.EqualTo(2));
+
+        var europe = lifetime.Series.Single(s => s.GateWay == GateWay.Europe);
+        var america = lifetime.Series.Single(s => s.GateWay == GateWay.America);
+
+        Assert.That(europe.Points.Select(p => p.Mmr), Is.EqualTo(new[] { 1500, 1600 }));
+        Assert.That(america.Points.Select(p => p.Mmr), Is.EqualTo(new[] { 900, 1000 }));
+        Assert.That(europe.Peak.Mmr, Is.EqualTo(1600), "each ladder peaks on its own rating");
+        Assert.That(america.Peak.Mmr, Is.EqualTo(1000));
+    }
+
+    [Test]
+    public void Build_SplitsGatewaysWithinARaceMergedMode()
+    {
+        // The two groupings are independent: a non-race-split mode still separates
+        // gateways, and both races collapse into Race.Total on each side.
+        var lifetime = PlayerLifetimeTimeline.Build(GameMode.GM_DOTA_5ON5,
+        [
+            Season(GameMode.GM_DOTA_5ON5, 1, Race.HU, GateWay.Europe, 1, Entry(0, 1500)),
+            Season(GameMode.GM_DOTA_5ON5, 1, Race.UD, GateWay.Europe, 1, Entry(1, 1550)),
+            Season(GameMode.GM_DOTA_5ON5, 1, Race.HU, GateWay.America, 1, Entry(2, 900)),
+        ]);
+
+        Assert.That(lifetime.Series, Has.Count.EqualTo(2));
+        Assert.That(lifetime.Series.All(s => s.Race == Race.Total));
+        Assert.That(lifetime.Series.Single(s => s.GateWay == GateWay.Europe).Points, Has.Count.EqualTo(2));
+        Assert.That(lifetime.Series.Single(s => s.GateWay == GateWay.America).Points, Has.Count.EqualTo(1));
     }
 }


### PR DESCRIPTION
> **Stack:** #540 → #542 → #543. Each PR's base is the one before it, so every diff shows only its own change. Merge in order.
>
> **Draft.** Top of the chain; its diff is against #542.
>
> Intended to ship with the Lifetime tab **hidden**, enabled by a later frontend deploy once #542 has run. That removes the deploy-ordering constraint entirely: this can merge and deploy whenever, and the backfill runs when convenient.

Adds `GET /api/players/{battleTag}/mmr-rp-timeline/lifetime?gameMode=` for the frontend's Lifetime tab. The existing timeline is per-season; this stitches the seasons together.

### How it loads

One `$in` over ids built from `overallStats.ParticipatedInSeasons`, rather than a query per season. The timeline id is deterministic (`{season}_{battleTag}_@{gateway}_{race}_{gameMode}`), so the ids can be constructed without a lookup.

Both gateways are covered, which only matters for season 5 and earlier.

### Peaks are computed server-side

Placement entries are excluded through `WasCalibrating`, which reads the stored RD. Entries written before RD was recorded have none and so read as settled — optimistic rather than exact. The backfill restores RD for every day it rebuilds, so the only entries this can flatter are ones a completed run never reached.

An earlier revision withheld the peak entirely for any history predating those fields. That has been dropped along with `SchemaVersion`: it is a light stats page, and once #542 has run the answer is right anyway.

RD is never serialized — same policy as `PlayersObfuscator`.

### Gateways get their own series

Europe and America were independent ladders up to season 5, so a player who ranked on both has two unrelated ratings for the same season and race. Interleaving them drew one line zigzagging between two histories, with a peak taken across both as though it were one rating.

Series are now keyed by gateway as well as race and carry their `GateWay` so the two lines can be labelled. Split happens only when the data contains more than one gateway, so every season-6-onward player still gets a single series.

### Race merging

Grouped by race only for modes that rate races separately (`GameModesHelper.IsRaceSplitGameMode`, currently 1v1 and PTR 1v1). Everything else merges to `Race.Total`.

This is not cosmetic. Direct Strike carries one rating across race switches — verified against a real player whose rating ran 2759→3057 as Undead and then continued 3103→3069 as Random. Splitting those into per-race series would draw one continuous rating as several disconnected lines.

### Test plan

- 12 tests in `PlayerLifetimeTimelineTests.cs` covering season stitching, peak computation, race merging for non-split modes, and the gateway split. Verified passing after the rebase — this is a plain fixture, so unlike #542's tests it does not touch the shared database.
- Pre-existing `Mongo2Go` failures are unrelated.

### Merge order

Ship the tab hidden and enable it after #542 has run. Before the backfill, peaks are computed from history that has no RD, so they read optimistically — for players below 1500 that means a placement-era rating can show as their lifetime best.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

