### PR TITLE
feat(search): one search core with ladder-context relevance and rank-in-context lookup

### DIFF
--- a/W3ChampionsStatisticService/Admin/Jobs/AdminJobServiceExtensions.cs
+++ b/W3ChampionsStatisticService/Admin/Jobs/AdminJobServiceExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using W3ChampionsStatisticService.Extensions;
+using W3ChampionsStatisticService.Ladder;
 
 namespace W3ChampionsStatisticService.Admin.Jobs;
 
@@ -19,6 +20,7 @@ public static class AdminJobServiceExtensions
         services.AddHostedService(sp => sp.GetRequiredService<AdminJobRunner>());
 
         // Job registrations. Discovered by the runner and the controller as IAdminJob.
+        services.AddInterceptedScoped<IAdminJob, RankMemberIdsBackfillJob>();
         return services;
     }
 }

--- a/W3ChampionsStatisticService/Ladder/LadderController.cs
+++ b/W3ChampionsStatisticService/Ladder/LadderController.cs
@@ -44,6 +44,21 @@ public class LadderController(
         return Ok(playerRanks);
     }
 
+    [HttpPost("ranks-for-players")]
+    public async Task<IActionResult> GetRanksForPlayers([FromBody] RanksForPlayersRequest request)
+    {
+        if (request?.BattleTags == null || request.BattleTags.Count == 0)
+        {
+            return Ok(new List<RankInContext>());
+        }
+        if (request.BattleTags.Count > RanksForPlayersRequest.MaxBattleTags)
+        {
+            return BadRequest($"battleTags must contain at most {RanksForPlayersRequest.MaxBattleTags} entries.");
+        }
+        var ranks = await _rankRepository.LoadRanksForPlayers(request.BattleTags, request.Season, request.GateWay, request.GameMode);
+        return Ok(ranks.Select(r => r.ToRankInContext()).ToList());
+    }
+
     [HttpGet("{leagueId}")]
     public async Task<IActionResult> GetLadder([FromRoute] int leagueId, int season, GateWay gateWay = GateWay.Europe, GameMode gameMode = GameMode.GM_1v1)
     {

--- a/W3ChampionsStatisticService/Ladder/PlayerLadderStanding.cs
+++ b/W3ChampionsStatisticService/Ladder/PlayerLadderStanding.cs
@@ -6,8 +6,8 @@ namespace W3ChampionsStatisticService.Ladder;
 /// Where a player sits on one ladder — the whole of what ordering a search by ladder standing needs.
 /// </summary>
 /// <remarks>
-/// Deliberately narrower than <see cref="Rank"/>: the search core reads League and RankNumber and
-/// nothing else, so hydrating the joined PlayerOverview on every hit would be payload it never opens.
+/// Deliberately narrower than <see cref="Rank"/>: the search core reads RankingPoints and nothing
+/// else, so hydrating the joined PlayerOverview on every hit would be payload it never opens.
 /// The row set is identical to what <c>LoadRanksForPlayers</c> returns for the same arguments —
 /// including dropping ranks whose PlayerOverview is missing — so both stages of a ladder search agree
 /// on who counts as ranked.
@@ -17,7 +17,8 @@ public class PlayerLadderStanding
     // Every member of the ranked entry, so ordering can credit the standing to all of them.
     public List<string> MemberIds { get; set; } = [];
 
-    // League leads ordering because RankNumber restarts at 1 in every league.
-    public int League { get; set; }
-    public int RankNumber { get; set; }
+    // Ranking points are the ladder's global ordering, monotone across every league and division.
+    // The neighbouring fields order nothing: league ids follow creation order (divisions added
+    // mid-season take the next free id) and rank numbers restart at 1 in every league.
+    public double RankingPoints { get; set; }
 }

--- a/W3ChampionsStatisticService/Ladder/PlayerLadderStanding.cs
+++ b/W3ChampionsStatisticService/Ladder/PlayerLadderStanding.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace W3ChampionsStatisticService.Ladder;
+
+/// <summary>
+/// Where a player sits on one ladder — the whole of what ordering a search by ladder standing needs.
+/// </summary>
+/// <remarks>
+/// Deliberately narrower than <see cref="Rank"/>: the search core reads League and RankNumber and
+/// nothing else, so hydrating the joined PlayerOverview on every hit would be payload it never opens.
+/// The row set is identical to what <c>LoadRanksForPlayers</c> returns for the same arguments —
+/// including dropping ranks whose PlayerOverview is missing — so both stages of a ladder search agree
+/// on who counts as ranked.
+/// </remarks>
+public class PlayerLadderStanding
+{
+    // Every member of the ranked entry, so ordering can credit the standing to all of them.
+    public List<string> MemberIds { get; set; } = [];
+
+    // League leads ordering because RankNumber restarts at 1 in every league.
+    public int League { get; set; }
+    public int RankNumber { get; set; }
+}

--- a/W3ChampionsStatisticService/Ladder/Rank.cs
+++ b/W3ChampionsStatisticService/Ladder/Rank.cs
@@ -38,6 +38,7 @@ public class Rank : IIdentifiable
 
         Player1Id = playerIds.FirstOrDefault();
         Player2Id = playerIds.Skip(1).FirstOrDefault();
+        MemberIds = playerIds;
     }
 
     public GateWay Gateway { get; set; }
@@ -50,6 +51,13 @@ public class Rank : IIdentifiable
     public double RankingPoints { get; set; }
     public Race? Race { get; set; }
     public string PlayerId { get; set; }
+
+    // Every member of the ranked entry. Player1Id/Player2Id hold the first two of these; looking a
+    // player up by battleTag goes through this list, so members past the second are findable too.
+    // JsonIgnore keeps it out of API responses: it exists for the lookup, and serializing it would
+    // change the wire shape of every legacy endpoint that returns ranks.
+    [JsonIgnore]
+    public List<string> MemberIds { get; set; } = [];
     public string Player1Id { get; set; }
     public string Player2Id { get; set; }
     [JsonIgnore]

--- a/W3ChampionsStatisticService/Ladder/RankExtensions.cs
+++ b/W3ChampionsStatisticService/Ladder/RankExtensions.cs
@@ -23,4 +23,24 @@ public static class RankExtensions
             }
         };
     }
+
+    public static RankInContext ToRankInContext(this Rank r)
+    {
+        var p = r.Player;
+        return new RankInContext
+        {
+            Players = p.PlayerIds,
+            Season = r.Season,
+            GateWay = r.Gateway,
+            GameMode = r.GameMode,
+            Race = r.Race,
+            League = r.League,
+            RankNumber = r.RankNumber,
+            RankingPoints = r.RankingPoints,
+            Mmr = p.MMR,
+            Wins = p.Wins,
+            Losses = p.Losses,
+            Games = p.Games,
+        };
+    }
 }

--- a/W3ChampionsStatisticService/Ladder/RankInContext.cs
+++ b/W3ChampionsStatisticService/Ladder/RankInContext.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using W3C.Domain.CommonValueObjects;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+
+namespace W3ChampionsStatisticService.Ladder;
+
+// A player's ladder rank within a specific season/gateway/gameMode context.
+// Decoupled from the internal Rank model so it can be reused as League/Ranks features grow.
+// Returned only for players who ARE ranked in the context — callers infer "unranked" from absence.
+public class RankInContext
+{
+    public List<PlayerId> Players { get; set; }   // one entry per team member
+    public int Season { get; set; }
+    public GateWay GateWay { get; set; }
+    public GameMode GameMode { get; set; }
+    public Race? Race { get; set; }                // per-race for 1v1; null for team modes
+    public int League { get; set; }
+    public int RankNumber { get; set; }
+    public double RankingPoints { get; set; }
+    public int Mmr { get; set; }
+    public int Wins { get; set; }
+    public int Losses { get; set; }
+    public int Games { get; set; }
+}

--- a/W3ChampionsStatisticService/Ladder/RankMemberIdsBackfillJob.cs
+++ b/W3ChampionsStatisticService/Ladder/RankMemberIdsBackfillJob.cs
@@ -47,5 +47,11 @@ public class RankMemberIdsBackfillJob(IRankRepository rankRepository) : IAdminJo
                 new BsonDocument("LastCompletedSeason", season));
             await context.Pace(cancellationToken);
         }
+
+        // Rest on a whole-run summary rather than the last season's line. The runner flushes
+        // the final report past the write throttle, so this is what the jobs page shows once
+        // the run has completed.
+        await context.Report(seasons.Count, seasons.Count,
+            $"{seasons.Count} season(s) done, {context.ItemsProcessed} row(s) filled");
     }
 }

--- a/W3ChampionsStatisticService/Ladder/RankMemberIdsBackfillJob.cs
+++ b/W3ChampionsStatisticService/Ladder/RankMemberIdsBackfillJob.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.Admin.Jobs;
+using W3ChampionsStatisticService.Ports;
+
+namespace W3ChampionsStatisticService.Ladder;
+
+/// <summary>
+/// Fills <see cref="Rank.MemberIds"/> on rows written before the field existed, one season per
+/// batch. Rows the sync writes carry the field from birth, so until this has run on an
+/// environment the member-list lookups (search ordering, ranks-for-players) miss pre-field rows;
+/// country/clan/chat keep working through their two-field fallback either way.
+/// </summary>
+/// <remarks>
+/// The checkpoint is the last completed season. Seasons are processed ascending and a filled row
+/// never becomes unfilled — new rows always carry the field — so everything at or below the
+/// checkpoint stays done and a resume continues where the run died. The missing-field match in
+/// <see cref="IRankRepository.BackfillMemberIds"/> makes redoing a season a no-op, which covers
+/// the checkpoint interval an abrupt death can lose.
+/// </remarks>
+[Trace]
+public class RankMemberIdsBackfillJob(IRankRepository rankRepository) : IAdminJob
+{
+    public string Key => "rank-member-ids-backfill";
+
+    public string Name => "Rank MemberIds backfill";
+
+    public string Description => "Fills the Rank member list (MemberIds) on rows written before the field existed, one season per batch. Run once per environment: until then, pre-existing ranks stay invisible to the search ordering and ranks-for-players lookups. Safe to re-run; resumes from the last completed season.";
+
+    public async Task RunAsync(IAdminJobContext context, CancellationToken cancellationToken)
+    {
+        var seasons = await rankRepository.LoadRankSeasons();
+
+        var lastCompleted = context.Checkpoint?.GetValue("LastCompletedSeason", int.MinValue).AsInt32;
+        var remaining = seasons.Where(s => s > (lastCompleted ?? int.MinValue)).ToList();
+        var done = seasons.Count - remaining.Count;
+
+        foreach (var season in remaining)
+        {
+            var filled = await rankRepository.BackfillMemberIds(season);
+            context.AddItems(filled);
+            done++;
+            await context.Report(done, seasons.Count, $"season {season}: filled {filled} row(s)",
+                new BsonDocument("LastCompletedSeason", season));
+            await context.Pace(cancellationToken);
+        }
+    }
+}

--- a/W3ChampionsStatisticService/Ladder/RankRepository.cs
+++ b/W3ChampionsStatisticService/Ladder/RankRepository.cs
@@ -275,7 +275,7 @@ public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider pe
 
     /// <summary>
     /// The same rows as <see cref="LoadRanksForPlayers(List{string}, int, GateWay, GameMode)"/>,
-    /// projected to ladder position alone. For callers that order by standing and never read the
+    /// projected to ladder standing alone. For callers that order by standing and never read the
     /// player's stats — the search core asks this for an entire match set, so the joined
     /// PlayerOverview would be payload per hit that nothing opens.
     /// </summary>
@@ -301,8 +301,7 @@ public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider pe
             .Project(r => new PlayerLadderStanding
             {
                 MemberIds = r.MemberIds,
-                League = r.League,
-                RankNumber = r.RankNumber,
+                RankingPoints = r.RankingPoints,
             })
             .ToListAsync();
     }

--- a/W3ChampionsStatisticService/Ladder/RankRepository.cs
+++ b/W3ChampionsStatisticService/Ladder/RankRepository.cs
@@ -25,12 +25,12 @@ public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider pe
     public string CollectionName => nameof(Rank);
 
     /// <summary>
-    /// Declares the Rank index the consolidated-search rank lookup seeks on —
-    /// <see cref="LoadRanksForPlayers(List{string}, int, GateWay, GameMode)"/> asks "which of these
-    /// battleTags hold a rank here" and would scan the whole collection without it. Then backfills
-    /// <see cref="Rank.MemberIds"/>, since rows written before the field existed would otherwise
-    /// answer "not ranked" forever — a row only rewrites itself when its league next syncs, which
-    /// for a finished season never happens.
+    /// Declares the Rank index both consolidated-search rank queries seek on —
+    /// <see cref="LoadLadderStandings"/> (ordering) and <see cref="LoadRanksForPlayers(List{string}, int, GateWay, GameMode)"/>
+    /// (display) ask "which of these battleTags hold a rank here" and would scan the whole
+    /// collection without it. Then backfills <see cref="Rank.MemberIds"/>, since rows written
+    /// before the field existed would otherwise answer "not ranked" forever — a row only rewrites
+    /// itself when its league next syncs, which for a finished season never happens.
     /// </summary>
     /// <remarks>
     /// Creation is idempotent, so redeploys are a no-op. Should prod hold this key under a different
@@ -257,7 +257,9 @@ public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider pe
         return JoinWith(r => (list.Contains(r.Player1Id) || list.Contains(r.Player2Id)) && r.Season == season);
     }
 
-    // The one definition of "holds a rank on this ladder".
+    // The one definition of "holds a rank on this ladder". Ordering (LoadLadderStandings) and
+    // display (LoadRanksForPlayers) both match on it, so the two stages of a search cannot disagree
+    // about who is ranked.
     private static Expression<Func<Rank, bool>> OnLadder(List<string> list, int season, GateWay gateWay, GameMode gameMode)
     {
         return r => r.MemberIds.Any(member => list.Contains(member))
@@ -271,4 +273,37 @@ public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider pe
         return JoinWith(OnLadder(list, season, gateWay, gameMode));
     }
 
+    /// <summary>
+    /// The same rows as <see cref="LoadRanksForPlayers(List{string}, int, GateWay, GameMode)"/>,
+    /// projected to ladder position alone. For callers that order by standing and never read the
+    /// player's stats — the search core asks this for an entire match set, so the joined
+    /// PlayerOverview would be payload per hit that nothing opens.
+    /// </summary>
+    public async Task<List<PlayerLadderStanding>> LoadLadderStandings(
+        List<string> list,
+        int season,
+        GateWay gateWay,
+        GameMode gameMode)
+    {
+        var ranks = CreateCollection<Rank>();
+        var players = CreateCollection<PlayerOverview>();
+        return await ranks
+            .Aggregate()
+            .Match(OnLadder(list, season, gateWay, gameMode))
+            // The join stays: dropping ranks with no PlayerOverview is what keeps this in agreement
+            // with LoadRanksForPlayers about who is ranked. Those orphans are real — 379 in
+            // season 13 / 2v2 AT alone.
+            .Lookup<Rank, PlayerOverview, Rank>(players,
+                rank => rank.PlayerId,
+                player => player.Id,
+                rank => rank.Players)
+            .Match(r => r.Players.Any())
+            .Project(r => new PlayerLadderStanding
+            {
+                MemberIds = r.MemberIds,
+                League = r.League,
+                RankNumber = r.RankNumber,
+            })
+            .ToListAsync();
+    }
 }

--- a/W3ChampionsStatisticService/Ladder/RankRepository.cs
+++ b/W3ChampionsStatisticService/Ladder/RankRepository.cs
@@ -1,9 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using MongoDB.Bson;
+﻿using MongoDB.Bson;
 using MongoDB.Driver;
 using System;
-using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -17,19 +14,19 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Ladder;
 
 [Trace]
-public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider personalSettingsProvider, ILogger<RankRepository> logger = null) : MongoDbRepositoryBase(mongoClient), IRankRepository, IRequiresIndexes
+public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider personalSettingsProvider) : MongoDbRepositoryBase(mongoClient), IRankRepository, IRequiresIndexes
 {
     private PersonalSettingsProvider _personalSettingsProvider = personalSettingsProvider;
-    private readonly ILogger<RankRepository> _logger = logger ?? NullLogger<RankRepository>.Instance;
 
     public string CollectionName => nameof(Rank);
 
     /// <summary>
     /// Declares the Rank index the member lookups seek on — <see cref="LoadLadderStandings"/>
     /// (search ordering) and the context overload of <see cref="LoadRanksForPlayers(List{string}, int, GateWay, GameMode)"/>
-    /// (display). Then backfills <see cref="Rank.MemberIds"/>, since rows written before the field
-    /// existed would otherwise answer "not ranked" forever — a row only rewrites itself when its
-    /// league next syncs, which for a finished season never happens.
+    /// (display). Rows written before <see cref="Rank.MemberIds"/> existed stay invisible to those
+    /// lookups until the rank-member-ids-backfill admin job (<see cref="RankMemberIdsBackfillJob"/>)
+    /// has run — a row only rewrites itself when its league next syncs, which for a finished season
+    /// never happens.
     /// </summary>
     /// <remarks>
     /// Creation is idempotent, so redeploys are a no-op. Should prod hold this key under a different
@@ -59,38 +56,39 @@ public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider pe
         };
 
         await ranks.Indexes.CreateManyAsync(indexes);
-
-        // After the index, and isolated: a backfill failure must not cost the lookups their index,
-        // and it reports under its own identity rather than as an index-creation error.
-        try
-        {
-            var stopwatch = Stopwatch.StartNew();
-            var filled = await BackfillMemberIdsAsync(ranks);
-            if (filled > 0)
-            {
-                _logger.LogInformation("Rank MemberIds backfill filled {Count} row(s) in {ElapsedMs}ms", filled, stopwatch.ElapsedMilliseconds);
-            }
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Rank MemberIds backfill failed; rows written before the field existed stay invisible to the member lookups until a later startup succeeds");
-        }
     }
 
     /// <summary>
-    /// Fills <see cref="Rank.MemberIds"/> on rows written before the field existed and returns how
-    /// many rows were missing it.
+    /// Every season that holds rank rows, ascending — the work list of the
+    /// rank-member-ids-backfill admin job.
+    /// </summary>
+    public async Task<List<int>> LoadRankSeasons()
+    {
+        var ranks = CreateCollection<Rank>();
+        var seasons = await ranks.DistinctAsync(r => r.Season, FilterDefinition<Rank>.Empty);
+        var list = await seasons.ToListAsync();
+        list.Sort();
+        return list;
+    }
+
+    /// <summary>
+    /// Fills <see cref="Rank.MemberIds"/> on the season's rows written before the field existed and
+    /// returns how many rows were missing it. One season is one batch of the
+    /// rank-member-ids-backfill admin job, which paces between calls.
     /// </summary>
     /// <remarks>
     /// Members come from the joined PlayerOverview, which carries the whole team as structured data,
     /// so teams of three and four are repaired rather than left at the two members the old fields
     /// held. Rows with no PlayerOverview fall back to those two fields; they are the orphan ranks the
     /// lookup drops anyway, so no query can return them either way. Reading the row id instead would
-    /// be guesswork — a battleTag may itself contain the separator.
+    /// be guesswork — a battleTag may itself contain the separator. The missing-field match makes a
+    /// season safe to redo: a filled row no longer matches, so re-running finds nothing.
     /// </remarks>
-    private static async Task<long> BackfillMemberIdsAsync(IMongoCollection<Rank> ranks)
+    public async Task<long> BackfillMemberIds(int season)
     {
-        var missingField = Builders<Rank>.Filter.Exists(r => r.MemberIds, false);
+        var ranks = CreateCollection<Rank>();
+        var missingField = Builders<Rank>.Filter.Eq(r => r.Season, season)
+            & Builders<Rank>.Filter.Exists(r => r.MemberIds, false);
         var missing = await ranks.CountDocumentsAsync(missingField);
         if (missing == 0)
         {
@@ -99,7 +97,11 @@ public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider pe
 
         var pipeline = new[]
         {
-            new BsonDocument("$match", new BsonDocument("MemberIds", new BsonDocument("$exists", false))),
+            new BsonDocument("$match", new BsonDocument
+            {
+                { "Season", season },
+                { "MemberIds", new BsonDocument("$exists", false) },
+            }),
             new BsonDocument("$lookup", new BsonDocument
             {
                 { "from", nameof(PlayerOverview) },

--- a/W3ChampionsStatisticService/Ladder/RankRepository.cs
+++ b/W3ChampionsStatisticService/Ladder/RankRepository.cs
@@ -25,19 +25,21 @@ public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider pe
     public string CollectionName => nameof(Rank);
 
     /// <summary>
-    /// Declares the Rank index both consolidated-search rank queries seek on —
-    /// <see cref="LoadLadderStandings"/> (ordering) and <see cref="LoadRanksForPlayers(List{string}, int, GateWay, GameMode)"/>
-    /// (display) ask "which of these battleTags hold a rank here" and would scan the whole
-    /// collection without it. Then backfills <see cref="Rank.MemberIds"/>, since rows written
-    /// before the field existed would otherwise answer "not ranked" forever — a row only rewrites
-    /// itself when its league next syncs, which for a finished season never happens.
+    /// Declares the Rank index the member lookups seek on — <see cref="LoadLadderStandings"/>
+    /// (search ordering) and the context overload of <see cref="LoadRanksForPlayers(List{string}, int, GateWay, GameMode)"/>
+    /// (display). Then backfills <see cref="Rank.MemberIds"/>, since rows written before the field
+    /// existed would otherwise answer "not ranked" forever — a row only rewrites itself when its
+    /// league next syncs, which for a finished season never happens.
     /// </summary>
     /// <remarks>
     /// Creation is idempotent, so redeploys are a no-op. Should prod hold this key under a different
     /// name, createIndexes raises IndexOptionsConflict; MongoIndexInitializationService logs it per
     /// repository and continues — correct results, collection scans, visible only in the startup log.
     /// The index is multikey — one entry per member, which is what lets it answer for every member —
-    /// and Background is inert on MongoDB 4.2+, set to match the sibling repositories.
+    /// and Background is inert on MongoDB 4.2+, set to match the sibling repositories. The
+    /// fallback-carrying queries (<see cref="LoadPlayersOfCountry"/> and the season-only
+    /// <see cref="LoadRanksForPlayers(List{string}, int)"/>) are not member-served by it: their $or
+    /// keeps them on the season index, exactly as before this field existed.
     /// </remarks>
     public async Task EnsureIndexesAsync()
     {
@@ -147,12 +149,15 @@ public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider pe
     {
         var personalSettings = await _personalSettingsProvider.GetPersonalSettingsAsync();
 
-        var battleTags = personalSettings.Where(ps => (ps.CountryCode ?? ps.Location) == countryCode).Select(ps => ps.Id);
+        var battleTags = personalSettings.Where(ps => (ps.CountryCode ?? ps.Location) == countryCode).Select(ps => ps.Id).ToList();
 
+        // The two-field match stays as a fallback: this surface has no rollback flag, so it must keep
+        // working on rows the MemberIds backfill has not reached. Remove with the legacy retirement.
         return await JoinWith(rank => rank.Gateway == gateWay
                 && rank.GameMode == gameMode
                 && rank.Season == season
-                && (battleTags.Contains(rank.Player1Id) || battleTags.Contains(rank.Player2Id)));
+                && (rank.MemberIds.Any(member => battleTags.Contains(member))
+                    || battleTags.Contains(rank.Player1Id) || battleTags.Contains(rank.Player2Id)));
     }
 
     public Task<List<Rank>> SearchPlayerOfLeague(string searchFor, int season, GateWay gateWay, GameMode gameMode)
@@ -254,7 +259,10 @@ public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider pe
 
     public Task<List<Rank>> LoadRanksForPlayers(List<string> list, int season)
     {
-        return JoinWith(r => (list.Contains(r.Player1Id) || list.Contains(r.Player2Id)) && r.Season == season);
+        // Two-field fallback as in LoadPlayersOfCountry: clan and chat call this with no rollback
+        // flag in front of them, so un-backfilled rows must stay findable.
+        return JoinWith(r => (r.MemberIds.Any(member => list.Contains(member))
+            || list.Contains(r.Player1Id) || list.Contains(r.Player2Id)) && r.Season == season);
     }
 
     // The one definition of "holds a rank on this ladder". Ordering (LoadLadderStandings) and

--- a/W3ChampionsStatisticService/Ladder/RankRepository.cs
+++ b/W3ChampionsStatisticService/Ladder/RankRepository.cs
@@ -1,5 +1,9 @@
-﻿using MongoDB.Driver;
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Bson;
+using MongoDB.Driver;
 using System;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -13,9 +17,122 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Ladder;
 
 [Trace]
-public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider personalSettingsProvider) : MongoDbRepositoryBase(mongoClient), IRankRepository
+public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider personalSettingsProvider, ILogger<RankRepository> logger = null) : MongoDbRepositoryBase(mongoClient), IRankRepository, IRequiresIndexes
 {
     private PersonalSettingsProvider _personalSettingsProvider = personalSettingsProvider;
+    private readonly ILogger<RankRepository> _logger = logger ?? NullLogger<RankRepository>.Instance;
+
+    public string CollectionName => nameof(Rank);
+
+    /// <summary>
+    /// Declares the Rank index the consolidated-search rank lookup seeks on —
+    /// <see cref="LoadRanksForPlayers(List{string}, int, GateWay, GameMode)"/> asks "which of these
+    /// battleTags hold a rank here" and would scan the whole collection without it. Then backfills
+    /// <see cref="Rank.MemberIds"/>, since rows written before the field existed would otherwise
+    /// answer "not ranked" forever — a row only rewrites itself when its league next syncs, which
+    /// for a finished season never happens.
+    /// </summary>
+    /// <remarks>
+    /// Creation is idempotent, so redeploys are a no-op. Should prod hold this key under a different
+    /// name, createIndexes raises IndexOptionsConflict; MongoIndexInitializationService logs it per
+    /// repository and continues — correct results, collection scans, visible only in the startup log.
+    /// The index is multikey — one entry per member, which is what lets it answer for every member —
+    /// and Background is inert on MongoDB 4.2+, set to match the sibling repositories.
+    /// </remarks>
+    public async Task EnsureIndexesAsync()
+    {
+        var ranks = CreateCollection<Rank>();
+        var indexes = new List<CreateIndexModel<Rank>>
+        {
+            // Keyed lookup for "rank for this battleTag in {season, gateway, gameMode}". Leading with
+            // the member lets the bounded $in jump straight to the matching rows instead of scanning
+            // the season/mode bucket.
+            new(
+                Builders<Rank>.IndexKeys
+                    .Ascending(r => r.MemberIds)
+                    .Ascending(r => r.Season)
+                    .Ascending(r => r.Gateway)
+                    .Ascending(r => r.GameMode),
+                new CreateIndexOptions { Name = "MemberIds_Season_Gateway_GameMode", Background = true }),
+        };
+
+        await ranks.Indexes.CreateManyAsync(indexes);
+
+        // After the index, and isolated: a backfill failure must not cost the lookups their index,
+        // and it reports under its own identity rather than as an index-creation error.
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var filled = await BackfillMemberIdsAsync(ranks);
+            if (filled > 0)
+            {
+                _logger.LogInformation("Rank MemberIds backfill filled {Count} row(s) in {ElapsedMs}ms", filled, stopwatch.ElapsedMilliseconds);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Rank MemberIds backfill failed; rows written before the field existed stay invisible to the member lookups until a later startup succeeds");
+        }
+    }
+
+    /// <summary>
+    /// Fills <see cref="Rank.MemberIds"/> on rows written before the field existed and returns how
+    /// many rows were missing it.
+    /// </summary>
+    /// <remarks>
+    /// Members come from the joined PlayerOverview, which carries the whole team as structured data,
+    /// so teams of three and four are repaired rather than left at the two members the old fields
+    /// held. Rows with no PlayerOverview fall back to those two fields; they are the orphan ranks the
+    /// lookup drops anyway, so no query can return them either way. Reading the row id instead would
+    /// be guesswork — a battleTag may itself contain the separator.
+    /// </remarks>
+    private static async Task<long> BackfillMemberIdsAsync(IMongoCollection<Rank> ranks)
+    {
+        var missingField = Builders<Rank>.Filter.Exists(r => r.MemberIds, false);
+        var missing = await ranks.CountDocumentsAsync(missingField);
+        if (missing == 0)
+        {
+            return 0;
+        }
+
+        var pipeline = new[]
+        {
+            new BsonDocument("$match", new BsonDocument("MemberIds", new BsonDocument("$exists", false))),
+            new BsonDocument("$lookup", new BsonDocument
+            {
+                { "from", nameof(PlayerOverview) },
+                { "localField", "_id" },
+                { "foreignField", "_id" },
+                { "as", "overview" },
+            }),
+            // $project keeps _id + MemberIds alone, and $merge whenMatched:merge writes only those.
+            new BsonDocument("$project", new BsonDocument("MemberIds", new BsonDocument("$cond", new BsonArray
+            {
+                new BsonDocument("$gt", new BsonArray { new BsonDocument("$size", "$overview"), 0 }),
+                new BsonDocument("$map", new BsonDocument
+                {
+                    { "input", new BsonDocument("$arrayElemAt", new BsonArray { "$overview.PlayerIds", 0 }) },
+                    { "as", "member" },
+                    { "in", "$$member.BattleTag" },
+                }),
+                new BsonDocument("$filter", new BsonDocument
+                {
+                    { "input", new BsonArray { "$Player1Id", "$Player2Id" } },
+                    { "cond", new BsonDocument("$ne", new BsonArray { "$$this", BsonNull.Value }) },
+                }),
+            }))),
+            new BsonDocument("$merge", new BsonDocument
+            {
+                { "into", nameof(Rank) },
+                { "on", "_id" },
+                { "whenMatched", "merge" },
+                { "whenNotMatched", "discard" },
+            }),
+        };
+
+        await ranks.AggregateAsync<BsonDocument>(pipeline);
+        return missing;
+    }
 
     public Task<List<Rank>> LoadPlayersOfLeague(int leagueId, int season, GateWay gateWay, GameMode gameMode)
     {
@@ -138,6 +255,20 @@ public class RankRepository(MongoClient mongoClient, PersonalSettingsProvider pe
     public Task<List<Rank>> LoadRanksForPlayers(List<string> list, int season)
     {
         return JoinWith(r => (list.Contains(r.Player1Id) || list.Contains(r.Player2Id)) && r.Season == season);
+    }
+
+    // The one definition of "holds a rank on this ladder".
+    private static Expression<Func<Rank, bool>> OnLadder(List<string> list, int season, GateWay gateWay, GameMode gameMode)
+    {
+        return r => r.MemberIds.Any(member => list.Contains(member))
+            && r.Season == season
+            && r.Gateway == gateWay
+            && r.GameMode == gameMode;
+    }
+
+    public Task<List<Rank>> LoadRanksForPlayers(List<string> list, int season, GateWay gateWay, GameMode gameMode)
+    {
+        return JoinWith(OnLadder(list, season, gateWay, gameMode));
     }
 
 }

--- a/W3ChampionsStatisticService/Ladder/RanksForPlayersRequest.cs
+++ b/W3ChampionsStatisticService/Ladder/RanksForPlayersRequest.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using W3C.Contracts.Matchmaking;
+
+namespace W3ChampionsStatisticService.Ladder;
+
+// Body for POST api/ladder/ranks-for-players — enrich a page of search results with rank-in-context.
+public class RanksForPlayersRequest
+{
+    // Callers enrich one search page at a time (global-search pages are capped at 20); the bound keeps
+    // the anonymous route's $in query small.
+    public const int MaxBattleTags = 50;
+
+    public List<string> BattleTags { get; set; }
+    public int Season { get; set; }
+    public GateWay GateWay { get; set; }
+    public GameMode GameMode { get; set; }
+}

--- a/W3ChampionsStatisticService/PlayerProfiles/GlobalSearch/PlayerSearchRelevance.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/GlobalSearch/PlayerSearchRelevance.cs
@@ -3,9 +3,12 @@ using W3ChampionsStatisticService.PersonalSettings;
 
 namespace W3ChampionsStatisticService.PlayerProfiles.GlobalSearch;
 
-public class PlayerSearchRelevance(PersonalSetting p, int relevance)
+public class PlayerSearchRelevance(PersonalSetting p, string relevanceId)
 {
     [BsonId]
     public PersonalSetting Player { get; set; } = p;
-    public string RelevanceId { get; set; } = $"{relevance}_{p.Id}";
+
+    // Sort key and pagination cursor in one. Its shape depends on the search's context — see
+    // PlayerService.RelevanceId.
+    public string RelevanceId { get; set; } = relevanceId;
 }

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
@@ -60,6 +60,13 @@ public class PlayersController(
         {
             return BadRequest("search parameter must be at least 3 letters.");
         }
+        // Rejected rather than partially honoured: the relevanceId doubles as the pagination cursor and
+        // its layout differs between the two modes, so a caller who drops one parameter between pages
+        // would page a context-mode cursor against context-free keys and silently receive nothing.
+        if (season.HasValue != gateWay.HasValue || season.HasValue != gameMode.HasValue)
+        {
+            return BadRequest("season, gateWay and gameMode must be supplied together or not at all.");
+        }
         if (pageSize > 20) pageSize = 20;
         var players = await _playerService.GlobalSearchForPlayer(search, lastRelevanceId, pageSize, season, gateWay, gameMode);
         return Ok(players);

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
@@ -40,11 +40,20 @@ public class PlayersController(
     private readonly IBattleTagResolver _battleTagResolver = battleTagResolver;
     private readonly ChatDetailsQueryHandler _chatDetailsQueryHandler = chatDetailsQueryHandler;
 
+    // season + gateWay + gameMode are optional and travel together: supplying all three searches in a
+    // ladder context, where standing on that ladder is part of relevance. Callers with no ladder
+    // (the header, the player picker, launcher-e) omit them and get name relevance alone.
     [HttpGet("global-search")]
-    public async Task<IActionResult> GlobalSearchPlayer(string search, string lastRelevanceId = "", int pageSize = 20)
+    public async Task<IActionResult> GlobalSearchPlayer(
+        string search,
+        string lastRelevanceId = "",
+        int pageSize = 20,
+        int? season = null,
+        GateWay? gateWay = null,
+        GameMode? gameMode = null)
     {
         if (pageSize > 20) pageSize = 20;
-        var players = await _playerService.GlobalSearchForPlayer(search, lastRelevanceId, pageSize);
+        var players = await _playerService.GlobalSearchForPlayer(search, lastRelevanceId, pageSize, season, gateWay, gameMode);
         return Ok(players);
     }
 

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
@@ -52,7 +52,11 @@ public class PlayersController(
         GateWay? gateWay = null,
         GameMode? gameMode = null)
     {
-        if (string.IsNullOrEmpty(search) || search.Length < 3)
+        // Counted over letters and digits, not raw length: matching is culture-sensitive, so a term of
+        // zero-weight characters (U+200B and friends) is contained in every battleTag while still
+        // measuring three long — with a ladder context that turns one request into a standings lookup
+        // for the entire directory.
+        if (string.IsNullOrEmpty(search) || search.Count(char.IsLetterOrDigit) < 3)
         {
             return BadRequest("search parameter must be at least 3 letters.");
         }

--- a/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
+++ b/W3ChampionsStatisticService/PlayerProfiles/PlayersController.cs
@@ -52,6 +52,10 @@ public class PlayersController(
         GateWay? gateWay = null,
         GameMode? gameMode = null)
     {
+        if (string.IsNullOrEmpty(search) || search.Length < 3)
+        {
+            return BadRequest("search parameter must be at least 3 letters.");
+        }
         if (pageSize > 20) pageSize = 20;
         var players = await _playerService.GlobalSearchForPlayer(search, lastRelevanceId, pageSize, season, gateWay, gameMode);
         return Ok(players);

--- a/W3ChampionsStatisticService/Ports/IRankRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IRankRepository.cs
@@ -18,5 +18,6 @@ public interface IRankRepository
     Task<List<Season>> LoadSeasons();
     Task<List<Rank>> LoadRanksForPlayers(List<string> list, int season);
     Task<List<Rank>> LoadRanksForPlayers(List<string> list, int season, GateWay gateWay, GameMode gameMode);
+    Task<List<PlayerLadderStanding>> LoadLadderStandings(List<string> list, int season, GateWay gateWay, GameMode gameMode);
     Task<List<PlayerInfoForProxy>> SearchAllPlayersForProxy(string tagSearch);
 }

--- a/W3ChampionsStatisticService/Ports/IRankRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IRankRepository.cs
@@ -20,4 +20,6 @@ public interface IRankRepository
     Task<List<Rank>> LoadRanksForPlayers(List<string> list, int season, GateWay gateWay, GameMode gameMode);
     Task<List<PlayerLadderStanding>> LoadLadderStandings(List<string> list, int season, GateWay gateWay, GameMode gameMode);
     Task<List<PlayerInfoForProxy>> SearchAllPlayersForProxy(string tagSearch);
+    Task<List<int>> LoadRankSeasons();
+    Task<long> BackfillMemberIds(int season);
 }

--- a/W3ChampionsStatisticService/Ports/IRankRepository.cs
+++ b/W3ChampionsStatisticService/Ports/IRankRepository.cs
@@ -17,5 +17,6 @@ public interface IRankRepository
     Task UpsertSeason(Season season);
     Task<List<Season>> LoadSeasons();
     Task<List<Rank>> LoadRanksForPlayers(List<string> list, int season);
+    Task<List<Rank>> LoadRanksForPlayers(List<string> list, int season, GateWay gateWay, GameMode gameMode);
     Task<List<PlayerInfoForProxy>> SearchAllPlayersForProxy(string tagSearch);
 }

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -166,6 +166,8 @@ builder.Services.AddInterceptedSingleton<IPlayerRepository, PlayerRepository>();
 // Ensure PlayerRepository-owned PlayerGameModeStatPerGateway indexes are created at startup
 builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexes, PlayerRepository>();
 builder.Services.AddInterceptedTransient<IRankRepository, RankRepository>();
+// Ensure Rank indexes (MemberIds lookups for ranks-for-players) are created at startup
+builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexes, RankRepository>();
 builder.Services.AddInterceptedTransient<IPlayerStatsRepository, PlayerStatsRepository>();
 builder.Services.AddInterceptedTransient<IW3StatsRepo, W3StatsRepo>();
 builder.Services.AddInterceptedTransient<IPatchRepository, PatchRepository>();

--- a/W3ChampionsStatisticService/Services/PlayerService.cs
+++ b/W3ChampionsStatisticService/Services/PlayerService.cs
@@ -179,15 +179,13 @@ public class PlayerService(IPlayerRepository playerRepository, ICachedDataProvid
 
     private static bool OutranksHeld(PlayerLadderStanding candidate, PlayerLadderStanding held)
     {
-        return candidate.League != held.League
-            ? candidate.League < held.League
-            : candidate.RankNumber < held.RankNumber;
+        return candidate.RankingPoints > held.RankingPoints;
     }
 
     /// <summary>
     /// The sort key, which doubles as the pagination cursor — so it is compared as a string, and its
-    /// numeric parts are zero-padded to sort numerically. League leads rank number because RankNumber
-    /// restarts at 1 in every league.
+    /// numeric parts are zero-padded to sort numerically. Ranked entries order by ranking points, the
+    /// ladder's own global ordering (see <see cref="PlayerLadderStanding.RankingPoints"/>).
     /// </summary>
     private static string RelevanceId(
         PersonalSetting ps,
@@ -213,8 +211,16 @@ public class PlayerService(IPlayerRepository playerRepository, ICachedDataProvid
         }
 
         return ladderStanding.TryGetValue(ps.Id, out var rank)
-            ? $"0_{rank.League:D3}_{rank.RankNumber:D4}_{ps.Id}"
+            ? $"0_{InvertedRankingPoints(rank):D5}_{ps.Id}"
             : $"1_{nameRelevance}_{ps.Id}";
+    }
+
+    // The key sorts ascending as a string, so higher points must encode smaller: the complement,
+    // scaled to keep the ladder's 0.1-point precision. The clamp pins anything past the 999.99
+    // ceiling to the edge of the range; ladder points top out near 60.
+    private static int InvertedRankingPoints(PlayerLadderStanding standing)
+    {
+        return System.Math.Clamp(99999 - (int)System.Math.Round(standing.RankingPoints * 100), 0, 99999);
     }
 
     [NoTrace]

--- a/W3ChampionsStatisticService/Services/PlayerService.cs
+++ b/W3ChampionsStatisticService/Services/PlayerService.cs
@@ -5,6 +5,7 @@ using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
 using W3C.Domain.CommonValueObjects;
 using W3ChampionsStatisticService.Cache;
+using W3ChampionsStatisticService.Ladder;
 using W3ChampionsStatisticService.PersonalSettings;
 using W3ChampionsStatisticService.PlayerProfiles.GlobalSearch;
 using W3ChampionsStatisticService.PlayerProfiles.MmrRankingStats;
@@ -14,11 +15,12 @@ using W3C.Domain.Tracing;
 namespace W3ChampionsStatisticService.Services;
 
 [Trace]
-public class PlayerService(IPlayerRepository playerRepository, ICachedDataProvider<List<MmrRank>> mmrCachedDataProvider, PersonalSettingsProvider personalSettingsProvider)
+public class PlayerService(IPlayerRepository playerRepository, ICachedDataProvider<List<MmrRank>> mmrCachedDataProvider, PersonalSettingsProvider personalSettingsProvider, IRankRepository rankRepository)
 {
     private readonly ICachedDataProvider<List<MmrRank>> _mmrCachedDataProvider = mmrCachedDataProvider;
     private readonly IPlayerRepository _playerRepository = playerRepository;
     private readonly PersonalSettingsProvider _personalSettingsProvider = personalSettingsProvider;
+    private readonly IRankRepository _rankRepository = rankRepository;
 
     public async Task<float?> GetQuantileForPlayer(List<PlayerId> playerIds, GateWay gateWay, GameMode gameMode, Race? race, int season)
     {
@@ -71,10 +73,26 @@ public class PlayerService(IPlayerRepository playerRepository, ICachedDataProvid
         return result;
     }
 
+    /// <summary>
+    /// The core directory search. Relevance is a function of the search's context: pass a ladder
+    /// context (season + gateway + gameMode) and standing on that ladder becomes part of relevance,
+    /// because on a ladder a ranked player is the more relevant hit. Omit it and ordering is name
+    /// relevance alone.
+    /// </summary>
+    /// <remarks>
+    /// Context has to reach the core rather than being applied by the caller afterwards: ladder
+    /// standing is orthogonal to name relevance, so any page cut on name alone samples the ranked
+    /// players effectively at random. Measured against the 2022 dump, searching "man" on 1v1/s13/EU
+    /// surfaced 4 of its 55 ranked players in the first page of 20; ordering by standing surfaces 20,
+    /// with the rest reachable in cursor order.
+    /// </remarks>
     public async Task<List<PlayerSearchInfo>> GlobalSearchForPlayer(
         string search,
         string lastRelevanceId = "",
-        int pageSize = 20
+        int pageSize = 20,
+        int? season = null,
+        GateWay? gateWay = null,
+        GameMode? gameMode = null
     )
     {
         // Fetch entire cache
@@ -84,26 +102,17 @@ public class PlayerService(IPlayerRepository playerRepository, ICachedDataProvid
             .Where(ps => ps.Id.Contains(search, System.StringComparison.CurrentCultureIgnoreCase))
             .ToList();
 
+        var ladderStanding = await LoadLadderStanding(matchingEntries, season, gateWay, gameMode);
+
         var searchRelevance = new List<PlayerSearchRelevance>();
         foreach (var ps in matchingEntries)
         {
-            int relevance = 9;
             string matchingName = ps.Id.Split('#').ElementAtOrDefault(0);
             if (matchingName == null)
             {
                 continue;
             }
-            // Exact match
-            if (matchingName.Equals(search, System.StringComparison.CurrentCultureIgnoreCase))
-            {
-                relevance = 1;
-            }
-            // Start with
-            else if (matchingName.StartsWith(search, System.StringComparison.CurrentCultureIgnoreCase))
-            {
-                relevance = 2;
-            }
-            searchRelevance.Add(new PlayerSearchRelevance(ps, relevance));
+            searchRelevance.Add(new PlayerSearchRelevance(ps, RelevanceId(ps, matchingName, search, ladderStanding)));
         }
 
         List<PlayerSearchInfo> result = searchRelevance
@@ -128,6 +137,84 @@ public class PlayerService(IPlayerRepository playerRepository, ICachedDataProvid
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Where each match stands on the given ladder, keyed by battleTag. Null when no ladder context
+    /// was supplied; absent from the map means unranked in that context.
+    /// </summary>
+    private async Task<Dictionary<string, PlayerLadderStanding>> LoadLadderStanding(
+        List<PersonalSetting> matchingEntries,
+        int? season,
+        GateWay? gateWay,
+        GameMode? gameMode)
+    {
+        if (season == null || gateWay == null || gameMode == null || matchingEntries.Count == 0)
+        {
+            return null;
+        }
+
+        var battleTags = matchingEntries.Select(ps => ps.Id).ToList();
+        var ranks = await _rankRepository.LoadLadderStandings(battleTags, season.Value, gateWay.Value, gameMode.Value);
+
+        var standing = new Dictionary<string, PlayerLadderStanding>();
+        foreach (var rank in ranks)
+        {
+            // A team's rank stands for every one of its members, and a 1v1 player holds one rank per
+            // race they laddered. Ordering needs one position per player, so keep their best.
+            foreach (var battleTag in rank.MemberIds)
+            {
+                if (string.IsNullOrEmpty(battleTag))
+                {
+                    continue;
+                }
+                if (!standing.TryGetValue(battleTag, out var held) || OutranksHeld(rank, held))
+                {
+                    standing[battleTag] = rank;
+                }
+            }
+        }
+        return standing;
+    }
+
+    private static bool OutranksHeld(PlayerLadderStanding candidate, PlayerLadderStanding held)
+    {
+        return candidate.League != held.League
+            ? candidate.League < held.League
+            : candidate.RankNumber < held.RankNumber;
+    }
+
+    /// <summary>
+    /// The sort key, which doubles as the pagination cursor — so it is compared as a string, and its
+    /// numeric parts are zero-padded to sort numerically. League leads rank number because RankNumber
+    /// restarts at 1 in every league.
+    /// </summary>
+    private static string RelevanceId(
+        PersonalSetting ps,
+        string matchingName,
+        string search,
+        Dictionary<string, PlayerLadderStanding> ladderStanding)
+    {
+        int nameRelevance = 9;
+        // Exact match
+        if (matchingName.Equals(search, System.StringComparison.CurrentCultureIgnoreCase))
+        {
+            nameRelevance = 1;
+        }
+        // Start with
+        else if (matchingName.StartsWith(search, System.StringComparison.CurrentCultureIgnoreCase))
+        {
+            nameRelevance = 2;
+        }
+
+        if (ladderStanding == null)
+        {
+            return $"{nameRelevance}_{ps.Id}";
+        }
+
+        return ladderStanding.TryGetValue(ps.Id, out var rank)
+            ? $"0_{rank.League:D3}_{rank.RankNumber:D4}_{ps.Id}"
+            : $"1_{nameRelevance}_{ps.Id}";
     }
 
     [NoTrace]

--- a/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/FakeAdminJobContext.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/Jobs/FakeAdminJobContext.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using W3ChampionsStatisticService.Admin.Jobs;
+
+namespace WC3ChampionsStatisticService.Tests.Admin.Jobs;
+
+/// <summary>
+/// A context for testing a job body in isolation from the runner: records every report and
+/// item count, paces without pausing, and hands the job the checkpoint the test supplies.
+/// </summary>
+public class FakeAdminJobContext(BsonDocument checkpoint = null) : IAdminJobContext
+{
+    public BsonDocument Checkpoint { get; } = checkpoint;
+
+    public long ItemsProcessed { get; private set; }
+
+    public List<(long Current, long Total, string Message)> Reports { get; } = [];
+
+    /// <summary>The most recent checkpoint the job reported.</summary>
+    public BsonDocument LastCheckpoint { get; private set; }
+
+    public int Paces { get; private set; }
+
+    public Task Report(long current, long total, string message = null, BsonDocument checkpoint = null)
+    {
+        Reports.Add((current, total, message));
+        LastCheckpoint = checkpoint ?? LastCheckpoint;
+        return Task.CompletedTask;
+    }
+
+    public void AddItems(long count) => ItemsProcessed += count;
+
+    public Task Pace(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Paces++;
+        return Task.CompletedTask;
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Player/PlayerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Player/PlayerTests.cs
@@ -81,7 +81,7 @@ public class PlayerTests : IntegrationTestBase
     {
         var playerRepository = new PlayerRepository(MongoClient);
         var personalSettingsRepository = new PersonalSettingsRepository(MongoClient);
-        var playerService = new PlayerService(playerRepository, CreateTestCache<List<MmrRank>>(), personalSettingsProvider);
+        var playerService = new PlayerService(playerRepository, CreateTestCache<List<MmrRank>>(), personalSettingsProvider, new RankRepository(MongoClient, personalSettingsProvider));
 
         var player1 = new PersonalSetting("ThunderHorn#2481");
         var playerStats = PlayerOverallStats.Create("ThunderHorn#2481");
@@ -545,7 +545,7 @@ public class PlayerTests : IntegrationTestBase
     {
         // Arrange
         var playerRepository = new PlayerRepository(MongoClient);
-        var playerService = new PlayerService(playerRepository, CreateTestCache<List<MmrRank>>(), personalSettingsProvider);
+        var playerService = new PlayerService(playerRepository, CreateTestCache<List<MmrRank>>(), personalSettingsProvider, new RankRepository(MongoClient, personalSettingsProvider));
 
         // Setup test data - 3 players with different MMRs
         var testPlayers = new[]

--- a/WC3ChampionsStatisticService.UnitTests/Ranks/RankMemberIdsBackfillJobTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ranks/RankMemberIdsBackfillJobTests.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsStatisticService.Ladder;
+using W3ChampionsStatisticService.Ports;
+using WC3ChampionsStatisticService.Tests.Admin.Jobs;
+
+namespace WC3ChampionsStatisticService.Tests.Ranks;
+
+[TestFixture]
+public class RankMemberIdsBackfillJobTests
+{
+    [Test]
+    public async Task RunAsync_BackfillsEverySeason_AndCheckpointsTheLast()
+    {
+        var repository = new Mock<IRankRepository>();
+        repository.Setup(r => r.LoadRankSeasons()).ReturnsAsync(new List<int> { 12, 13 });
+        repository.Setup(r => r.BackfillMemberIds(12)).ReturnsAsync(3);
+        repository.Setup(r => r.BackfillMemberIds(13)).ReturnsAsync(2);
+        var context = new FakeAdminJobContext();
+
+        await new RankMemberIdsBackfillJob(repository.Object).RunAsync(context, CancellationToken.None);
+
+        repository.Verify(r => r.BackfillMemberIds(12), Times.Once);
+        repository.Verify(r => r.BackfillMemberIds(13), Times.Once);
+        Assert.AreEqual(5, context.ItemsProcessed);
+        Assert.AreEqual(2, context.Reports[^1].Current);
+        Assert.AreEqual(2, context.Reports[^1].Total);
+        Assert.AreEqual(13, context.LastCheckpoint["LastCompletedSeason"].AsInt32);
+        // Paced after every season, so cancellation and back-pressure reach the job between batches
+        Assert.AreEqual(2, context.Paces);
+    }
+
+    [Test]
+    public async Task RunAsync_ResumesPastTheCheckpointedSeasons()
+    {
+        var repository = new Mock<IRankRepository>();
+        repository.Setup(r => r.LoadRankSeasons()).ReturnsAsync(new List<int> { 12, 13 });
+        repository.Setup(r => r.BackfillMemberIds(13)).ReturnsAsync(2);
+        var context = new FakeAdminJobContext(new BsonDocument("LastCompletedSeason", 12));
+
+        await new RankMemberIdsBackfillJob(repository.Object).RunAsync(context, CancellationToken.None);
+
+        // Seasons at or below the checkpoint stay done — a filled row never loses the field
+        repository.Verify(r => r.BackfillMemberIds(12), Times.Never);
+        repository.Verify(r => r.BackfillMemberIds(13), Times.Once);
+        // The skipped season still counts as done, so progress reads 2/2 rather than restarting
+        Assert.AreEqual(2, context.Reports[^1].Current);
+        Assert.AreEqual(2, context.Reports[^1].Total);
+    }
+
+    [Test]
+    public async Task RunAsync_WithNothingPastTheCheckpoint_DoesNoWork()
+    {
+        var repository = new Mock<IRankRepository>();
+        repository.Setup(r => r.LoadRankSeasons()).ReturnsAsync(new List<int> { 12, 13 });
+        var context = new FakeAdminJobContext(new BsonDocument("LastCompletedSeason", 13));
+
+        await new RankMemberIdsBackfillJob(repository.Object).RunAsync(context, CancellationToken.None);
+
+        repository.Verify(r => r.BackfillMemberIds(It.IsAny<int>()), Times.Never);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Ranks/RankMemberIdsBackfillJobTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ranks/RankMemberIdsBackfillJobTests.cs
@@ -29,6 +29,8 @@ public class RankMemberIdsBackfillJobTests
         Assert.AreEqual(5, context.ItemsProcessed);
         Assert.AreEqual(2, context.Reports[^1].Current);
         Assert.AreEqual(2, context.Reports[^1].Total);
+        // The resting message summarises the run rather than naming the last season
+        Assert.AreEqual("2 season(s) done, 5 row(s) filled", context.Reports[^1].Message);
         Assert.AreEqual(13, context.LastCheckpoint["LastCompletedSeason"].AsInt32);
         // Paced after every season, so cancellation and back-pressure reach the job between batches
         Assert.AreEqual(2, context.Paces);

--- a/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
@@ -475,13 +475,11 @@ public class RankTests : IntegrationTestBase
 
         // Assert
         Assert.AreEqual(1, soloStandings.Count);
-        Assert.AreEqual(1, soloStandings[0].League);
-        Assert.AreEqual(5, soloStandings[0].RankNumber);
+        Assert.AreEqual(100, soloStandings[0].RankingPoints);
         CollectionAssert.AreEqual(new[] { "solo#123" }, soloStandings[0].MemberIds);
 
         Assert.AreEqual(1, teamStandings.Count);
-        Assert.AreEqual(2, teamStandings[0].League);
-        Assert.AreEqual(7, teamStandings[0].RankNumber);
+        Assert.AreEqual(90, teamStandings[0].RankingPoints);
         CollectionAssert.AreEqual(new[] { "first#456", "second#789" }, teamStandings[0].MemberIds);
     }
 
@@ -491,11 +489,12 @@ public class RankTests : IntegrationTestBase
         var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
         var playerRepository = new PlayerRepository(MongoClient);
 
-        // The same player ranked on three more ladders, each differing in exactly one dimension
+        // The same player ranked on three more ladders, each differing in exactly one dimension;
+        // distinct ranking points prove which ladder the standing came from.
         var asked = new Rank(new List<string> { "peter#123" }, 1, 5, 100, null, GateWay.Europe, GameMode.GM_1v1, 13);
-        var otherSeason = new Rank(new List<string> { "peter#123" }, 2, 9, 100, null, GateWay.Europe, GameMode.GM_1v1, 12);
-        var otherGateway = new Rank(new List<string> { "peter#123" }, 3, 9, 100, null, GateWay.America, GameMode.GM_1v1, 13);
-        var otherMode = new Rank(new List<string> { "peter#123" }, 4, 9, 100, null, GateWay.Europe, GameMode.GM_2v2_AT, 13);
+        var otherSeason = new Rank(new List<string> { "peter#123" }, 2, 9, 90, null, GateWay.Europe, GameMode.GM_1v1, 12);
+        var otherGateway = new Rank(new List<string> { "peter#123" }, 3, 9, 80, null, GateWay.America, GameMode.GM_1v1, 13);
+        var otherMode = new Rank(new List<string> { "peter#123" }, 4, 9, 70, null, GateWay.Europe, GameMode.GM_2v2_AT, 13);
         await rankRepository.InsertRanks(new List<Rank> { asked, otherSeason, otherGateway, otherMode });
 
         await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(new List<PlayerId> { PlayerId.Create("peter#123") }, GateWay.Europe, GameMode.GM_1v1, 13, null));
@@ -508,8 +507,7 @@ public class RankTests : IntegrationTestBase
 
         // Assert
         Assert.AreEqual(1, standings.Count);
-        Assert.AreEqual(1, standings[0].League);
-        Assert.AreEqual(5, standings[0].RankNumber);
+        Assert.AreEqual(100, standings[0].RankingPoints);
     }
 
     [Test]
@@ -530,7 +528,8 @@ public class RankTests : IntegrationTestBase
 
         // Assert
         Assert.AreEqual(1, standings.Count);
-        CollectionAssert.AreEqual(new[] { "kept#123" }, standings[0].MemberIds);    }
+        CollectionAssert.AreEqual(new[] { "kept#123" }, standings[0].MemberIds);
+    }
 
     [Test]
     public async Task LoadRanksForPlayers_WithContext_DropsRanksWithoutPlayerOverview()
@@ -600,4 +599,5 @@ public class RankTests : IntegrationTestBase
         var stored = await ranksCollection.Find(FilterDefinition<Rank>.Empty).FirstAsync();
         CollectionAssert.AreEqual(new[] { "aaa#1", "bbb#2" }, stored.MemberIds);
     }
+
 }

--- a/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
@@ -600,4 +600,92 @@ public class RankTests : IntegrationTestBase
         CollectionAssert.AreEqual(new[] { "aaa#1", "bbb#2" }, stored.MemberIds);
     }
 
+    [Test]
+    public async Task LoadRanksForPlayers_FindsRowsTheBackfillHasNotReached()
+    {
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+
+        var team = new List<string> { "aaa#1", "bbb#2" };
+        var rank = new Rank(team, 1, 5, 100, null, GateWay.Europe, GameMode.GM_2v2_AT, 13);
+        await rankRepository.InsertRanks(new List<Rank> { rank });
+        await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(team.Select(PlayerId.Create).ToList(), GateWay.Europe, GameMode.GM_2v2_AT, 13, null));
+
+        var ranksCollection = MongoClient.GetDatabase("W3Champions-Statistic-Service").GetCollection<Rank>(nameof(Rank));
+        await ranksCollection.UpdateManyAsync(FilterDefinition<Rank>.Empty, Builders<Rank>.Update.Unset(r => r.MemberIds));
+
+        // Act — deliberately NO EnsureIndexesAsync: clan and chat sit in front of no rollback flag,
+        // so the query itself must keep finding rows the backfill has not reached
+        var ranks = await rankRepository.LoadRanksForPlayers(new List<string> { "bbb#2" }, 13);
+
+        // Assert
+        Assert.AreEqual(1, ranks.Count);
+        Assert.AreEqual("aaa#1", ranks[0].Player1Id);
+    }
+
+    [Test]
+    public async Task LoadRanksForPlayers_SeasonOnly_FindsMembersBeyondTheSecond()
+    {
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+
+        var team = new List<string> { "aaa#1", "bbb#2", "ccc#3" };
+        var rank = new Rank(team, 1, 5, 100, null, GateWay.Europe, GameMode.GM_4v4_AT, 13);
+        await rankRepository.InsertRanks(new List<Rank> { rank });
+        await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(team.Select(PlayerId.Create).ToList(), GateWay.Europe, GameMode.GM_4v4_AT, 13, null));
+
+        // Act — clan and chat resolve members through this overload, and the third member must
+        // reach the team the two stored fields cannot name
+        var ranks = await rankRepository.LoadRanksForPlayers(new List<string> { "ccc#3" }, 13);
+
+        // Assert
+        Assert.AreEqual(1, ranks.Count);
+        CollectionAssert.AreEqual(team, ranks[0].MemberIds);
+    }
+
+    [Test]
+    public async Task LoadPlayersOfCountry_FindsMembersBeyondTheSecond()
+    {
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+        var personalSettingsRepository = new PersonalSettingsRepository(MongoClient);
+
+        var team = new List<string> { "aaa#1", "bbb#2", "ccc#3" };
+        var rank = new Rank(team, 1, 5, 100, null, GateWay.Europe, GameMode.GM_4v4_AT, 13);
+        await rankRepository.InsertRanks(new List<Rank> { rank });
+        await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(team.Select(PlayerId.Create).ToList(), GateWay.Europe, GameMode.GM_4v4_AT, 13, null));
+        await personalSettingsRepository.Save(new PersonalSetting("ccc#3") { CountryCode = "NL" });
+
+        // Act
+        var ranks = await rankRepository.LoadPlayersOfCountry("NL", 13, GateWay.Europe, GameMode.GM_4v4_AT);
+
+        // Assert — the third member's country page shows their team
+        Assert.AreEqual(1, ranks.Count);
+        CollectionAssert.AreEqual(team, ranks[0].MemberIds);
+    }
+
+    [Test]
+    public async Task LoadPlayersOfCountry_FindsRowsTheBackfillHasNotReached()
+    {
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+        var personalSettingsRepository = new PersonalSettingsRepository(MongoClient);
+
+        var team = new List<string> { "aaa#1", "bbb#2" };
+        var rank = new Rank(team, 1, 5, 100, null, GateWay.Europe, GameMode.GM_2v2_AT, 13);
+        await rankRepository.InsertRanks(new List<Rank> { rank });
+        await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(team.Select(PlayerId.Create).ToList(), GateWay.Europe, GameMode.GM_2v2_AT, 13, null));
+        await personalSettingsRepository.Save(new PersonalSetting("bbb#2") { CountryCode = "NL" });
+
+        var ranksCollection = MongoClient.GetDatabase("W3Champions-Statistic-Service").GetCollection<Rank>(nameof(Rank));
+        await ranksCollection.UpdateManyAsync(FilterDefinition<Rank>.Empty, Builders<Rank>.Update.Unset(r => r.MemberIds));
+
+        // Act — deliberately NO EnsureIndexesAsync: the country page sits in front of no rollback
+        // flag, so its two-field fallback must keep finding rows the backfill has not reached
+        var ranks = await rankRepository.LoadPlayersOfCountry("NL", 13, GateWay.Europe, GameMode.GM_2v2_AT);
+
+        // Assert
+        Assert.AreEqual(1, ranks.Count);
+        Assert.AreEqual("aaa#1", ranks[0].Player1Id);
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
@@ -452,6 +452,136 @@ public class RankTests : IntegrationTestBase
         // Assert
         Assert.AreEqual(2, playerLoaded2.Count);
     }
+
+    [Test]
+    public async Task LoadLadderStandings_ReturnsPositions_MatchingEitherTeamMember()
+    {
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+
+        var soloRank = new Rank(new List<string> { "solo#123" }, 1, 5, 100, null, GateWay.Europe, GameMode.GM_1v1, 13);
+        var teamRank = new Rank(new List<string> { "first#456", "second#789" }, 2, 7, 90, null, GateWay.Europe, GameMode.GM_2v2_AT, 13);
+        await rankRepository.InsertRanks(new List<Rank> { soloRank, teamRank });
+
+        var solo = PlayerOverview.Create(new List<PlayerId> { PlayerId.Create("solo#123") }, GateWay.Europe, GameMode.GM_1v1, 13, null);
+        var team = PlayerOverview.Create(new List<PlayerId> { PlayerId.Create("first#456"), PlayerId.Create("second#789") }, GateWay.Europe, GameMode.GM_2v2_AT, 13, null);
+        await playerRepository.UpsertPlayerOverview(solo);
+        await playerRepository.UpsertPlayerOverview(team);
+
+        // Act
+        var soloStandings = await rankRepository.LoadLadderStandings(new List<string> { "solo#123" }, 13, GateWay.Europe, GameMode.GM_1v1);
+        // second#789 is the team's second member — a standing must be found through any member
+        var teamStandings = await rankRepository.LoadLadderStandings(new List<string> { "second#789" }, 13, GateWay.Europe, GameMode.GM_2v2_AT);
+
+        // Assert
+        Assert.AreEqual(1, soloStandings.Count);
+        Assert.AreEqual(1, soloStandings[0].League);
+        Assert.AreEqual(5, soloStandings[0].RankNumber);
+        CollectionAssert.AreEqual(new[] { "solo#123" }, soloStandings[0].MemberIds);
+
+        Assert.AreEqual(1, teamStandings.Count);
+        Assert.AreEqual(2, teamStandings[0].League);
+        Assert.AreEqual(7, teamStandings[0].RankNumber);
+        CollectionAssert.AreEqual(new[] { "first#456", "second#789" }, teamStandings[0].MemberIds);
+    }
+
+    [Test]
+    public async Task LoadLadderStandings_ScopesToTheLadderAskedFor()
+    {
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+
+        // The same player ranked on three more ladders, each differing in exactly one dimension
+        var asked = new Rank(new List<string> { "peter#123" }, 1, 5, 100, null, GateWay.Europe, GameMode.GM_1v1, 13);
+        var otherSeason = new Rank(new List<string> { "peter#123" }, 2, 9, 100, null, GateWay.Europe, GameMode.GM_1v1, 12);
+        var otherGateway = new Rank(new List<string> { "peter#123" }, 3, 9, 100, null, GateWay.America, GameMode.GM_1v1, 13);
+        var otherMode = new Rank(new List<string> { "peter#123" }, 4, 9, 100, null, GateWay.Europe, GameMode.GM_2v2_AT, 13);
+        await rankRepository.InsertRanks(new List<Rank> { asked, otherSeason, otherGateway, otherMode });
+
+        await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(new List<PlayerId> { PlayerId.Create("peter#123") }, GateWay.Europe, GameMode.GM_1v1, 13, null));
+        await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(new List<PlayerId> { PlayerId.Create("peter#123") }, GateWay.Europe, GameMode.GM_1v1, 12, null));
+        await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(new List<PlayerId> { PlayerId.Create("peter#123") }, GateWay.America, GameMode.GM_1v1, 13, null));
+        await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(new List<PlayerId> { PlayerId.Create("peter#123") }, GateWay.Europe, GameMode.GM_2v2_AT, 13, null));
+
+        // Act
+        var standings = await rankRepository.LoadLadderStandings(new List<string> { "peter#123" }, 13, GateWay.Europe, GameMode.GM_1v1);
+
+        // Assert
+        Assert.AreEqual(1, standings.Count);
+        Assert.AreEqual(1, standings[0].League);
+        Assert.AreEqual(5, standings[0].RankNumber);
+    }
+
+    [Test]
+    public async Task LoadLadderStandings_DropsRanksWithoutPlayerOverview()
+    {
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+
+        var joined = new Rank(new List<string> { "kept#123" }, 1, 5, 100, null, GateWay.Europe, GameMode.GM_1v1, 13);
+        var orphan = new Rank(new List<string> { "orphan#456" }, 1, 6, 90, null, GateWay.Europe, GameMode.GM_1v1, 13);
+        await rankRepository.InsertRanks(new List<Rank> { joined, orphan });
+        // Only kept#123 gets a PlayerOverview — the orphan rank must be dropped, keeping this
+        // method in agreement with LoadRanksForPlayers about who counts as ranked
+        await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(new List<PlayerId> { PlayerId.Create("kept#123") }, GateWay.Europe, GameMode.GM_1v1, 13, null));
+
+        // Act
+        var standings = await rankRepository.LoadLadderStandings(new List<string> { "kept#123", "orphan#456" }, 13, GateWay.Europe, GameMode.GM_1v1);
+
+        // Assert
+        Assert.AreEqual(1, standings.Count);
+        CollectionAssert.AreEqual(new[] { "kept#123" }, standings[0].MemberIds);    }
+
+    [Test]
+    public async Task LoadRanksForPlayers_WithContext_DropsRanksWithoutPlayerOverview()
+    {
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+
+        var joined = new Rank(new List<string> { "kept#123" }, 1, 5, 100, null, GateWay.Europe, GameMode.GM_1v1, 13);
+        var orphan = new Rank(new List<string> { "orphan#456" }, 1, 6, 90, null, GateWay.Europe, GameMode.GM_1v1, 13);
+        await rankRepository.InsertRanks(new List<Rank> { joined, orphan });
+        // Only kept#123 gets a PlayerOverview — the display half of the agreement the test above
+        // pins for the ordering half. Both calls must drop the orphan, or the search would order a
+        // player its enrichment then reports as unranked.
+        await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(new List<PlayerId> { PlayerId.Create("kept#123") }, GateWay.Europe, GameMode.GM_1v1, 13, null));
+
+        // Act
+        var ranks = await rankRepository.LoadRanksForPlayers(new List<string> { "kept#123", "orphan#456" }, 13, GateWay.Europe, GameMode.GM_1v1);
+
+        // Assert
+        Assert.AreEqual(1, ranks.Count);
+        Assert.AreEqual("kept#123", ranks[0].Player1Id);
+    }
+
+    [Test]
+    public async Task EnsureIndexes_BackfillsMemberIdsFromThePlayerOverview()
+    {
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+        var playerRepository = new PlayerRepository(MongoClient);
+
+        // A three-player team: the member the two stored fields cannot hold is what the backfill
+        // must recover, and only the PlayerOverview still knows them.
+        var team = new List<string> { "aaa#1", "bbb#2", "ccc#3" };
+        var rank = new Rank(team, 1, 5, 100, null, GateWay.Europe, GameMode.GM_4v4_AT, 13);
+        await rankRepository.InsertRanks(new List<Rank> { rank });
+        await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(team.Select(PlayerId.Create).ToList(), GateWay.Europe, GameMode.GM_4v4_AT, 13, null));
+
+        // Strip the field to the shape of rows written before it existed
+        var ranksCollection = MongoClient.GetDatabase("W3Champions-Statistic-Service").GetCollection<Rank>(nameof(Rank));
+        await ranksCollection.UpdateManyAsync(FilterDefinition<Rank>.Empty, Builders<Rank>.Update.Unset(r => r.MemberIds));
+
+        // Act — twice: the second run must find nothing left to fill and change nothing
+        await rankRepository.EnsureIndexesAsync();
+        await rankRepository.EnsureIndexesAsync();
+
+        var standings = await rankRepository.LoadLadderStandings(new List<string> { "ccc#3" }, 13, GateWay.Europe, GameMode.GM_4v4_AT);
+
+        // Assert — the third member finds the team again
+        Assert.AreEqual(1, standings.Count);
+        CollectionAssert.AreEqual(team, standings[0].MemberIds);
+    }
+
     [Test]
     public async Task EnsureIndexes_BackfillFallsBackToTheStoredMembers_WhenTheOverviewIsMissing()
     {

--- a/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
@@ -1,3 +1,4 @@
+using MongoDB.Bson;
 using MongoDB.Driver;
 using Moq;
 using NUnit.Framework;
@@ -554,50 +555,79 @@ public class RankTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task EnsureIndexes_BackfillsMemberIdsFromThePlayerOverview()
+    public async Task BackfillMemberIds_FillsFromThePlayerOverview()
     {
         var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
         var playerRepository = new PlayerRepository(MongoClient);
 
         // A three-player team: the member the two stored fields cannot hold is what the backfill
         // must recover, and only the PlayerOverview still knows them.
+        const int season = 13;
         var team = new List<string> { "aaa#1", "bbb#2", "ccc#3" };
-        var rank = new Rank(team, 1, 5, 100, null, GateWay.Europe, GameMode.GM_4v4_AT, 13);
+        var rank = new Rank(team, 1, 5, 100, null, GateWay.Europe, GameMode.GM_4v4_AT, season);
         await rankRepository.InsertRanks(new List<Rank> { rank });
-        await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(team.Select(PlayerId.Create).ToList(), GateWay.Europe, GameMode.GM_4v4_AT, 13, null));
+        await playerRepository.UpsertPlayerOverview(PlayerOverview.Create(team.Select(PlayerId.Create).ToList(), GateWay.Europe, GameMode.GM_4v4_AT, season, null));
 
         // Strip the field to the shape of rows written before it existed
         var ranksCollection = MongoClient.GetDatabase("W3Champions-Statistic-Service").GetCollection<Rank>(nameof(Rank));
         await ranksCollection.UpdateManyAsync(FilterDefinition<Rank>.Empty, Builders<Rank>.Update.Unset(r => r.MemberIds));
 
         // Act — twice: the second run must find nothing left to fill and change nothing
-        await rankRepository.EnsureIndexesAsync();
-        await rankRepository.EnsureIndexesAsync();
+        var filled = await rankRepository.BackfillMemberIds(season);
+        var refilled = await rankRepository.BackfillMemberIds(season);
 
-        var standings = await rankRepository.LoadLadderStandings(new List<string> { "ccc#3" }, 13, GateWay.Europe, GameMode.GM_4v4_AT);
+        var standings = await rankRepository.LoadLadderStandings(new List<string> { "ccc#3" }, season, GateWay.Europe, GameMode.GM_4v4_AT);
 
-        // Assert — the third member finds the team again
+        // Assert — the third member finds the team again, and the redo found nothing left
+        Assert.AreEqual(1, filled);
+        Assert.AreEqual(0, refilled);
         Assert.AreEqual(1, standings.Count);
         CollectionAssert.AreEqual(team, standings[0].MemberIds);
     }
 
     [Test]
-    public async Task EnsureIndexes_BackfillFallsBackToTheStoredMembers_WhenTheOverviewIsMissing()
+    public async Task BackfillMemberIds_FallsBackToTheStoredMembers_WhenTheOverviewIsMissing()
     {
         var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
 
-        var rank = new Rank(new List<string> { "aaa#1", "bbb#2" }, 1, 5, 100, null, GateWay.Europe, GameMode.GM_2v2_AT, 13);
+        const int season = 13;
+        var rank = new Rank(new List<string> { "aaa#1", "bbb#2" }, 1, 5, 100, null, GateWay.Europe, GameMode.GM_2v2_AT, season);
         await rankRepository.InsertRanks(new List<Rank> { rank });
 
         var ranksCollection = MongoClient.GetDatabase("W3Champions-Statistic-Service").GetCollection<Rank>(nameof(Rank));
         await ranksCollection.UpdateManyAsync(FilterDefinition<Rank>.Empty, Builders<Rank>.Update.Unset(r => r.MemberIds));
 
         // Act — no PlayerOverview exists, so the backfill only has Player1Id/Player2Id to go on
-        await rankRepository.EnsureIndexesAsync();
+        await rankRepository.BackfillMemberIds(season);
 
         // Assert on the stored document: an orphan rank is invisible to the joined queries either way
         var stored = await ranksCollection.Find(FilterDefinition<Rank>.Empty).FirstAsync();
         CollectionAssert.AreEqual(new[] { "aaa#1", "bbb#2" }, stored.MemberIds);
+    }
+
+    [Test]
+    public async Task BackfillMemberIds_TouchesOnlyTheRequestedSeason()
+    {
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+
+        const int season = 13;
+        const int otherSeason = 12;
+        var thisSeasonRank = new Rank(new List<string> { "aaa#1", "bbb#2" }, 1, 5, 100, null, GateWay.Europe, GameMode.GM_2v2_AT, season);
+        var otherSeasonRank = new Rank(new List<string> { "ccc#3", "ddd#4" }, 1, 5, 100, null, GateWay.Europe, GameMode.GM_2v2_AT, otherSeason);
+        await rankRepository.InsertRanks(new List<Rank> { thisSeasonRank, otherSeasonRank });
+
+        var ranksCollection = MongoClient.GetDatabase("W3Champions-Statistic-Service").GetCollection<Rank>(nameof(Rank));
+        await ranksCollection.UpdateManyAsync(FilterDefinition<Rank>.Empty, Builders<Rank>.Update.Unset(r => r.MemberIds));
+
+        // Act — a season is one batch; the other season is the next batch's work, not this one's
+        var filled = await rankRepository.BackfillMemberIds(season);
+
+        // Assert — on the raw document: an absent field deserializes to the model's empty-list
+        // initializer, which a filled-but-empty row would also show
+        Assert.AreEqual(1, filled);
+        var rawRanks = MongoClient.GetDatabase("W3Champions-Statistic-Service").GetCollection<BsonDocument>(nameof(Rank));
+        var untouched = await rawRanks.Find(new BsonDocument("Season", otherSeason)).FirstAsync();
+        Assert.IsFalse(untouched.Contains("MemberIds"));
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Ranks/RankTests.cs
@@ -1,3 +1,4 @@
+using MongoDB.Driver;
 using Moq;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -450,5 +451,23 @@ public class RankTests : IntegrationTestBase
 
         // Assert
         Assert.AreEqual(2, playerLoaded2.Count);
+    }
+    [Test]
+    public async Task EnsureIndexes_BackfillFallsBackToTheStoredMembers_WhenTheOverviewIsMissing()
+    {
+        var rankRepository = new RankRepository(MongoClient, personalSettingsProvider);
+
+        var rank = new Rank(new List<string> { "aaa#1", "bbb#2" }, 1, 5, 100, null, GateWay.Europe, GameMode.GM_2v2_AT, 13);
+        await rankRepository.InsertRanks(new List<Rank> { rank });
+
+        var ranksCollection = MongoClient.GetDatabase("W3Champions-Statistic-Service").GetCollection<Rank>(nameof(Rank));
+        await ranksCollection.UpdateManyAsync(FilterDefinition<Rank>.Empty, Builders<Rank>.Update.Unset(r => r.MemberIds));
+
+        // Act — no PlayerOverview exists, so the backfill only has Player1Id/Player2Id to go on
+        await rankRepository.EnsureIndexesAsync();
+
+        // Assert on the stored document: an orphan rank is invisible to the joined queries either way
+        var stored = await ranksCollection.Find(FilterDefinition<Rank>.Empty).FirstAsync();
+        CollectionAssert.AreEqual(new[] { "aaa#1", "bbb#2" }, stored.MemberIds);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Search/GlobalSearchControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Search/GlobalSearchControllerTests.cs
@@ -94,4 +94,35 @@ public class GlobalSearchControllerTests
 
         Assert.AreEqual(PageSizeCap, ResultOf(result).Count);
     }
+
+    // Zero-weight characters are found inside every string by culture-sensitive matching, so a term
+    // made of them measures three long and matches the whole directory. Counting letters and digits
+    // is what keeps the guard's promise.
+    [TestCase("​​​", Description = "zero-width spaces")]
+    [TestCase("­­­", Description = "soft hyphens")]
+    [TestCase("﻿﻿﻿", Description = "byte-order marks")]
+    [TestCase("m​​o", Description = "two letters padded to four characters")]
+    public async Task MinLength_TermsWithoutThreeSearchableCharactersAreRejected(string search)
+    {
+        var result = await CreateController(50).GlobalSearchPlayer(search);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
+
+    [Test]
+    public async Task MinLength_NonLatinLettersCount()
+    {
+        // BattleTags carry Cyrillic, CJK and accented names; those letters are searchable characters.
+        var result = await CreateController(50).GlobalSearchPlayer("Гоб");
+
+        Assert.IsInstanceOf<OkObjectResult>(result);
+    }
+
+    [Test]
+    public async Task MinLength_DigitsCount()
+    {
+        var result = await CreateController(50).GlobalSearchPlayer("123");
+
+        Assert.IsInstanceOf<OkObjectResult>(result);
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Search/GlobalSearchControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Search/GlobalSearchControllerTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
+using W3C.Contracts.Matchmaking;
 using W3ChampionsStatisticService.PlayerProfiles;
 using W3ChampionsStatisticService.PlayerProfiles.GlobalSearch;
 using static WC3ChampionsStatisticService.UnitTests.Search.SearchTestFixtures;
@@ -122,6 +123,39 @@ public class GlobalSearchControllerTests
     public async Task MinLength_DigitsCount()
     {
         var result = await CreateController(50).GlobalSearchPlayer("123");
+
+        Assert.IsInstanceOf<OkObjectResult>(result);
+    }
+
+    // The three ladder-context parameters travel together. A partial context used to be dropped in
+    // silence, which also switched the relevanceId's layout — so a caller paging across the change
+    // compared cursors from two different key namespaces and got an empty page with no error.
+    [TestCase(13, GateWay.Europe, null)]
+    [TestCase(13, null, GameMode.GM_1v1)]
+    [TestCase(null, GateWay.Europe, GameMode.GM_1v1)]
+    [TestCase(13, null, null)]
+    [TestCase(null, null, GameMode.GM_1v1)]
+    public async Task Context_PartialLadderContextIsRejected(int? season, GateWay? gateWay, GameMode? gameMode)
+    {
+        var result = await CreateController(50).GlobalSearchPlayer("moo", "", 20, season, gateWay, gameMode);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
+
+    [Test]
+    public async Task Context_TheFullLadderContextIsServed()
+    {
+        var result = await CreateController(50).GlobalSearchPlayer("moo", "", 20, 13, GateWay.Europe, GameMode.GM_1v1);
+
+        Assert.IsInstanceOf<OkObjectResult>(result);
+    }
+
+    [Test]
+    public async Task Context_OmittingItEntirelyIsServed()
+    {
+        // The header, the player picker and launcher-e all search without a ladder; launcher-e never
+        // sends these parameters at all, so no context must stay as valid as a full one.
+        var result = await CreateController(50).GlobalSearchPlayer("moo");
 
         Assert.IsInstanceOf<OkObjectResult>(result);
     }

--- a/WC3ChampionsStatisticService.UnitTests/Search/GlobalSearchControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Search/GlobalSearchControllerTests.cs
@@ -12,7 +12,9 @@ namespace WC3ChampionsStatisticService.UnitTests.Search;
 // GET api/players/global-search at the controller boundary.
 //
 // GlobalSearchTests covers the search itself; this covers what only the controller does — clamping
-// pageSize. The cap is the guard that stops an anonymous caller from pulling the directory in bulk.
+// pageSize and rejecting short searches. Together they guard the anonymous route: the cap stops
+// pulling the directory in bulk, the minimum length stops near-empty terms from matching most of it
+// (with a ladder context, every match feeds the standings $in query).
 [TestFixture]
 public class GlobalSearchControllerTests
 {
@@ -70,5 +72,26 @@ public class GlobalSearchControllerTests
         var result = await CreateController(3).GlobalSearchPlayer("moon");
 
         Assert.AreEqual(3, ResultOf(result).Count);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("m")]
+    [TestCase("mo")]
+    public async Task MinLength_SearchesUnderThreeLettersAreRejected(string search)
+    {
+        var result = await CreateController(50).GlobalSearchPlayer(search);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
+
+    [Test]
+    public async Task MinLength_ThreeLettersAreServed()
+    {
+        // Every known client gates its input at exactly three characters (website surfaces and
+        // launcher-e alike), so three letters must stay served — the guard must never creep higher.
+        var result = await CreateController(50).GlobalSearchPlayer("moo");
+
+        Assert.AreEqual(PageSizeCap, ResultOf(result).Count);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Search/GlobalSearchControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Search/GlobalSearchControllerTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+using W3ChampionsStatisticService.PlayerProfiles;
+using W3ChampionsStatisticService.PlayerProfiles.GlobalSearch;
+using static WC3ChampionsStatisticService.UnitTests.Search.SearchTestFixtures;
+
+namespace WC3ChampionsStatisticService.UnitTests.Search;
+
+// GET api/players/global-search at the controller boundary.
+//
+// GlobalSearchTests covers the search itself; this covers what only the controller does — clamping
+// pageSize. The cap is the guard that stops an anonymous caller from pulling the directory in bulk.
+[TestFixture]
+public class GlobalSearchControllerTests
+{
+    private const int PageSizeCap = 20;
+
+    private PlayersController CreateController(int directorySize)
+    {
+        var directory = Settings(
+            Enumerable.Range(1, directorySize).Select(i => $"Moon{i:000}#{i}").ToArray());
+
+        return PlayersControllerWith(playerService: PlayerServiceWith(directory));
+    }
+
+    private static List<PlayerSearchInfo> ResultOf(IActionResult result)
+    {
+        return (List<PlayerSearchInfo>)((OkObjectResult)result).Value;
+    }
+
+    [Test]
+    public async Task PageSize_DefaultsToTheCap()
+    {
+        var result = await CreateController(50).GlobalSearchPlayer("moon");
+
+        Assert.AreEqual(PageSizeCap, ResultOf(result).Count);
+    }
+
+    [Test]
+    public async Task PageSize_SmallerValuesAreHonoured()
+    {
+        // launcher-e asks for 10 and infers "there is more" from getting exactly 10 back.
+        var result = await CreateController(50).GlobalSearchPlayer("moon", pageSize: 10);
+
+        Assert.AreEqual(10, ResultOf(result).Count);
+    }
+
+    [Test]
+    public async Task PageSize_LargerValuesAreClampedToTheCap()
+    {
+        var result = await CreateController(500).GlobalSearchPlayer("moon", pageSize: 200);
+
+        Assert.AreEqual(PageSizeCap, ResultOf(result).Count);
+    }
+
+    [Test]
+    public async Task PageSize_ExactlyTheCapIsAllowed()
+    {
+        var result = await CreateController(50).GlobalSearchPlayer("moon", pageSize: PageSizeCap);
+
+        Assert.AreEqual(PageSizeCap, ResultOf(result).Count);
+    }
+
+    [Test]
+    public async Task Search_ReturnsFewerThanThePageSizeWhenTheDirectoryIsSmaller()
+    {
+        var result = await CreateController(3).GlobalSearchPlayer("moon");
+
+        Assert.AreEqual(3, ResultOf(result).Count);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Search/GlobalSearchTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Search/GlobalSearchTests.cs
@@ -1,0 +1,567 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.CommonValueObjects;
+using W3ChampionsStatisticService.PlayerProfiles;
+using static WC3ChampionsStatisticService.UnitTests.Search.SearchTestFixtures;
+
+namespace WC3ChampionsStatisticService.UnitTests.Search;
+
+// GET api/players/global-search — the consolidated core search.
+//
+// Contract under test is consumed by the website picker, the website ladder search, and the
+// W3Champions launcher (launcher-e). Anything asserted here is load-bearing for at least one of them.
+[TestFixture]
+public class GlobalSearchTests
+{
+    // --- Matching -----------------------------------------------------------------------------
+
+    [Test]
+    public async Task Matches_Substring_AnywhereInBattleTag()
+    {
+        var service = PlayerServiceWith(Settings("Afternoon#1", "Grubby#2", "Moonlight#3"));
+
+        var result = await service.GlobalSearchForPlayer("oon");
+
+        CollectionAssert.AreEquivalent(
+            new[] { "Afternoon#1", "Moonlight#3" },
+            result.Select(r => r.BattleTag).ToList());
+    }
+
+    [Test]
+    public async Task Matches_IsCaseInsensitive()
+    {
+        var service = PlayerServiceWith(Settings("MoOn#1"));
+
+        var result = await service.GlobalSearchForPlayer("moon");
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("MoOn#1", result[0].BattleTag);
+    }
+
+    [Test]
+    public async Task Matches_NothingWhenNoTagContainsTheTerm()
+    {
+        var service = PlayerServiceWith(Settings("Grubby#1", "Happy#2"));
+
+        var result = await service.GlobalSearchForPlayer("moon");
+
+        Assert.IsEmpty(result);
+    }
+
+    // --- Relevance ranking --------------------------------------------------------------------
+    //
+    // Relevance is encoded as a numeric prefix on RelevanceId: 1 = exact name, 2 = name starts with
+    // the term, 9 = substring elsewhere. Results are ordered by that string, so the tier drives
+    // ordering AND doubles as the pagination cursor.
+
+    [Test]
+    public async Task Relevance_ExactBeatsPrefix_BeatsSubstring()
+    {
+        var service = PlayerServiceWith(Settings("Redmoon#4", "Moonlight#2", "Moon#1"));
+
+        var result = await service.GlobalSearchForPlayer("moon");
+
+        Assert.AreEqual(
+            new[] { "Moon#1", "Moonlight#2", "Redmoon#4" },
+            result.Select(r => r.BattleTag).ToArray());
+    }
+
+    [Test]
+    public async Task Relevance_TierIsEncodedInRelevanceId()
+    {
+        var service = PlayerServiceWith(Settings("Moon#1", "Moonlight#2", "Redmoon#4"));
+
+        var result = await service.GlobalSearchForPlayer("moon");
+
+        Assert.AreEqual("1_Moon#1", result[0].RelevanceId);
+        Assert.AreEqual("2_Moonlight#2", result[1].RelevanceId);
+        Assert.AreEqual("9_Redmoon#4", result[2].RelevanceId);
+    }
+
+    [Test]
+    public async Task Relevance_MatchIsOnNameOnly_NotTheNumericTag()
+    {
+        // "1234" appears only after the '#', so it is a substring hit (9), never exact or prefix.
+        var service = PlayerServiceWith(Settings("Grubby#1234"));
+
+        var result = await service.GlobalSearchForPlayer("1234");
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("9_Grubby#1234", result[0].RelevanceId);
+    }
+
+    [Test]
+    public async Task Relevance_WithinATierOrderingIsByBattleTag()
+    {
+        var service = PlayerServiceWith(Settings("MoonC#3", "MoonA#1", "MoonB#2"));
+
+        var result = await service.GlobalSearchForPlayer("moon");
+
+        Assert.AreEqual(
+            new[] { "MoonA#1", "MoonB#2", "MoonC#3" },
+            result.Select(r => r.BattleTag).ToArray());
+    }
+
+    // --- Paging -------------------------------------------------------------------------------
+    //
+    // Cursor paging, not offset paging. The caller echoes back the last RelevanceId it saw and the
+    // server returns strictly-greater ones. launcher-e depends on this directly
+    // (src/models/player-search.ts:43).
+
+    [Test]
+    public async Task Paging_HonoursPageSizeExactly()
+    {
+        // launcher-e sends pageSize=10 and treats "got exactly 10" as "there is another page".
+        // A backend that silently returned its own default would end that launcher's paging at page 1.
+        var service = PlayerServiceWith(Settings(
+            Enumerable.Range(1, 30).Select(i => $"Moon{i:00}#{i}").ToArray()));
+
+        var result = await service.GlobalSearchForPlayer("moon", pageSize: 10);
+
+        Assert.AreEqual(10, result.Count);
+    }
+
+    [Test]
+    public async Task Paging_CursorReturnsTheNextPageWithoutOverlap()
+    {
+        var directory = Settings(
+            Enumerable.Range(1, 30).Select(i => $"Moon{i:00}#{i}").ToArray());
+        var service = PlayerServiceWith(directory);
+
+        var page1 = await service.GlobalSearchForPlayer("moon", pageSize: 10);
+        var page2 = await service.GlobalSearchForPlayer(
+            "moon",
+            lastRelevanceId: page1.Last().RelevanceId,
+            pageSize: 10);
+
+        Assert.AreEqual(10, page2.Count);
+        CollectionAssert.IsEmpty(
+            page1.Select(r => r.BattleTag).Intersect(page2.Select(r => r.BattleTag)),
+            "a cursor page must not repeat entries from the previous page");
+    }
+
+    [Test]
+    public async Task Paging_EmptyCursorStartsAtTheFirstPage()
+    {
+        var service = PlayerServiceWith(Settings("MoonA#1", "MoonB#2"));
+
+        var withEmptyCursor = await service.GlobalSearchForPlayer("moon", lastRelevanceId: "");
+
+        Assert.AreEqual(2, withEmptyCursor.Count);
+        Assert.AreEqual("MoonA#1", withEmptyCursor[0].BattleTag);
+    }
+
+    [Test]
+    public async Task Paging_ExhaustedCursorReturnsEmpty()
+    {
+        var service = PlayerServiceWith(Settings("MoonA#1", "MoonB#2"));
+
+        var page1 = await service.GlobalSearchForPlayer("moon", pageSize: 10);
+        var page2 = await service.GlobalSearchForPlayer(
+            "moon",
+            lastRelevanceId: page1.Last().RelevanceId,
+            pageSize: 10);
+
+        Assert.IsEmpty(page2);
+    }
+
+    // --- Response shape -----------------------------------------------------------------------
+    //
+    // launcher-e reads battleTag, relevanceId, profilePicture.{race,pictureId,isClassic} and
+    // seasons[].id. It declares `name` but never reads it. The website picker reads battleTag.
+
+    [Test]
+    public async Task Shape_EveryItemCarriesTheFieldsConsumersRead()
+    {
+        var service = PlayerServiceWith(Settings("Moon#1", "Moonlight#2"));
+
+        var result = await service.GlobalSearchForPlayer("moon");
+
+        foreach (var item in result)
+        {
+            Assert.IsNotNull(item.BattleTag, "battleTag is the identity every consumer emits");
+            Assert.IsNotEmpty(item.RelevanceId, "relevanceId is the pagination cursor");
+            Assert.IsNotNull(item.ProfilePicture, "launcher-e dereferences profilePicture without a null guard");
+            Assert.IsNotNull(item.Seasons, "launcher-e maps over seasons without a null guard");
+        }
+    }
+
+    [Test]
+    public async Task Shape_NameIsTheBattleTagWithoutTheNumericSuffix()
+    {
+        var service = PlayerServiceWith(Settings("Moon#1234"));
+
+        var result = await service.GlobalSearchForPlayer("moon");
+
+        Assert.AreEqual("Moon", result[0].Name);
+        Assert.AreEqual("Moon#1234", result[0].BattleTag);
+    }
+
+    [Test]
+    public async Task Shape_ProfilePictureIsCarriedThrough()
+    {
+        var service = PlayerServiceWith([Setting("Moon#1", AvatarCategory.NE, 7)]);
+
+        var result = await service.GlobalSearchForPlayer("moon");
+
+        Assert.AreEqual(AvatarCategory.NE, result[0].ProfilePicture.Race);
+        Assert.AreEqual(7, result[0].ProfilePicture.PictureId);
+    }
+
+    [Test]
+    public async Task Shape_SeasonsAreEmptyWhenThePlayerHasNoOverallStats()
+    {
+        var service = PlayerServiceWith(Settings("Moon#1"));
+
+        var result = await service.GlobalSearchForPlayer("moon");
+
+        Assert.IsNotNull(result[0].Seasons);
+        Assert.IsEmpty(result[0].Seasons);
+    }
+
+    // --- Seasons decoration -------------------------------------------------------------------
+
+    [Test]
+    public async Task Seasons_AreTheThreeMostRecent_Descending()
+    {
+        var stats = new Dictionary<string, PlayerOverallStats>
+        {
+            ["Moon#1"] = StatsWithSeasons("Moon#1", 1, 5, 3, 13, 9),
+        };
+        var service = PlayerServiceWith(Settings("Moon#1"), PlayerRepositoryWithSeasons(stats));
+
+        var result = await service.GlobalSearchForPlayer("moon");
+
+        Assert.AreEqual(
+            new[] { 13, 9, 5 },
+            result[0].Seasons.Select(s => s.Id).ToArray());
+    }
+
+    [Test]
+    public async Task Seasons_AreLookedUpOnlyForThePageReturned()
+    {
+        // The seasons lookup happens after paging, so a 3000-row match still costs one bounded
+        // lookup of pageSize keys rather than 3000.
+        var directory = Settings(
+            Enumerable.Range(1, 100).Select(i => $"Moon{i:000}#{i}").ToArray());
+        var repo = EmptyPlayerRepository();
+        var service = PlayerServiceWith(directory, repo);
+
+        await service.GlobalSearchForPlayer("moon", pageSize: 10);
+
+        repo.Verify(
+            r => r.GetPlayerBattleTagsAsync(It.Is<ICollection<string>>(tags => tags.Count == 10)),
+            Times.Once);
+    }
+
+    // --- Ladder context -----------------------------------------------------------------------
+    //
+    // Passing season + gateWay + gameMode searches in a ladder context, where standing on that ladder
+    // is part of relevance. This exists because ladder standing is orthogonal to name relevance: a
+    // page cut on name alone samples the ranked players effectively at random, so the ladder search
+    // missed most of the ranked players matching a term. Context makes the cut land on the ranked
+    // block first and pagination drain it in ladder order.
+
+    [Test]
+    public async Task Context_RankedSortsAboveUnranked_EvenWithWorseNameRelevance()
+    {
+        // "Moon#1" is an exact name match and "Redmoon#2" a mere substring hit, but on this ladder
+        // only Redmoon is ranked — and on a ladder, that is the more relevant hit.
+        var service = PlayerServiceWith(
+            Settings("Moon#1", "Redmoon#2"),
+            rankRepository: RankRepositoryWith(RankFor("Redmoon#2")));
+
+        var result = await service.GlobalSearchForPlayer(
+            "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        Assert.AreEqual(
+            new[] { "Redmoon#2", "Moon#1" },
+            result.Select(r => r.BattleTag).ToArray());
+    }
+
+    [Test]
+    public async Task Context_RankedBlockIsOrderedByLadderPosition()
+    {
+        var service = PlayerServiceWith(
+            Settings("MoonA#1", "MoonB#2", "MoonC#3"),
+            rankRepository: RankRepositoryWith(
+                RankFor("MoonA#1", league: 1, rankNumber: 50),
+                RankFor("MoonB#2", league: 0, rankNumber: 9),
+                RankFor("MoonC#3", league: 1, rankNumber: 7)));
+
+        var result = await service.GlobalSearchForPlayer(
+            "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        Assert.AreEqual(
+            new[] { "MoonB#2", "MoonC#3", "MoonA#1" },
+            result.Select(r => r.BattleTag).ToArray());
+    }
+
+    [Test]
+    public async Task Context_LeagueOutranksRankNumber()
+    {
+        // RankNumber restarts at 1 in every league, so rank 1 of league 2 stands below rank 100 of
+        // league 1. Ordering on rank number alone would inspect them.
+        var service = PlayerServiceWith(
+            Settings("MoonA#1", "MoonB#2"),
+            rankRepository: RankRepositoryWith(
+                RankFor("MoonA#1", league: 2, rankNumber: 1),
+                RankFor("MoonB#2", league: 1, rankNumber: 100)));
+
+        var result = await service.GlobalSearchForPlayer(
+            "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        Assert.AreEqual(
+            new[] { "MoonB#2", "MoonA#1" },
+            result.Select(r => r.BattleTag).ToArray());
+    }
+
+    [Test]
+    public async Task Context_NumericPartsSortNumerically_NotLexically()
+    {
+        // The key is compared as a string because it doubles as the cursor, so its numbers are
+        // zero-padded. Unpadded, "10" would sort before "9".
+        var service = PlayerServiceWith(
+            Settings("MoonA#1", "MoonB#2"),
+            rankRepository: RankRepositoryWith(
+                RankFor("MoonA#1", league: 1, rankNumber: 10),
+                RankFor("MoonB#2", league: 1, rankNumber: 9)));
+
+        var result = await service.GlobalSearchForPlayer(
+            "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        Assert.AreEqual(
+            new[] { "MoonB#2", "MoonA#1" },
+            result.Select(r => r.BattleTag).ToArray());
+    }
+
+    [Test]
+    public async Task Context_UnrankedTailKeepsNameRelevanceOrder()
+    {
+        var service = PlayerServiceWith(
+            Settings("Redmoon#3", "Moon#1", "Moonlight#2"),
+            rankRepository: EmptyRankRepository());
+
+        var result = await service.GlobalSearchForPlayer(
+            "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        Assert.AreEqual(
+            new[] { "Moon#1", "Moonlight#2", "Redmoon#3" },
+            result.Select(r => r.BattleTag).ToArray());
+    }
+
+    [Test]
+    public async Task Context_RelevanceIdEncodesTheBlockItBelongsTo()
+    {
+        var service = PlayerServiceWith(
+            Settings("Moon#1", "Moonlight#2"),
+            rankRepository: RankRepositoryWith(RankFor("Moonlight#2", league: 3, rankNumber: 42)));
+
+        var result = await service.GlobalSearchForPlayer(
+            "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        Assert.AreEqual("0_003_0042_Moonlight#2", result[0].RelevanceId, "ranked: block 0, then ladder position");
+        Assert.AreEqual("1_1_Moon#1", result[1].RelevanceId, "unranked: block 1, then name relevance");
+    }
+
+    [Test]
+    public async Task Context_OnlyCountsRanksOnTheLadderAsked_For()
+    {
+        // Ranked in 2v2 does not make you ranked on the 1v1 ladder being searched.
+        var service = PlayerServiceWith(
+            Settings("Moonlight#2"),
+            rankRepository: RankRepositoryWith(
+                RankFor("Moonlight#2", gameMode: GameMode.GM_2v2_AT)));
+
+        var result = await service.GlobalSearchForPlayer(
+            "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        Assert.AreEqual("1_2_Moonlight#2", result[0].RelevanceId, "wrong-ladder rank leaves them unranked here");
+    }
+
+    [Test]
+    public async Task Context_ATTeamRankStandsForBothMembers()
+    {
+        var service = PlayerServiceWith(
+            Settings("MoonMate#1", "MoonBoss#2", "MoonSolo#3"),
+            rankRepository: RankRepositoryWith(
+                TeamRankFor(["MoonBoss#2", "MoonMate#1"], league: 1, rankNumber: 3)));
+
+        var result = await service.GlobalSearchForPlayer(
+            "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_2v2_AT);
+
+        // Both members are ranked at the team's position; only the unpartnered player falls to the tail.
+        Assert.AreEqual("MoonSolo#3", result[2].BattleTag);
+        CollectionAssert.AreEquivalent(
+            new[] { "MoonBoss#2", "MoonMate#1" },
+            result.Take(2).Select(r => r.BattleTag).ToArray());
+    }
+
+    [Test]
+    public async Task Context_TeamRankStandsForMembersBeyondTheSecond()
+    {
+        // Rank keeps its first two members in dedicated fields; a third exists only in MemberIds.
+        var service = PlayerServiceWith(
+            Settings("MoonMate#1", "MoonBoss#2", "MoonThird#3", "MoonSolo#4"),
+            rankRepository: RankRepositoryWith(
+                TeamRankFor(["MoonBoss#2", "MoonMate#1", "MoonThird#3"], gameMode: GameMode.GM_4v4_AT)));
+
+        var result = await service.GlobalSearchForPlayer(
+            "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_4v4_AT);
+
+        // All three members are ranked at the team's position; only the teamless player is unranked.
+        Assert.AreEqual("MoonSolo#4", result[3].BattleTag);
+        CollectionAssert.AreEquivalent(
+            new[] { "MoonBoss#2", "MoonMate#1", "MoonThird#3" },
+            result.Take(3).Select(r => r.BattleTag).ToArray());
+    }
+
+    [Test]
+    public async Task Context_PlayerHoldingSeveralRanksIsPlacedByTheirBest()
+    {
+        // 1v1 is ranked per race, so one player legitimately holds several ranks in one context.
+        var service = PlayerServiceWith(
+            Settings("MoonA#1", "MoonB#2"),
+            rankRepository: RankRepositoryWith(
+                RankFor("MoonA#1", league: 4, rankNumber: 1, race: Race.HU),
+                RankFor("MoonA#1", league: 1, rankNumber: 2, race: Race.UD),
+                RankFor("MoonB#2", league: 2, rankNumber: 1)));
+
+        var result = await service.GlobalSearchForPlayer(
+            "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        Assert.AreEqual(
+            new[] { "MoonA#1", "MoonB#2" },
+            result.Select(r => r.BattleTag).ToArray(),
+            "MoonA's league-1 rank should place them, not their league-4 one");
+    }
+
+    [Test]
+    public async Task Context_PagingRunsThroughTheRankedBlockIntoTheTail()
+    {
+        var service = PlayerServiceWith(
+            Settings("MoonA#1", "MoonB#2", "MoonC#3", "MoonD#4"),
+            rankRepository: RankRepositoryWith(
+                RankFor("MoonC#3", league: 1, rankNumber: 1),
+                RankFor("MoonD#4", league: 1, rankNumber: 2)));
+
+        var page1 = await service.GlobalSearchForPlayer(
+            "moon", pageSize: 2, season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+        var page2 = await service.GlobalSearchForPlayer(
+            "moon", lastRelevanceId: page1.Last().RelevanceId, pageSize: 2,
+            season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        Assert.AreEqual(new[] { "MoonC#3", "MoonD#4" }, page1.Select(r => r.BattleTag).ToArray());
+        Assert.AreEqual(new[] { "MoonA#1", "MoonB#2" }, page2.Select(r => r.BattleTag).ToArray());
+    }
+
+    [Test]
+    public async Task Context_RankedPlayersBeyondThePageSurfaceThatNameOrderWouldBury()
+    {
+        // The defect this feature fixes, in miniature: one ranked player behind a wall of
+        // better-name-matching unranked ones. Without context they fall off the page entirely.
+        var directory = Settings(
+            Enumerable.Range(1, 30).Select(i => $"Moon{i:00}#{i}").Append("Redmoon#99").ToArray());
+        var ranked = RankRepositoryWith(RankFor("Redmoon#99", league: 1, rankNumber: 1));
+
+        var withoutContext = await PlayerServiceWith(directory, rankRepository: ranked)
+            .GlobalSearchForPlayer("moon", pageSize: 20);
+        var withContext = await PlayerServiceWith(directory, rankRepository: ranked)
+            .GlobalSearchForPlayer(
+                "moon", pageSize: 20, season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        CollectionAssert.DoesNotContain(withoutContext.Select(r => r.BattleTag).ToList(), "Redmoon#99");
+        Assert.AreEqual("Redmoon#99", withContext[0].BattleTag);
+    }
+
+    // --- Context is opt-in --------------------------------------------------------------------
+
+    [Test]
+    public async Task Context_OmittedLeavesRelevanceIdsExactlyAsTheyWere()
+    {
+        // launcher-e holds relevanceId as an opaque cursor and sends no context. Its key shape must
+        // not move.
+        var service = PlayerServiceWith(
+            Settings("Moon#1", "Moonlight#2", "Redmoon#3"),
+            rankRepository: RankRepositoryWith(RankFor("Redmoon#3")));
+
+        var result = await service.GlobalSearchForPlayer("moon");
+
+        Assert.AreEqual(
+            new[] { "1_Moon#1", "2_Moonlight#2", "9_Redmoon#3" },
+            result.Select(r => r.RelevanceId).ToArray());
+    }
+
+    [Test]
+    public async Task Context_IsIgnoredUnlessAllThreePartsAreGiven()
+    {
+        // The three travel together; a partial context is not a ladder.
+        var service = PlayerServiceWith(
+            Settings("Moon#1", "Redmoon#2"),
+            rankRepository: RankRepositoryWith(RankFor("Redmoon#2")));
+
+        var seasonOnly = await service.GlobalSearchForPlayer("moon", season: 13);
+        var noGameMode = await service.GlobalSearchForPlayer("moon", season: 13, gateWay: GateWay.Europe);
+
+        Assert.AreEqual("1_Moon#1", seasonOnly[0].RelevanceId);
+        Assert.AreEqual("1_Moon#1", noGameMode[0].RelevanceId);
+    }
+
+    [Test]
+    public async Task Context_DoesNotHitTheLadderWhenNothingMatched()
+    {
+        var ranks = RankRepositoryWith(RankFor("Grubby#1"));
+        var service = PlayerServiceWith(Settings("Grubby#1"), rankRepository: ranks);
+
+        await service.GlobalSearchForPlayer(
+            "nobodyhasthisname", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        ranks.Verify(
+            r => r.LoadLadderStandings(
+                It.IsAny<List<string>>(), It.IsAny<int>(), It.IsAny<GateWay>(), It.IsAny<GameMode>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task Context_AsksOnlyForLadderPosition_NotTheFullRankRows()
+    {
+        // Ordering reads League and RankNumber and nothing else, so the core takes the projected
+        // query. Falling back to LoadRanksForPlayers would hydrate a joined PlayerOverview for every
+        // hit in the match set — payload nothing here opens.
+        var ranks = RankRepositoryWith(RankFor("Moon#1"));
+        var service = PlayerServiceWith(Settings("Moon#1"), rankRepository: ranks);
+
+        await service.GlobalSearchForPlayer(
+            "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        ranks.Verify(
+            r => r.LoadRanksForPlayers(
+                It.IsAny<List<string>>(), It.IsAny<int>(), It.IsAny<GateWay>(), It.IsAny<GameMode>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task Context_LooksUpTheLadderOnceForTheWholeMatchSet()
+    {
+        // Standing has to be known for every match before the page is cut — that is the whole point —
+        // but it costs one lookup, not one per candidate.
+        var directory = Settings(
+            Enumerable.Range(1, 50).Select(i => $"Moon{i:00}#{i}").ToArray());
+        var ranks = RankRepositoryWith();
+        var service = PlayerServiceWith(directory, rankRepository: ranks);
+
+        await service.GlobalSearchForPlayer(
+            "moon", pageSize: 10, season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        ranks.Verify(
+            r => r.LoadLadderStandings(
+                It.Is<List<string>>(tags => tags.Count == 50),
+                13, GateWay.Europe, GameMode.GM_1v1),
+            Times.Once);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Search/GlobalSearchTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Search/GlobalSearchTests.cs
@@ -285,14 +285,14 @@ public class GlobalSearchTests
     }
 
     [Test]
-    public async Task Context_RankedBlockIsOrderedByLadderPosition()
+    public async Task Context_RankedBlockIsOrderedByRankingPoints()
     {
         var service = PlayerServiceWith(
             Settings("MoonA#1", "MoonB#2", "MoonC#3"),
             rankRepository: RankRepositoryWith(
-                RankFor("MoonA#1", league: 1, rankNumber: 50),
-                RankFor("MoonB#2", league: 0, rankNumber: 9),
-                RankFor("MoonC#3", league: 1, rankNumber: 7)));
+                RankFor("MoonA#1", rankingPoints: 12.6),
+                RankFor("MoonB#2", rankingPoints: 47.8),
+                RankFor("MoonC#3", rankingPoints: 30.1)));
 
         var result = await service.GlobalSearchForPlayer(
             "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
@@ -303,40 +303,82 @@ public class GlobalSearchTests
     }
 
     [Test]
-    public async Task Context_LeagueOutranksRankNumber()
+    public async Task Context_AppendedDivisionOrdersByStanding_NotLeagueId()
     {
-        // RankNumber restarts at 1 in every league, so rank 1 of league 2 stands below rank 100 of
-        // league 1. Ordering on rank number alone would inspect them.
+        // Divisions created mid-season take the next free league id: prod s13/EU/1v1 files Diamond
+        // division 8 as league 52, behind Grass's 49–51. Ranking points carry the real ordering,
+        // so the Diamond player leads whatever the ids say.
         var service = PlayerServiceWith(
-            Settings("MoonA#1", "MoonB#2"),
+            Settings("MoonDia#1", "MoonGrass#2"),
             rankRepository: RankRepositoryWith(
-                RankFor("MoonA#1", league: 2, rankNumber: 1),
-                RankFor("MoonB#2", league: 1, rankNumber: 100)));
+                RankFor("MoonDia#1", league: 52, rankNumber: 32, rankingPoints: 30.1),
+                RankFor("MoonGrass#2", league: 49, rankNumber: 1, rankingPoints: 5.3)));
 
         var result = await service.GlobalSearchForPlayer(
             "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
 
         Assert.AreEqual(
-            new[] { "MoonB#2", "MoonA#1" },
+            new[] { "MoonDia#1", "MoonGrass#2" },
             result.Select(r => r.BattleTag).ToArray());
     }
 
     [Test]
     public async Task Context_NumericPartsSortNumerically_NotLexically()
     {
-        // The key is compared as a string because it doubles as the cursor, so its numbers are
-        // zero-padded. Unpadded, "10" would sort before "9".
+        // The key is compared as a string because it doubles as the cursor, so the complement is
+        // zero-padded to a fixed five digits. Near the ceiling the complement gets short (999.5
+        // points → 49), and unpadded it would sort behind the longer complement of a lower score.
         var service = PlayerServiceWith(
             Settings("MoonA#1", "MoonB#2"),
             rankRepository: RankRepositoryWith(
-                RankFor("MoonA#1", league: 1, rankNumber: 10),
-                RankFor("MoonB#2", league: 1, rankNumber: 9)));
+                RankFor("MoonA#1", rankingPoints: 999.5),
+                RankFor("MoonB#2", rankingPoints: 960)));
 
         var result = await service.GlobalSearchForPlayer(
             "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
 
         Assert.AreEqual(
-            new[] { "MoonB#2", "MoonA#1" },
+            new[] { "MoonA#1", "MoonB#2" },
+            result.Select(r => r.BattleTag).ToArray());
+    }
+
+    [Test]
+    public async Task Context_RankingPointsOutsideTheKeyRangeAreClamped()
+    {
+        // The complement has exactly five digits, so points past 999.99 or below zero would
+        // otherwise leave the key's namespace and break the string comparison the cursor relies on.
+        // Clamped, the extremes still order correctly and still mint well-formed cursors.
+        var service = PlayerServiceWith(
+            Settings("MoonHigh#1", "MoonMid#2", "MoonNeg#3"),
+            rankRepository: RankRepositoryWith(
+                RankFor("MoonNeg#3", rankingPoints: -5),
+                RankFor("MoonMid#2", rankingPoints: 500),
+                RankFor("MoonHigh#1", rankingPoints: 1200)));
+
+        var result = await service.GlobalSearchForPlayer(
+            "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        Assert.AreEqual("0_00000_MoonHigh#1", result[0].RelevanceId, "past the ceiling clamps to the best key");
+        Assert.AreEqual("0_49999_MoonMid#2", result[1].RelevanceId);
+        Assert.AreEqual("0_99999_MoonNeg#3", result[2].RelevanceId, "below zero clamps to the worst key");
+    }
+
+    [Test]
+    public async Task Context_EqualRankingPointsFallBackToBattleTagOrder()
+    {
+        // Equal points produce equal complements, so the battleTag suffix is what keeps the key —
+        // and with it the cursor — deterministic between requests.
+        var service = PlayerServiceWith(
+            Settings("MoonA#1", "MoonB#2"),
+            rankRepository: RankRepositoryWith(
+                RankFor("MoonB#2", rankingPoints: 42.5),
+                RankFor("MoonA#1", rankingPoints: 42.5)));
+
+        var result = await service.GlobalSearchForPlayer(
+            "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
+
+        Assert.AreEqual(
+            new[] { "MoonA#1", "MoonB#2" },
             result.Select(r => r.BattleTag).ToArray());
     }
 
@@ -360,12 +402,13 @@ public class GlobalSearchTests
     {
         var service = PlayerServiceWith(
             Settings("Moon#1", "Moonlight#2"),
-            rankRepository: RankRepositoryWith(RankFor("Moonlight#2", league: 3, rankNumber: 42)));
+            rankRepository: RankRepositoryWith(RankFor("Moonlight#2", rankingPoints: 42.5)));
 
         var result = await service.GlobalSearchForPlayer(
             "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
 
-        Assert.AreEqual("0_003_0042_Moonlight#2", result[0].RelevanceId, "ranked: block 0, then ladder position");
+        // 95749 = 99999 - 42.5 * 100: the zero-padded complement, so higher points sort first.
+        Assert.AreEqual("0_95749_Moonlight#2", result[0].RelevanceId, "ranked: block 0, then ladder standing");
         Assert.AreEqual("1_1_Moon#1", result[1].RelevanceId, "unranked: block 1, then name relevance");
     }
 
@@ -428,9 +471,9 @@ public class GlobalSearchTests
         var service = PlayerServiceWith(
             Settings("MoonA#1", "MoonB#2"),
             rankRepository: RankRepositoryWith(
-                RankFor("MoonA#1", league: 4, rankNumber: 1, race: Race.HU),
-                RankFor("MoonA#1", league: 1, rankNumber: 2, race: Race.UD),
-                RankFor("MoonB#2", league: 2, rankNumber: 1)));
+                RankFor("MoonA#1", rankingPoints: 22.1, race: Race.HU),
+                RankFor("MoonA#1", rankingPoints: 47.8, race: Race.UD),
+                RankFor("MoonB#2", rankingPoints: 33.4)));
 
         var result = await service.GlobalSearchForPlayer(
             "moon", season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
@@ -438,7 +481,7 @@ public class GlobalSearchTests
         Assert.AreEqual(
             new[] { "MoonA#1", "MoonB#2" },
             result.Select(r => r.BattleTag).ToArray(),
-            "MoonA's league-1 rank should place them, not their league-4 one");
+            "MoonA's 47.8-point rank should place them, not their 22.1-point one");
     }
 
     [Test]
@@ -447,8 +490,8 @@ public class GlobalSearchTests
         var service = PlayerServiceWith(
             Settings("MoonA#1", "MoonB#2", "MoonC#3", "MoonD#4"),
             rankRepository: RankRepositoryWith(
-                RankFor("MoonC#3", league: 1, rankNumber: 1),
-                RankFor("MoonD#4", league: 1, rankNumber: 2)));
+                RankFor("MoonC#3", rankingPoints: 47.8),
+                RankFor("MoonD#4", rankingPoints: 30.1)));
 
         var page1 = await service.GlobalSearchForPlayer(
             "moon", pageSize: 2, season: 13, gateWay: GateWay.Europe, gameMode: GameMode.GM_1v1);
@@ -530,7 +573,7 @@ public class GlobalSearchTests
     [Test]
     public async Task Context_AsksOnlyForLadderPosition_NotTheFullRankRows()
     {
-        // Ordering reads League and RankNumber and nothing else, so the core takes the projected
+        // Ordering reads RankingPoints and nothing else, so the core takes the projected
         // query. Falling back to LoadRanksForPlayers would hydrate a joined PlayerOverview for every
         // hit in the match set — payload nothing here opens.
         var ranks = RankRepositoryWith(RankFor("Moon#1"));

--- a/WC3ChampionsStatisticService.UnitTests/Search/LegacyLadderSearchTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Search/LegacyLadderSearchTests.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.Ladder;
+using W3ChampionsStatisticService.PlayerProfiles;
+using W3ChampionsStatisticService.Ports;
+using static WC3ChampionsStatisticService.UnitTests.Search.SearchTestFixtures;
+
+namespace WC3ChampionsStatisticService.UnitTests.Search;
+
+// GET api/ladder/search — the LEGACY ladder search.
+//
+// These are characterisation tests. The consolidation does not change this endpoint; it stays live as
+// the website's rollback target and because the in-game UI bundle
+// (storage.w3champions.com/{env}/integration/w3champions.js) still calls it. The tests pin today's
+// behaviour so that retiring or altering the route later is a deliberate act with a failing test
+// attached, rather than a silent break of a consumer nobody was tracking.
+[TestFixture]
+public class LegacyLadderSearchTests
+{
+    private Mock<IRankRepository> _rankRepo;
+    private Mock<IPlayerRepository> _playerRepo;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _rankRepo = new Mock<IRankRepository>();
+        _playerRepo = new Mock<IPlayerRepository>();
+
+        _rankRepo
+            .Setup(r => r.SearchPlayerOfLeague(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<GateWay>(), It.IsAny<GameMode>()))
+            .ReturnsAsync([]);
+        _playerRepo
+            .Setup(p => p.SearchForPlayer(It.IsAny<string>()))
+            .ReturnsAsync([]);
+    }
+
+    private LadderController CreateController()
+    {
+        return LadderControllerWith(_rankRepo.Object, _playerRepo.Object);
+    }
+
+    // --- Minimum length -----------------------------------------------------------------------
+    //
+    // This is the only search route that enforces a minimum length server-side. global-search and
+    // players?search= leave it to the client.
+
+    [TestCase("mo")]
+    [TestCase("")]
+    [TestCase(null)]
+    public async Task MinLength_UnderThreeIsRejected(string searchFor)
+    {
+        var result = await CreateController().SearchPlayer(searchFor, 13);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
+
+    [Test]
+    public async Task MinLength_ThreeCharactersIsAccepted()
+    {
+        var result = await CreateController().SearchPlayer("moo", 13);
+
+        Assert.IsInstanceOf<OkObjectResult>(result);
+    }
+
+    // --- The hybrid response ------------------------------------------------------------------
+    //
+    // The response is two concatenated blocks in one flat array: ranked rows for the requested
+    // {season, gateway, gameMode}, then a globally-matched tail of zeroed rows for everyone else
+    // whose battleTag matches. Consumers fork on player.games > 0. This shape is exactly what the
+    // consolidated flow replaces — global-search plus ranks-for-players — and pinning it makes the
+    // difference explicit.
+
+    [Test]
+    public async Task Hybrid_RankedBlockAndUnrankedTailAreConcatenated()
+    {
+        _rankRepo
+            .Setup(r => r.SearchPlayerOfLeague(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<GateWay>(), It.IsAny<GameMode>()))
+            .ReturnsAsync([RankFor("Moon#1", league: 2, rankNumber: 42)]);
+        _playerRepo
+            .Setup(p => p.SearchForPlayer(It.IsAny<string>()))
+            .ReturnsAsync([PlayerOverallStats.Create("Moonlight#2")]);
+
+        var result = await CreateController().SearchPlayer("moon", 13);
+
+        var ranks = (List<Rank>)((OkObjectResult)result).Value;
+        Assert.AreEqual(2, ranks.Count);
+        Assert.AreEqual(42, ranks[0].RankNumber, "the ranked block comes first");
+        Assert.AreEqual(0, ranks[1].RankNumber, "the unranked tail is appended after it");
+    }
+
+    [Test]
+    public async Task Hybrid_TailRowsAreFullyZeroed()
+    {
+        _playerRepo
+            .Setup(p => p.SearchForPlayer(It.IsAny<string>()))
+            .ReturnsAsync([PlayerOverallStats.Create("Moonlight#2")]);
+
+        var result = await CreateController().SearchPlayer("moon", 13);
+
+        var tail = ((List<Rank>)((OkObjectResult)result).Value).Single();
+        Assert.AreEqual(0, tail.League);
+        Assert.AreEqual(0, tail.RankNumber);
+        Assert.AreEqual(0, tail.RankingPoints);
+        Assert.AreEqual(GameMode.Undefined, tail.GameMode);
+        Assert.AreEqual(GateWay.Undefined, tail.Gateway);
+    }
+
+    [Test]
+    public async Task Hybrid_TailIsNotScopedToTheRequestedContext()
+    {
+        // The tail comes from an unfiltered directory scan: the same battleTag search runs regardless
+        // of season, gateway or gameMode. This is why an exact-tag search can return a player twice —
+        // once ranked, once in the tail.
+        _playerRepo
+            .Setup(p => p.SearchForPlayer(It.IsAny<string>()))
+            .ReturnsAsync([PlayerOverallStats.Create("Moon#1")]);
+
+        await CreateController().SearchPlayer("moon", 13, GateWay.America, GameMode.GM_4v4_AT);
+
+        _playerRepo.Verify(
+            p => p.SearchForPlayer("moon"),
+            Times.Once,
+            "the tail query takes only the search term — no season, gateway or gameMode");
+    }
+
+    [Test]
+    public async Task Hybrid_RankedBlockIsScopedToTheRequestedContext()
+    {
+        await CreateController().SearchPlayer("moon", 13, GateWay.America, GameMode.GM_4v4_AT);
+
+        _rankRepo.Verify(
+            r => r.SearchPlayerOfLeague("moon", 13, GateWay.America, GameMode.GM_4v4_AT),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task Hybrid_DefaultsAreEuropeAnd1v1()
+    {
+        // Callers may omit gateWay and gameMode entirely; the route still answers.
+        await CreateController().SearchPlayer("moon", 13);
+
+        _rankRepo.Verify(
+            r => r.SearchPlayerOfLeague("moon", 13, GateWay.Europe, GameMode.GM_1v1),
+            Times.Once);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Search/LegacyPlayerSearchTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Search/LegacyPlayerSearchTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsStatisticService.PlayerProfiles;
+using W3ChampionsStatisticService.Ports;
+using static WC3ChampionsStatisticService.UnitTests.Search.SearchTestFixtures;
+
+namespace WC3ChampionsStatisticService.UnitTests.Search;
+
+// GET api/players/?search= — the LEGACY directory search.
+//
+// The oldest of the three search modes and the one global-search replaces for the player picker. Like
+// LegacyLadderSearchTests these are characterisation tests: the consolidation does not change this
+// route, it keeps it serving as the picker's rollback target when USE_NEW_SEARCH is off.
+//
+// Its distinguishing property is what it does NOT do — no pagination, no cap, no relevance ordering.
+// That is pinned here deliberately: those absences are the reason the endpoint is being retired, and
+// a future change that quietly adds a cap would alter rollback behaviour rather than fix it.
+//
+// Unlike api/ladder/search, this route has no known consumer outside this repo (audited 2026-07-18),
+// so it is the one legacy endpoint retirable on the website's own schedule.
+[TestFixture]
+public class LegacyPlayerSearchTests
+{
+    private Mock<IPlayerRepository> _playerRepo;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _playerRepo = new Mock<IPlayerRepository>();
+        _playerRepo
+            .Setup(p => p.SearchForPlayer(It.IsAny<string>()))
+            .ReturnsAsync([]);
+    }
+
+    private PlayersController CreateController()
+    {
+        return PlayersControllerWith(_playerRepo.Object);
+    }
+
+    // --- Request validation -------------------------------------------------------------------
+    //
+    // The only guard this route has. Note it is weaker than api/ladder/search: no minimum length, so
+    // a single character is accepted and scans the whole collection.
+
+    [TestCase("")]
+    [TestCase(null)]
+    public async Task Validation_EmptyOrNullIsRejected(string search)
+    {
+        var result = await CreateController().SearchPlayer(search);
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
+
+    [Test]
+    public async Task Validation_ASingleCharacterIsAccepted()
+    {
+        // Characterisation, not endorsement: there is no server-side minimum here, which is why a
+        // one-character search can return tens of thousands of rows.
+        var result = await CreateController().SearchPlayer("m");
+
+        Assert.IsInstanceOf<OkObjectResult>(result);
+    }
+
+    [Test]
+    public async Task Validation_RejectedRequestsDoNotHitTheRepository()
+    {
+        await CreateController().SearchPlayer("");
+
+        _playerRepo.Verify(p => p.SearchForPlayer(It.IsAny<string>()), Times.Never);
+    }
+
+    // --- Behaviour ----------------------------------------------------------------------------
+
+    [Test]
+    public async Task Search_PassesTheTermThroughUnmodified()
+    {
+        await CreateController().SearchPlayer("Moon#123");
+
+        _playerRepo.Verify(p => p.SearchForPlayer("Moon#123"), Times.Once);
+    }
+
+    [Test]
+    public async Task Search_ReturnsThePlayerOverallStatsShape()
+    {
+        // The picker's legacy path consumes only battleTag off these rows, but the whole heavy
+        // document is what goes over the wire — the reason the swap to global-search is worth making.
+        _playerRepo
+            .Setup(p => p.SearchForPlayer(It.IsAny<string>()))
+            .ReturnsAsync([PlayerOverallStats.Create("Moon#1")]);
+
+        var result = await CreateController().SearchPlayer("moon");
+
+        var players = (List<PlayerOverallStats>)((OkObjectResult)result).Value;
+        Assert.AreEqual(1, players.Count);
+        Assert.AreEqual("Moon#1", players[0].BattleTag);
+    }
+
+    [Test]
+    public async Task Search_AppliesNoCapOrPagination()
+    {
+        // Every match is returned in one response. There is no pageSize parameter to pass and none is
+        // applied server-side — pinned because adding one silently would change rollback behaviour.
+        var many = new List<PlayerOverallStats>();
+        for (var i = 0; i < 500; i++)
+        {
+            many.Add(PlayerOverallStats.Create($"Moon{i}#{i}"));
+        }
+        _playerRepo.Setup(p => p.SearchForPlayer(It.IsAny<string>())).ReturnsAsync(many);
+
+        var result = await CreateController().SearchPlayer("moon");
+
+        Assert.AreEqual(500, ((List<PlayerOverallStats>)((OkObjectResult)result).Value).Count);
+    }
+
+    [Test]
+    public async Task Search_NoMatchesReturnsAnEmptyListNotAnError()
+    {
+        var result = await CreateController().SearchPlayer("nobody");
+
+        Assert.IsEmpty((List<PlayerOverallStats>)((OkObjectResult)result).Value);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Search/README.md
+++ b/WC3ChampionsStatisticService.UnitTests/Search/README.md
@@ -9,7 +9,7 @@ Run them with:
 dotnet test WC3ChampionsStatisticService.UnitTests --filter "FullyQualifiedName~UnitTests.Search"
 ```
 
-82 tests, ~380 ms.
+104 tests, ~550 ms.
 
 All four search modes are covered:
 

--- a/WC3ChampionsStatisticService.UnitTests/Search/README.md
+++ b/WC3ChampionsStatisticService.UnitTests/Search/README.md
@@ -1,0 +1,155 @@
+# Search API tests
+
+Covers the player-search endpoints: the consolidated core (`global-search`), its rank enrichment
+(`ranks-for-players`), and the legacy ladder search that both replace.
+
+Run them with:
+
+```bash
+dotnet test WC3ChampionsStatisticService.UnitTests --filter "FullyQualifiedName~UnitTests.Search"
+```
+
+82 tests, ~380 ms.
+
+All four search modes are covered:
+
+| Mode | Route | Status | Tests |
+|---|---|---|---|
+| Core directory search | `GET api/players/global-search` | Current + future | `GlobalSearchTests`, `GlobalSearchControllerTests` |
+| Rank enrichment | `POST api/ladder/ranks-for-players` | New | `RanksForPlayersTests` |
+| Ladder hybrid search | `GET api/ladder/search` | Outdated, still serving | `LegacyLadderSearchTests` |
+| Directory dump | `GET api/players/?search=` | Outdated, still serving | `LegacyPlayerSearchTests` |
+
+Both outdated modes remain live: `api/ladder/search` because the in-game UI bundle calls it and because
+it is the ladder's rollback path, `api/players/?search=` because it is the picker's rollback path.
+
+## These tests need no database
+
+Every other repository-backed suite in this project inherits `IntegrationTestBase`, which points at the
+shared W3C test Mongo (`IntegrationTestBase.cs:19`) and drops the database in `[SetUp]`. That makes those
+suites unrunnable without network access to that host, and destructive when it is reachable.
+
+This suite deliberately avoids that. The seam is the cache in front of the directory:
+
+```
+PersonalSettingsProvider.GetPersonalSettingsAsync()
+    └── ICachedDataProvider.GetCachedOrRequestAsync(fetchFromMongo, key)
+```
+
+Mock the cache so it returns a value **without invoking the callback**, and the Mongo fetch is never
+reached — the `MongoClient` handed to the provider stays inert, and `MongoClient`'s constructor opens no
+connection. `SearchTestFixtures.PlayerServiceWith(directory)` packages this: hand it a list of
+`PersonalSetting` and you have a `PlayerService` whose entire searchable directory is that list.
+
+Everything else is an interface (`IRankRepository`, `IPlayerRepository`) and mocks normally.
+
+The practical consequence: these tests run in CI, on a laptop, and offline, and a failure means the
+search logic changed rather than that a shared host was unreachable.
+
+## Layout
+
+| File | Covers |
+|---|---|
+| `SearchTestFixtures.cs` | Shared builders. No tests. |
+| `GlobalSearchTests.cs` | `PlayerService.GlobalSearchForPlayer` — matching, relevance, paging, response shape, seasons |
+| `GlobalSearchControllerTests.cs` | `PlayersController.GlobalSearchPlayer` — the `pageSize` clamp, which only exists at the controller |
+| `RanksForPlayersTests.cs` | `LadderController.GetRanksForPlayers` — validation, context scoping, mapping |
+| `LegacyLadderSearchTests.cs` | `LadderController.SearchPlayer` — characterisation of the legacy ladder route |
+| `LegacyPlayerSearchTests.cs` | `PlayersController.SearchPlayer` — characterisation of the legacy directory dump |
+| `SubscriberContractTests.cs` | Promises made to identified shipped clients — see below |
+
+## Subscriber contracts
+
+`SubscriberContractTests.cs` answers a different question from the rest of the folder. The other files
+ask "does the search behave correctly." That one asks "does it still behave the way a client that ships
+today already depends on" — a logic test can be legitimately rewritten when the logic changes, and that
+must not quietly take a subscriber guarantee with it.
+
+The subscriber registry, the audit date, and the file's limits live in the header of
+`SubscriberContractTests.cs` itself, next to the tests a maintainer would edit — one home, kept where
+it is enforced.
+
+## What each group pins, and why it matters
+
+### Matching and relevance
+
+Relevance is a numeric tier encoded as a prefix on `RelevanceId`: `1` exact name, `2` name starts with
+the term, `9` substring anywhere. Results are ordered by that string, so **one value is both the sort key
+and the pagination cursor**. Changing the tier numbers, the separator, or the ordering silently changes
+paging for every consumer — hence `Relevance_TierIsEncodedInRelevanceId` asserts the literal format.
+
+`Relevance_MatchIsOnNameOnly_NotTheNumericTag` pins a non-obvious rule: tiering splits on `#` and looks
+only at the name, so searching `1234` finds `Grubby#1234` as a tier-9 substring hit, never as exact.
+
+### Paging
+
+Cursor-based, not offset-based: the caller echoes the last `RelevanceId` it saw and the server returns
+strictly-greater ones.
+
+`Paging_HonoursPageSizeExactly` guards a live external dependency. The W3Champions launcher
+(`launcher-e`, `src/models/player-search.ts:63`) infers "there is another page" from
+`newPlayers.length === PAGE_SIZE` with `PAGE_SIZE = 10`. A backend that silently substituted its own
+default would end that launcher's infinite scroll at page one — no error, just missing results.
+
+`Seasons_AreLookedUpOnlyForThePageReturned` pins the ordering that keeps the endpoint cheap: seasons are
+fetched *after* paging, so a 3,000-row match costs one bounded lookup of `pageSize` keys. Moving that
+lookup before the `Take` would not fail any other test.
+
+### Response shape
+
+The assertions in `Shape_EveryItemCarriesTheFieldsConsumersRead` are drawn from what consumers actually
+dereference, not from the DTO definition:
+
+| Field | Consumer requirement |
+|---|---|
+| `battleTag` | Identity every consumer emits |
+| `relevanceId` | Pagination cursor — a missing value breaks the next page |
+| `profilePicture` | launcher-e dereferences `.race`/`.pictureId`/`.isClassic` with no null guard |
+| `seasons` | launcher-e maps over it with no null guard |
+| `name` | Declared, never read by any known consumer |
+
+### `ranks-for-players`
+
+Two things are worth knowing about this endpoint's design, and both are pinned.
+
+**Absence means unranked.** The response contains only players who *are* ranked in the requested
+context; callers synthesise their own unranked rows from the search result. Returning zeroed rows here is
+what produced the old duplicate-result bug in ladder search, so
+`Mapping_UnrankedPlayersAreAbsent_RatherThanZeroed` locks the current behaviour in.
+
+**The four-argument overload is the one that must be called.** `IRankRepository` has both
+`LoadRanksForPlayers(tags, season)` (pre-existing, season-only) and
+`LoadRanksForPlayers(tags, season, gateWay, gameMode)` (added for this endpoint). C# overload resolution
+picks silently, and calling the two-argument version would return ranks from the wrong gateway and game
+mode while still looking correct. `Context_TheSeasonOnlyOverloadIsNotUsed` asserts the old overload is
+never invoked.
+
+`Validation_OverTheBatchLimitIsRejected` guards the batch bound. The route is anonymous, so
+`MaxBattleTags` is what keeps the `$in` query small.
+
+### Legacy ladder search
+
+`LegacyLadderSearchTests` is a **characterisation suite**, not a specification. The consolidation does
+not change `api/ladder/search`; it stays live as the website's rollback target and because the in-game UI
+bundle (`storage.w3champions.com/{env}/integration/w3champions.js`, shipped by the deprecated Electron
+launcher) still calls it.
+
+The tests pin the hybrid response: one flat array holding a ranked block scoped to
+`{season, gateway, gameMode}` followed by a globally-matched tail of fully-zeroed rows, which consumers
+fork on via `player.games > 0`. `Hybrid_TailIsNotScopedToTheRequestedContext` records the reason an
+exact-tag search can return the same player twice.
+
+This route is also the only search endpoint that enforces a minimum length server-side (3 characters);
+`global-search` and `players?search=` leave that to the client.
+
+The value of pinning behaviour nobody intends to change: when this route is eventually retired, the
+failing tests are the checklist of what retiring it actually breaks.
+
+## Extending
+
+Add to `SearchTestFixtures` rather than building `PersonalSetting` or `Rank` inline — the constructors
+carry defaults (`ProfilePicture.Default()` randomises `PictureId`) that make ad-hoc fixtures flaky.
+
+When adding a test for a consumer-visible guarantee, name the consumer in a comment. Several assertions
+here look arbitrary until you know which client would break, and that context is the difference between a
+future maintainer fixing the code and "fixing" the test.

--- a/WC3ChampionsStatisticService.UnitTests/Search/README.md
+++ b/WC3ChampionsStatisticService.UnitTests/Search/README.md
@@ -139,8 +139,8 @@ The tests pin the hybrid response: one flat array holding a ranked block scoped 
 fork on via `player.games > 0`. `Hybrid_TailIsNotScopedToTheRequestedContext` records the reason an
 exact-tag search can return the same player twice.
 
-This route is also the only search endpoint that enforces a minimum length server-side (3 characters);
-`global-search` and `players?search=` leave that to the client.
+This route and `global-search` both enforce a minimum length server-side (3 characters);
+`players?search=` leaves that to the client.
 
 The value of pinning behaviour nobody intends to change: when this route is eventually retired, the
 failing tests are the checklist of what retiring it actually breaks.

--- a/WC3ChampionsStatisticService.UnitTests/Search/RanksForPlayersTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Search/RanksForPlayersTests.cs
@@ -1,0 +1,219 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.Ladder;
+using W3ChampionsStatisticService.Ports;
+using static WC3ChampionsStatisticService.UnitTests.Search.SearchTestFixtures;
+
+namespace WC3ChampionsStatisticService.UnitTests.Search;
+
+// POST api/ladder/ranks-for-players — rank-in-context enrichment.
+//
+// The second half of the consolidated flow: global-search returns a page of directory hits, this
+// endpoint annotates that page with ladder rank for one {season, gateway, gameMode}. Players absent
+// from the response are unranked in that context — absence is the signal, there is no "unranked" row.
+[TestFixture]
+public class RanksForPlayersTests
+{
+    private Mock<IRankRepository> _rankRepo;
+    private Mock<IPlayerRepository> _playerRepo;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _rankRepo = new Mock<IRankRepository>();
+        _playerRepo = new Mock<IPlayerRepository>();
+    }
+
+    private LadderController CreateController()
+    {
+        return LadderControllerWith(_rankRepo.Object, _playerRepo.Object);
+    }
+
+    private void EnrichmentReturns(params Rank[] ranks)
+    {
+        _rankRepo
+            .Setup(r => r.LoadRanksForPlayers(
+                It.IsAny<List<string>>(), It.IsAny<int>(), It.IsAny<GateWay>(), It.IsAny<GameMode>()))
+            .ReturnsAsync([.. ranks]);
+    }
+
+    private static List<RankInContext> RanksOf(IActionResult result)
+    {
+        return (List<RankInContext>)((OkObjectResult)result).Value;
+    }
+
+    // --- Request validation -------------------------------------------------------------------
+    //
+    // The route is anonymous, so the bound on batch size is what keeps the $in query small.
+
+    [Test]
+    public async Task Validation_NullRequestReturnsEmptyList_NotAnError()
+    {
+        // A caller with nothing to enrich should get an empty enrichment, not a 400 to handle.
+        var result = await CreateController().GetRanksForPlayers(null);
+
+        Assert.IsEmpty(RanksOf(result));
+    }
+
+    [Test]
+    public async Task Validation_NullBattleTagsReturnsEmptyList()
+    {
+        var result = await CreateController().GetRanksForPlayers(Request(null));
+
+        Assert.IsEmpty(RanksOf(result));
+    }
+
+    [Test]
+    public async Task Validation_EmptyBattleTagsReturnsEmptyList()
+    {
+        var result = await CreateController().GetRanksForPlayers(Request([]));
+
+        Assert.IsEmpty(RanksOf(result));
+    }
+
+    [Test]
+    public async Task Validation_EmptyRequestDoesNotHitTheRepository()
+    {
+        await CreateController().GetRanksForPlayers(Request([]));
+
+        _rankRepo.Verify(
+            r => r.LoadRanksForPlayers(
+                It.IsAny<List<string>>(), It.IsAny<int>(), It.IsAny<GateWay>(), It.IsAny<GameMode>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task Validation_AtTheBatchLimitIsAccepted()
+    {
+        var tags = Enumerable.Range(1, RanksForPlayersRequest.MaxBattleTags)
+            .Select(i => $"Player{i}#{i}")
+            .ToList();
+        EnrichmentReturns();
+
+        var result = await CreateController().GetRanksForPlayers(Request(tags));
+
+        Assert.IsInstanceOf<OkObjectResult>(result);
+    }
+
+    [Test]
+    public async Task Validation_OverTheBatchLimitIsRejected()
+    {
+        var tags = Enumerable.Range(1, RanksForPlayersRequest.MaxBattleTags + 1)
+            .Select(i => $"Player{i}#{i}")
+            .ToList();
+
+        var result = await CreateController().GetRanksForPlayers(Request(tags));
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
+
+    // --- Context scoping ----------------------------------------------------------------------
+    //
+    // The whole point of the endpoint: a rank is only meaningful inside one season/gateway/gameMode.
+    // The pre-existing 2-argument overload filters by season alone and must not be the one called.
+
+    [Test]
+    public async Task Context_AllFourScopingArgumentsReachTheRepository()
+    {
+        EnrichmentReturns();
+
+        await CreateController().GetRanksForPlayers(
+            Request(["Moon#1"], season: 13, gateWay: GateWay.America, gameMode: GameMode.GM_2v2_AT));
+
+        _rankRepo.Verify(
+            r => r.LoadRanksForPlayers(
+                It.Is<List<string>>(t => t.Count == 1 && t[0] == "Moon#1"),
+                13,
+                GateWay.America,
+                GameMode.GM_2v2_AT),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task Context_TheSeasonOnlyOverloadIsNotUsed()
+    {
+        EnrichmentReturns();
+
+        await CreateController().GetRanksForPlayers(Request(["Moon#1"]));
+
+        _rankRepo.Verify(
+            r => r.LoadRanksForPlayers(It.IsAny<List<string>>(), It.IsAny<int>()),
+            Times.Never);
+    }
+
+    // --- Response mapping ---------------------------------------------------------------------
+
+    [Test]
+    public async Task Mapping_RankBecomesRankInContext()
+    {
+        EnrichmentReturns(RankFor("Moon#1", league: 2, rankNumber: 42, rankingPoints: 1234));
+
+        var result = await CreateController().GetRanksForPlayers(Request(["Moon#1"]));
+
+        var ranks = RanksOf(result);
+        Assert.AreEqual(1, ranks.Count);
+        Assert.AreEqual("Moon#1", ranks[0].Players.Single().BattleTag);
+        Assert.AreEqual(2, ranks[0].League);
+        Assert.AreEqual(42, ranks[0].RankNumber);
+        Assert.AreEqual(1234, ranks[0].RankingPoints);
+    }
+
+    [Test]
+    public async Task Mapping_LeagueAndRankNumberSurvive_TheyDriveScrollToRow()
+    {
+        // The website scrolls to a ladder row using league (to load the right list) and rankNumber
+        // (the DOM anchor). Dropping either silently breaks that navigation.
+        EnrichmentReturns(RankFor("Moon#1", league: 3, rankNumber: 501));
+
+        var result = await CreateController().GetRanksForPlayers(Request(["Moon#1"]));
+
+        var rank = RanksOf(result).Single();
+        Assert.AreEqual(3, rank.League);
+        Assert.AreEqual(501, rank.RankNumber);
+    }
+
+    [Test]
+    public async Task Mapping_RaceIsCarried_ForPerRace1v1Ladders()
+    {
+        EnrichmentReturns(
+            RankFor("Moon#1", league: 1, rankNumber: 500, race: Race.HU),
+            RankFor("Moon#1", league: 3, rankNumber: 501, race: Race.UD));
+
+        var result = await CreateController().GetRanksForPlayers(Request(["Moon#1"]));
+
+        var ranks = RanksOf(result);
+        CollectionAssert.AreEquivalent(
+            new Race?[] { Race.HU, Race.UD },
+            ranks.Select(r => r.Race).ToList());
+    }
+
+    [Test]
+    public async Task Mapping_UnrankedPlayersAreAbsent_RatherThanZeroed()
+    {
+        // Two tags requested, one ranked. The other must simply not appear — the caller synthesises
+        // its own "unranked" row. A zeroed row here is what produced the old duplicate-result bug.
+        EnrichmentReturns(RankFor("Moon#1"));
+
+        var result = await CreateController().GetRanksForPlayers(Request(["Moon#1", "Grubby#2"]));
+
+        var ranks = RanksOf(result);
+        Assert.AreEqual(1, ranks.Count);
+        Assert.AreEqual("Moon#1", ranks[0].Players.Single().BattleTag);
+    }
+
+    [Test]
+    public async Task Mapping_NoMatchesReturnsAnEmptyList()
+    {
+        EnrichmentReturns();
+
+        var result = await CreateController().GetRanksForPlayers(Request(["Nobody#1"]));
+
+        Assert.IsEmpty(RanksOf(result));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Search/SearchTestFixtures.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Search/SearchTestFixtures.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using MongoDB.Driver;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.CommonValueObjects;
+using W3ChampionsStatisticService.Cache;
+using W3ChampionsStatisticService.Ladder;
+using W3ChampionsStatisticService.PersonalSettings;
+using W3ChampionsStatisticService.PlayerProfiles;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.Services;
+
+namespace WC3ChampionsStatisticService.UnitTests.Search;
+
+// Shared builders for the search suite. These tests run without Mongo — see README.md in this folder
+// for why, and for the seam that makes it possible.
+public static class SearchTestFixtures
+{
+    // A PersonalSetting is the unit of global-search's directory: matching runs over its Id (the
+    // battleTag) and the response carries its ProfilePicture.
+    public static PersonalSetting Setting(
+        string battleTag,
+        AvatarCategory race = AvatarCategory.HU,
+        long pictureId = 1)
+    {
+        return new PersonalSetting(battleTag)
+        {
+            ProfilePicture = new ProfilePicture { Race = race, PictureId = pictureId },
+        };
+    }
+
+    public static List<PersonalSetting> Settings(params string[] battleTags)
+    {
+        var list = new List<PersonalSetting>();
+        foreach (var tag in battleTags)
+        {
+            list.Add(Setting(tag));
+        }
+        return list;
+    }
+
+    // Builds a PlayerService whose directory is exactly `directory`, with no database behind it.
+    //
+    // The seam: PersonalSettingsProvider.GetPersonalSettingsAsync delegates to
+    // ICachedDataProvider.GetCachedOrRequestAsync(fetchFromMongo, key). Mocking the cache to return a
+    // value WITHOUT invoking the callback means the Mongo fetch is never reached, so the MongoClient
+    // handed to the provider is inert. MongoClient's constructor does not open a connection.
+    public static PlayerService PlayerServiceWith(
+        List<PersonalSetting> directory,
+        Mock<IPlayerRepository> playerRepository = null,
+        Mock<IRankRepository> rankRepository = null)
+    {
+        var cache = new Mock<ICachedDataProvider<List<PersonalSetting>>>();
+        cache
+            .Setup(c => c.GetCachedOrRequestAsync(
+                It.IsAny<Func<Task<List<PersonalSetting>>>>(),
+                It.IsAny<string>(),
+                It.IsAny<TimeSpan?>()))
+            .ReturnsAsync(directory);
+
+        var settingsProvider = new PersonalSettingsProvider(
+            new MongoClient("mongodb://localhost:27017"),
+            cache.Object);
+
+        var repo = playerRepository ?? EmptyPlayerRepository();
+        var ranks = rankRepository ?? EmptyRankRepository();
+
+        return new PlayerService(repo.Object, null, settingsProvider, ranks.Object);
+    }
+
+    // Default: nobody is ranked, so a context search puts every hit in the unranked block.
+    public static Mock<IRankRepository> EmptyRankRepository()
+    {
+        return RankRepositoryWith();
+    }
+
+    // A rank repository whose ladder is exactly `ranks`, honouring the season/gateway/gameMode filter
+    // the way the real methods do. Both are stubbed from the same ladder so a test cannot have the
+    // search core and the enrichment call disagree about who is ranked — the real implementations
+    // return the same row set, and a fixture that let them drift would hide that.
+    public static Mock<IRankRepository> RankRepositoryWith(params Rank[] ranks)
+    {
+        var repo = new Mock<IRankRepository>();
+
+        List<Rank> OnLadder(List<string> tags, int season, GateWay gateWay, GameMode gameMode) =>
+            ranks.Where(r =>
+                r.MemberIds.Any(tags.Contains)
+                && r.Season == season
+                && r.Gateway == gateWay
+                && r.GameMode == gameMode).ToList();
+
+        repo
+            .Setup(r => r.LoadRanksForPlayers(
+                It.IsAny<List<string>>(),
+                It.IsAny<int>(),
+                It.IsAny<GateWay>(),
+                It.IsAny<GameMode>()))
+            .ReturnsAsync((List<string> tags, int season, GateWay gateWay, GameMode gameMode) =>
+                OnLadder(tags, season, gateWay, gameMode));
+
+        repo
+            .Setup(r => r.LoadLadderStandings(
+                It.IsAny<List<string>>(),
+                It.IsAny<int>(),
+                It.IsAny<GateWay>(),
+                It.IsAny<GameMode>()))
+            .ReturnsAsync((List<string> tags, int season, GateWay gateWay, GameMode gameMode) =>
+                OnLadder(tags, season, gateWay, gameMode)
+                    .Select(r => new PlayerLadderStanding
+                    {
+                        MemberIds = r.MemberIds,
+                        League = r.League,
+                        RankNumber = r.RankNumber,
+                    })
+                    .ToList());
+
+        return repo;
+    }
+
+    // Default: no PlayerOverallStats for anyone, so Seasons stays empty.
+    public static Mock<IPlayerRepository> EmptyPlayerRepository()
+    {
+        var repo = new Mock<IPlayerRepository>();
+        repo
+            .Setup(r => r.GetPlayerBattleTagsAsync(It.IsAny<ICollection<string>>()))
+            .ReturnsAsync(new Dictionary<string, PlayerOverallStats>());
+        return repo;
+    }
+
+    public static Mock<IPlayerRepository> PlayerRepositoryWithSeasons(
+        Dictionary<string, PlayerOverallStats> statsByBattleTag)
+    {
+        var repo = new Mock<IPlayerRepository>();
+        repo
+            .Setup(r => r.GetPlayerBattleTagsAsync(It.IsAny<ICollection<string>>()))
+            .ReturnsAsync(statsByBattleTag);
+        return repo;
+    }
+
+    public static PlayerOverallStats StatsWithSeasons(string battleTag, params int[] seasonIds)
+    {
+        var stats = PlayerOverallStats.Create(battleTag);
+        foreach (var id in seasonIds)
+        {
+            stats.ParticipatedInSeasons.Add(new Season(id));
+        }
+        return stats;
+    }
+
+    // An AT team rank of any size — members beyond the second exist only in MemberIds.
+    public static Rank TeamRankFor(
+        string[] members,
+        int league = 1,
+        int rankNumber = 5,
+        GateWay gateWay = GateWay.Europe,
+        GameMode gameMode = GameMode.GM_2v2_AT,
+        int season = 13)
+    {
+        return new Rank([.. members], league, rankNumber, 500, null, gateWay, gameMode, season)
+        {
+            Players =
+            [
+                PlayerOverview.Create(
+                    members.Select(PlayerId.Create).ToList(),
+                    gateWay,
+                    gameMode,
+                    season,
+                    null),
+            ],
+        };
+    }
+
+    public static Rank RankFor(
+        string battleTag,
+        int league = 1,
+        int rankNumber = 5,
+        double rankingPoints = 500,
+        Race? race = null,
+        GateWay gateWay = GateWay.Europe,
+        GameMode gameMode = GameMode.GM_1v1,
+        int season = 13)
+    {
+        return new Rank([battleTag], league, rankNumber, rankingPoints, race, gateWay, gameMode, season)
+        {
+            Players =
+            [
+                PlayerOverview.Create(
+                    [PlayerId.Create(battleTag)],
+                    gateWay,
+                    gameMode,
+                    season,
+                    race),
+            ],
+        };
+    }
+
+    // Body for POST api/ladder/ranks-for-players with the suite's defaults.
+    public static RanksForPlayersRequest Request(
+        List<string> battleTags,
+        int season = 13,
+        GateWay gateWay = GateWay.Europe,
+        GameMode gameMode = GameMode.GM_1v1)
+    {
+        return new RanksForPlayersRequest
+        {
+            BattleTags = battleTags,
+            Season = season,
+            GateWay = gateWay,
+            GameMode = gameMode,
+        };
+    }
+
+    // The two controllers under test, with every dependency the search actions never reach nulled.
+    public static PlayersController PlayersControllerWith(IPlayerRepository playerRepo = null, PlayerService playerService = null)
+    {
+        return new PlayersController(
+            playerRepo ?? EmptyPlayerRepository().Object,
+            null, // GameModeStatQueryHandler
+            null, // IPersonalSettingsRepository
+            null, // IClanRepository
+            null, // PlayerAkaProvider
+            playerService,
+            null, // IBattleTagResolver
+            null); // ChatDetailsQueryHandler
+    }
+
+    public static LadderController LadderControllerWith(IRankRepository rankRepo, IPlayerRepository playerRepo)
+    {
+        return new LadderController(rankRepo, playerRepo, null, null, null);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Search/SearchTestFixtures.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Search/SearchTestFixtures.cs
@@ -113,8 +113,7 @@ public static class SearchTestFixtures
                     .Select(r => new PlayerLadderStanding
                     {
                         MemberIds = r.MemberIds,
-                        League = r.League,
-                        RankNumber = r.RankNumber,
+                        RankingPoints = r.RankingPoints,
                     })
                     .ToList());
 
@@ -156,11 +155,12 @@ public static class SearchTestFixtures
         string[] members,
         int league = 1,
         int rankNumber = 5,
+        double rankingPoints = 500,
         GateWay gateWay = GateWay.Europe,
         GameMode gameMode = GameMode.GM_2v2_AT,
         int season = 13)
     {
-        return new Rank([.. members], league, rankNumber, 500, null, gateWay, gameMode, season)
+        return new Rank([.. members], league, rankNumber, rankingPoints, null, gateWay, gameMode, season)
         {
             Players =
             [

--- a/WC3ChampionsStatisticService.UnitTests/Search/SubscriberContractTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Search/SubscriberContractTests.cs
@@ -1,0 +1,320 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using W3C.Contracts.GameObjects;
+using W3C.Contracts.Matchmaking;
+using W3ChampionsStatisticService.Ladder;
+using W3ChampionsStatisticService.PlayerProfiles;
+using W3ChampionsStatisticService.PlayerProfiles.GlobalSearch;
+using W3ChampionsStatisticService.Ports;
+using static WC3ChampionsStatisticService.UnitTests.Search.SearchTestFixtures;
+
+namespace WC3ChampionsStatisticService.UnitTests.Search;
+
+// SUBSCRIBER CONTRACTS — what backend changes must not break.
+//
+// This file exists for one purpose: every test here is a promise made to a real, identified client
+// that ships today. A failure means a backend change has broken a known subscriber, not that a
+// refactor needs tidying up.
+//
+// It is deliberately separate from the other suites in this folder. GlobalSearchTests and
+// RanksForPlayersTests verify that the search behaves correctly. These verify that it still behaves
+// the way a specific subscriber already relies on. The overlap is intentional — a logic test can be
+// legitimately rewritten when the logic changes, and that must not silently take a subscriber
+// guarantee with it.
+//
+// Each test states its subscriber and the exact call that subscriber makes. Where a subscriber's
+// source is known, the call site is cited so the claim can be re-checked rather than trusted.
+//
+// Registry of subscribers (audited 2026-07-18):
+//   1. Website          — this repo's frontend, both the flag-on and flag-off paths.
+//   2. launcher-e       — the Tauri launcher. Active, shipped.
+//   3. In-game UI       — storage.w3champions.com/{env}/integration/w3champions.js, loaded by the
+//                         WC3 glue UI that the deprecated Electron launcher installs. Source repo
+//                         UNIDENTIFIED, so it can never be migrated on demand — treat as frozen.
+//
+// LIMITS OF THIS FILE — read before trusting it:
+//   - These run at the controller boundary, so routing, model binding and JSON serialisation are NOT
+//     exercised. A change to serialiser configuration (casing, null handling, enum-as-string) could
+//     break a subscriber with every test here still green.
+//   - Adding a subscriber means adding tests here by hand. Nothing discovers them.
+//   - A subscriber that changes what it needs will not be reflected here until someone updates it.
+//     That direction is intentionally unprotected: this file guards subscribers against the backend,
+//     not the backend against subscribers.
+[TestFixture]
+public class SubscriberContractTests
+{
+    private Mock<IRankRepository> _rankRepo;
+    private Mock<IPlayerRepository> _playerRepo;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _rankRepo = new Mock<IRankRepository>();
+        _playerRepo = new Mock<IPlayerRepository>();
+    }
+
+    private static PlayersController PlayersControllerOver(List<W3ChampionsStatisticService.PersonalSettings.PersonalSetting> directory)
+    {
+        return PlayersControllerWith(playerService: PlayerServiceWith(directory));
+    }
+
+    private LadderController LadderController()
+    {
+        return LadderControllerWith(_rankRepo.Object, _playerRepo.Object);
+    }
+
+    private void EnrichmentReturns(params Rank[] ranks)
+    {
+        _rankRepo
+            .Setup(r => r.LoadRanksForPlayers(It.IsAny<List<string>>(), It.IsAny<int>(), It.IsAny<GateWay>(), It.IsAny<GameMode>()))
+            .ReturnsAsync([.. ranks]);
+    }
+
+    private static List<RankInContext> RanksOf(IActionResult result)
+    {
+        return (List<RankInContext>)((OkObjectResult)result).Value;
+    }
+
+    private static List<PlayerSearchInfo> SearchResult(IActionResult result)
+    {
+        Assert.IsInstanceOf<OkObjectResult>(result, "subscribers treat any non-200 as a failure");
+        return (List<PlayerSearchInfo>)((OkObjectResult)result).Value;
+    }
+
+    // =========================================================================================
+    // SUBSCRIBER: launcher-e  (Tauri launcher — active, shipped)
+    // Call site: src/services/player-search.service.ts:48
+    // Store:     src/models/player-search.ts:40-63
+    // =========================================================================================
+
+    [Test]
+    public async Task LauncherE_GlobalSearch_ReturnsABareArray()
+    {
+        // player-search.service.ts:56 casts the body directly to IPlayerSearchResult[]. Wrapping the
+        // response in a paging envelope — however reasonable an API improvement — breaks it outright.
+        var result = await PlayersControllerOver(Settings("Moon#1")).GlobalSearchPlayer("moon");
+
+        Assert.IsInstanceOf<List<PlayerSearchInfo>>(((OkObjectResult)result).Value);
+    }
+
+    [Test]
+    public async Task LauncherE_GlobalSearch_HonoursPageSizeTenExactly()
+    {
+        // player-search.ts:63 sets hasMore = (received == PAGE_SIZE), with PAGE_SIZE = 10. If the
+        // backend substitutes its own page size, that comparison is false on a full page and the
+        // launcher's infinite scroll stops after page one — silently, with no error anywhere.
+        var directory = Settings(Enumerable.Range(1, 40).Select(i => $"Moon{i:00}#{i}").ToArray());
+
+        var result = await PlayersControllerOver(directory).GlobalSearchPlayer("moon", pageSize: 10);
+
+        Assert.AreEqual(10, SearchResult(result).Count);
+    }
+
+    [Test]
+    public async Task LauncherE_GlobalSearch_ItemsCarryEveryFieldItDereferences()
+    {
+        // PlayerSearch.tsx:150,154,162 and player-search.ts:43. None of these are null-guarded on the
+        // launcher side, so a null here is a TypeError in a shipped desktop client.
+        var directory = Settings("Moon#1", "Moonlight#2");
+
+        var result = await PlayersControllerOver(directory).GlobalSearchPlayer("moon");
+
+        foreach (var item in SearchResult(result))
+        {
+            Assert.IsNotNull(item.BattleTag, "PlayerSearch.tsx:150 calls .split('#') on it");
+            Assert.IsNotEmpty(item.RelevanceId, "player-search.ts:43 uses it as the paging cursor");
+            Assert.IsNotNull(item.ProfilePicture, "PlayerSearch.tsx:154 reads .race/.pictureId/.isClassic");
+            Assert.IsNotNull(item.Seasons, "PlayerSearch.tsx:162 maps over it");
+        }
+    }
+
+    [Test]
+    public async Task LauncherE_GlobalSearch_CursorPagingAdvancesWithoutRepeating()
+    {
+        // The launcher appends pages rather than replacing them (player-search.ts:25), so a repeated
+        // entry becomes a visible duplicate row rather than a silent no-op.
+        var directory = Settings(Enumerable.Range(1, 40).Select(i => $"Moon{i:00}#{i}").ToArray());
+        var controller = PlayersControllerOver(directory);
+
+        var page1 = SearchResult(await controller.GlobalSearchPlayer("moon", pageSize: 10));
+        var page2 = SearchResult(await controller.GlobalSearchPlayer(
+            "moon", lastRelevanceId: page1.Last().RelevanceId, pageSize: 10));
+
+        CollectionAssert.IsEmpty(
+            page1.Select(p => p.BattleTag).Intersect(page2.Select(p => p.BattleTag)));
+    }
+
+    [Test]
+    public async Task LauncherE_GlobalSearch_EmptyResultIsAnEmptyArrayNotAnError()
+    {
+        // A non-200 is mapped to null and then to "clear the list" (player-search.ts:64-69), which
+        // renders identically to a failed request. No-matches must stay a 200.
+        var result = await PlayersControllerOver(Settings("Grubby#1")).GlobalSearchPlayer("moon");
+
+        Assert.IsEmpty(SearchResult(result));
+    }
+
+    // =========================================================================================
+    // SUBSCRIBER: In-game UI bundle  (FROZEN — source repo unidentified)
+    // storage.w3champions.com/{env}/integration/w3champions.js
+    // Call site: StatisticsClient.prototype.searchRankings
+    // =========================================================================================
+
+    [Test]
+    public async Task InGameUi_LadderSearch_AcceptsItsExactCallShape()
+    {
+        // The bundle builds: api/ladder/search?gateWay={gw}&searchFor={name}&gameMode={gm}&season={s}
+        // and passes EGateway.Europe with the user's current mode filter and selected season.
+        _rankRepo
+            .Setup(r => r.SearchPlayerOfLeague(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<GateWay>(), It.IsAny<GameMode>()))
+            .ReturnsAsync([]);
+        _playerRepo.Setup(p => p.SearchForPlayer(It.IsAny<string>())).ReturnsAsync([]);
+
+        var result = await LadderController().SearchPlayer("moon", 13, GateWay.Europe, GameMode.GM_1v1);
+
+        Assert.IsInstanceOf<OkObjectResult>(result);
+    }
+
+    [Test]
+    public async Task InGameUi_LadderSearch_StillReturnsTheHybridArrayItForksOn()
+    {
+        // The bundle distinguishes ranked from unranked by player.games > 0 on a single flat array.
+        // Splitting this into two collections, or dropping the zeroed tail, breaks a client that
+        // cannot be patched on our schedule.
+        _rankRepo
+            .Setup(r => r.SearchPlayerOfLeague(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<GateWay>(), It.IsAny<GameMode>()))
+            .ReturnsAsync([RankFor("Moon#1", league: 2, rankNumber: 42)]);
+        _playerRepo
+            .Setup(p => p.SearchForPlayer(It.IsAny<string>()))
+            .ReturnsAsync([PlayerOverallStats.Create("Moonlight#2")]);
+
+        var result = await LadderController().SearchPlayer("moon", 13);
+
+        var rows = (List<Rank>)((OkObjectResult)result).Value;
+        Assert.AreEqual(2, rows.Count, "one flat array holding both blocks");
+        Assert.IsNotNull(rows[0].Player, "every row carries a player object the client dereferences");
+        Assert.IsNotNull(rows[1].Player);
+    }
+
+    [Test]
+    public async Task InGameUi_LadderSearch_MinimumLengthIsStillThree()
+    {
+        // The bundle guards on searchPhrase.length >= 3 before calling. Raising the server-side
+        // minimum would reject calls it considers valid.
+        _rankRepo
+            .Setup(r => r.SearchPlayerOfLeague(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<GateWay>(), It.IsAny<GameMode>()))
+            .ReturnsAsync([]);
+        _playerRepo.Setup(p => p.SearchForPlayer(It.IsAny<string>())).ReturnsAsync([]);
+
+        Assert.IsInstanceOf<OkObjectResult>(await LadderController().SearchPlayer("moo", 13));
+    }
+
+    [Test]
+    public void InGameUi_LadderSearch_MemberIdsStaysOffTheWire()
+    {
+        // MemberIds exists for the database lookup only. Rank rows serialize straight out of
+        // api/ladder/search, so dropping the JsonIgnore would change the wire shape of every
+        // rank-returning legacy endpoint.
+        var json = System.Text.Json.JsonSerializer.Serialize(TeamRankFor(["Moon#1", "Mate#2"]));
+
+        Assert.IsFalse(json.ToLowerInvariant().Contains("memberids"), "Rank.MemberIds leaked into the response JSON");
+    }
+
+    // =========================================================================================
+    // SUBSCRIBER: Website  (this repo's frontend)
+    // =========================================================================================
+
+    [Test]
+    public async Task Website_GlobalSearch_HonoursPageSizeTwentyExactly()
+    {
+        // Both the header store (globalSearch/store.ts:24) and the ladder search use
+        // hasMore = (received == PAGE_SIZE) with PAGE_SIZE = 20 — the same heuristic launcher-e uses.
+        var directory = Settings(Enumerable.Range(1, 60).Select(i => $"Moon{i:00}#{i}").ToArray());
+
+        var result = await PlayersControllerOver(directory).GlobalSearchPlayer("moon", pageSize: 20);
+
+        Assert.AreEqual(20, SearchResult(result).Count);
+    }
+
+    [Test]
+    public async Task Website_RanksForPlayers_CarriesTheFieldsScrollToRowNeeds()
+    {
+        // ranking/store.ts:54,59 read league and rankNumber. league selects which ladder page to load,
+        // rankNumber is the DOM anchor (#listitem_{n}). Losing either breaks click-to-ladder-row
+        // without breaking anything visible in the search dropdown itself.
+        EnrichmentReturns(RankFor("Moon#1", league: 3, rankNumber: 501, rankingPoints: 420));
+
+        var result = await LadderController().GetRanksForPlayers(Request(["Moon#1"]));
+
+        var rank = RanksOf(result).Single();
+        Assert.AreEqual(3, rank.League);
+        Assert.AreEqual(501, rank.RankNumber);
+        Assert.AreEqual(420, rank.RankingPoints);
+    }
+
+    [Test]
+    public async Task Website_RanksForPlayers_CarriesPlayerIdentityAndGateway()
+    {
+        // ranking/store.ts:45 builds a row key as `${battleTag}@${gateWay}` joined across players, and
+        // :64 reads players[0].name for the display row.
+        EnrichmentReturns(RankFor("Moon#1", gateWay: GateWay.America));
+
+        var result = await LadderController().GetRanksForPlayers(Request(["Moon#1"], gateWay: GateWay.America));
+
+        var rank = RanksOf(result).Single();
+        Assert.AreEqual(GateWay.America, rank.GateWay);
+        Assert.IsNotEmpty(rank.Players, "the row key is built from players[]");
+        Assert.AreEqual("Moon#1", rank.Players[0].BattleTag);
+        Assert.IsNotNull(rank.Players[0].Name, "store.ts:64 reads players[0].name");
+    }
+
+    [Test]
+    public async Task Website_RanksForPlayers_CarriesRaceSoPerRaceRowsStaySeparate()
+    {
+        // 1v1 is ranked per race, so one battleTag can hold several ranks. store.ts:24-34 keys them by
+        // tag and relies on race to keep the rows distinct rather than collapsing them.
+        EnrichmentReturns(
+            RankFor("Moon#1", league: 1, rankNumber: 500, race: Race.HU),
+            RankFor("Moon#1", league: 3, rankNumber: 501, race: Race.UD));
+
+        var result = await LadderController().GetRanksForPlayers(Request(["Moon#1"]));
+
+        var ranks = RanksOf(result);
+        Assert.AreEqual(2, ranks.Count);
+        CollectionAssert.AreEquivalent(new Race?[] { Race.HU, Race.UD }, ranks.Select(r => r.Race).ToList());
+    }
+
+    [Test]
+    public async Task Website_LegacyLadderSearchStillServes_ItIsTheRollbackPath()
+    {
+        // USE_NEW_SEARCH=false routes the ladder back to api/ladder/search. It must keep working for
+        // the flag to be a real rollback lever rather than a decoration.
+        _rankRepo
+            .Setup(r => r.SearchPlayerOfLeague(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<GateWay>(), It.IsAny<GameMode>()))
+            .ReturnsAsync([]);
+        _playerRepo.Setup(p => p.SearchForPlayer(It.IsAny<string>())).ReturnsAsync([]);
+
+        Assert.IsInstanceOf<OkObjectResult>(await LadderController().SearchPlayer("moon", 13));
+    }
+
+    [Test]
+    public async Task Website_LegacyPlayerSearchStillServes_ItIsThePickersRollbackPath()
+    {
+        // The other half of the same lever: with the flag off, PlayerSearch.vue — the shared picker
+        // behind ~12 admin/clan/profile surfaces — goes back to api/players/?search=.
+        _playerRepo
+            .Setup(p => p.SearchForPlayer(It.IsAny<string>()))
+            .ReturnsAsync([PlayerOverallStats.Create("Moon#1")]);
+
+        var controller = new PlayersController(_playerRepo.Object, null, null, null, null, null, null, null);
+
+        var result = await controller.SearchPlayer("moon");
+
+        var players = (List<PlayerOverallStats>)((OkObjectResult)result).Value;
+        Assert.AreEqual("Moon#1", players[0].BattleTag, "the picker consumes battleTag off these rows");
+    }
+}

--- a/docs/PLAYER_SEARCH_CONSOLIDATION.md
+++ b/docs/PLAYER_SEARCH_CONSOLIDATION.md
@@ -1,0 +1,301 @@
+# Player search consolidation
+
+One search core serves every place the site looks a player up by name. Rank data is a separate
+follow-up call, made only where a ladder is on screen.
+
+- [Shape](#shape)
+- [Relevance](#relevance)
+- [Paging](#paging)
+- [Guards](#guards)
+- [Consumers](#consumers)
+- [Rollout and rollback](#rollout-and-rollback)
+- [Rank storage and lookup](#rank-storage-and-lookup)
+- [Retirement](#retirement)
+
+> Render the diagrams with VS Code's Mermaid preview, GitHub, or
+> `npx @mermaid-js/mermaid-cli -i docs/PLAYER_SEARCH_CONSOLIDATION.md -o search.svg`.
+
+## Shape
+
+`api/players/global-search` is the core (`PlayersController.cs:46` →
+`PlayerService.GlobalSearchForPlayer`, `Services/PlayerService.cs:89`). It matches the search text
+against the PersonalSettings directory held in memory, orders by relevance, and returns a page of
+refs: battleTag, name, seasons and avatar. It pages by cursor and validates its own input, so those
+guards live in one place instead of in each caller — see [Guards](#guards).
+
+Rank is not part of a ref. A caller with a ladder on screen follows up with
+`POST api/ladder/ranks-for-players`, which annotates the page it just received with rank in one
+season, gateway and game mode. A player missing from that response holds no rank there.
+
+```mermaid
+flowchart LR
+  H["Header<br/>GlobalSearch.vue"] --> CORE
+  P["Player picker<br/>PlayerSearch.vue<br/>13 embeds"] --> CORE
+  R["Ladder<br/>Rankings.vue"] -->|"+ season, gateway, gameMode"| CORE
+  CORE["api/players/global-search<br/>relevance · paged · guarded"] --> REFS[/"refs<br/>battleTag · name · seasons · avatar"/]
+  REFS -->|"header, picker"| USE(["rendered as-is"])
+  REFS -->|"ladder"| ENR["api/ladder/ranks-for-players"]
+  ENR --> RANK[/"mmr · W-L · league · rankNumber<br/>absent = unranked"/]
+```
+
+The two searches this replaces, `api/players/?search=` (`PlayersController.cs:134`) and
+`api/ladder/search` (`LadderController.cs:29`), stay live and unmodified. A frontend flag chooses
+between them and the core.
+
+**The directory decides who can be found** — the one change in *which* players a search can return.
+The core looks names up in the settings collection, a record per player who has settings; the
+searches it replaces looked in the stats collection, a record per player who has finished a game.
+Most players are in both — 47,141 in a 2022 snapshot — but 5,193 exist only in the stats collection
+and stop being findable, while 4,615 exist only in the settings collection and become findable for
+the first time. Which of the two a name search ought to mean is a question of its own; this design
+takes the answer the core already gave.
+
+**Enrichment is a lookup, not a second search.** It takes the exact battleTags the core returned.
+Partial-name matching happens once, in the core.
+
+### What each call asks
+
+|  | `global-search` | `ranks-for-players` |
+|---|---|---|
+| Question | which matches are on this ladder, and where do they stand | for these exact players, what do I display |
+| Scope | the whole match set — standing decides the page cut | the ≤20 tags the core returned |
+| Reads | `RankingPoints` | mmr, W-L, games, race, league, rankNumber |
+| Backed by | `RankRepository.LoadLadderStandings` | `RankRepository.LoadRanksForPlayers` (`:279`) |
+| Returns | ordering, encoded in `relevanceId` | the rank rows |
+
+`LoadLadderStandings` exists so the ordering query fetches only the one field it actually reads.
+Both queries `$lookup` `PlayerOverview` and drop ranks that fail to join. The join is what keeps the
+two calls in agreement on who counts as ranked: orphaned ranks are real — 379 in season 13 / 2v2
+AT — and an ordering query that skipped the join would sort them into the ranked block while
+enrichment returned nothing for them.
+
+The split reads the same rank rows twice — once for each match's standing, to decide who appears,
+and once for the page's full rows, to display them. One request could do both, by having the
+directory search return rank data itself when given a ladder. That would make its response shape
+depend on the context it was called with, and the context-free response is exactly what the launcher
+and the header already consume — keeping the two apart is what lets that reply stay byte-for-byte
+what it was. It also leaves rank-in-context as an endpoint of its own, usable by anything that has a
+list of players and a ladder in mind.
+
+## Relevance
+
+`global-search` takes an optional ladder context: `season`, `gateWay` and `gameMode`, all three or
+none. With a context, standing on that ladder is part of relevance. Without one, results are ordered
+by name alone and are byte-identical to what the endpoint returned before this change.
+
+A request carrying one or two of the three is rejected. The `relevanceId` doubles as the pagination
+cursor and its layout differs between the two modes, so a caller who dropped a parameter between
+pages would compare keys from two different namespaces.
+
+**The context has to reach the core.** Filtering a name-ordered page afterwards is too late: how well
+a name matches says nothing about being ranked, so the first page of name matches misses most of the
+ranked players. Searching `man` on season 13 / EU / 1v1 matches 766 players, 55 of them ranked, and a
+name-ordered page of 20 reaches none of them. Ordered by standing it reaches 20.
+
+Ordering ranked-first within each name tier does not fix it either. The tiers are larger than a page,
+so a page runs out inside an early tier and every ranked player below that point is lost.
+
+### The sort key
+
+The key is also the cursor, so it is compared as a string.
+
+| Block | Key |
+|---|---|
+| No context | `{tier}_{battleTag}` |
+| Ranked in context | `0_{99999 − round(RankingPoints × 100):D5}_{battleTag}` |
+| Unranked in context | `1_{tier}_{battleTag}` |
+
+Ranking points are the ladder's own ordering, monotone and contiguous across every league and
+division. The other rank fields are not: league ids follow creation order, so a division added
+mid-season files below leagues it outranks, and `RankNumber` restarts at 1 in every league.
+`LeagueName` is null on every stored rank and `LeagueOrder` is inconsistently populated.
+
+String comparison ascends, so higher points have to encode smaller — hence the complement. It is
+scaled by 100 to keep the ladder's 0.1-point precision, zero-padded because the comparison is
+lexical, and clamped to `[0, 99999]`. Players sharing the points floor fall back to battleTag order.
+
+The ordering has a price: a shared name can push its owner down the list. Someone of modest rank
+whose name is contained in the names of twenty better-ranked players is not at the top of the
+results for that name — typing the full battleTag goes straight to them, and scrolling reaches them
+otherwise. Putting exact matches first would not repair it: it cannot tell two players with the same
+name apart, and it would cost the best-players-first ordering on every other search.
+
+## Paging
+
+The core is cursor-paged. A caller reaching the end of the list asks for the next page with the last
+row's `relevanceId`, and the ladder runs a fresh enrichment call for each page it receives. The list
+loads further pages by itself as it is scrolled, which is how a context search reaches its unranked
+matches: they file behind every ranked one.
+
+Every page of one search carries the same ladder context — a cursor minted in one key layout cannot
+page against the other.
+
+## Guards
+
+A server guard holds for every caller, including the two clients outside the website. A client guard
+protects one surface only. So anything defending the database or the response contract belongs on the
+server, and the client guards are the ones about typing.
+
+The server guards live in `PlayersController.cs:59` onwards and in the repository:
+
+| Guard | Behaviour |
+|---|---|
+| Three letters or digits | 400. Counted over letters and digits rather than raw length, because matching is culture-sensitive: three zero-width characters measure three long and are contained in every battleTag, and with a ladder context that turns one request into a standings lookup for the whole directory. |
+| Ladder context complete | 400 when one or two of `season`, `gateWay`, `gameMode` arrive without the others, rather than honouring them partially. The cursor layouts differ between the two modes, so a caller dropping a parameter between pages would page against keys from the other namespace and silently get nothing. |
+| `pageSize` capped at 20 | Clamped, not rejected. `launcher-e` sends 10 and infers a further page from receiving exactly 10, so rejecting an oversized value would break a shipped client's paging. |
+| Enrichment batch bounded | `ranks-for-players` answers an empty list with `[]` and refuses more than 50 battleTags, keeping the anonymous route's `$in` small. |
+| Ranking points clamped | The sort key clamps to `[0, 99999]`, so a stored value outside the ladder's range cannot produce a malformed cursor. |
+| Ranked means joined | Both rank queries drop rows whose `PlayerOverview` is missing, so ordering and enrichment agree on who counts as ranked. |
+
+The server guards assume an anonymous caller, because that is what these routes have: none of them
+need a login, on either path, so the player directory can be collected from any of them — the legacy
+searches hand back every match at once, the core twenty at a time with a pointer to the next.
+Retiring the legacy routes removes the quicker way of doing it, not the possibility.
+
+The client guards live in `PlayerSearch.vue` and the ranking store. Three of them repair defects
+that predate this work and are visible on the legacy path too: the `#` encoding, the debounce
+cancel, and the scroll sentinel — which used to load the header's entire result list, page after
+page, the moment the menu opened:
+
+| Guard | Behaviour |
+|---|---|
+| Debounce 500ms, three characters | The flow fires about once per typing pause rather than per keystroke. |
+| Debounce cancelled on clear | Deleting below three characters cancels the armed timer. Without it the timer fires a search for text that is no longer in the box and repopulates a cleared list. |
+| Newest search wins | A monotonic ticket is checked after every await, twice on the ladder's two-call path. Clearing bumps it, so a reply already in flight cannot repopulate an empty box. |
+| `#` encoded | `encodeURIComponent` on both the search term and the cursor. A raw `#` starts a URL fragment and the rest of the query never reaches the server. |
+| A failed page cannot wedge the list | The append awaits inside `try`/`finally`, so a rejected request still clears the loading flag — which also gates the scroll sentinel, and would otherwise block every later append. |
+| Sentinel bound to its own list | The observer resolves the list it belongs to and appends only within 120px of that list's scrolled end, so a sentinel flashing into view during layout does not page. |
+
+## Consumers
+
+| Surface | Context it can offer | Enrichment |
+|---|---|---|
+| Header, `GlobalSearch.vue` | none | none — avatar and seasons are already in the ref |
+| `PlayerSearch.vue`, 13 embeds across 12 files | none | none — rows show the ref's avatar and seasons, and selection yields a battleTag |
+| Rankings, `Rankings.vue` | season, gateway, game mode, all on screen | rank in that context |
+
+The header and the picker have no ladder in view to pass. Rankings is the only surface that renders
+one, which is why the context is defined by what is on screen, not by which surface is calling.
+
+**The core does not serve match-scoped search.** "Who have I played" is a question about a
+relationship, not about the directory, and it carries per-pair data the directory has no notion of.
+It has its own endpoint. `PlayerSearch.vue` picks the source per embed.
+
+Two clients outside the website call these endpoints directly:
+
+| Client | Calls | What it constrains |
+|---|---|---|
+| `launcher-e` (Tauri, active) | `global-search`, `player-search.service.ts:48` | Reads `battleTag`, `relevanceId`, `profilePicture.{race,pictureId,isClassic}` and `seasons[].id`. Sends `pageSize=10` and infers a further page from receiving exactly 10, so `pageSize` must be honoured rather than substituted. |
+| In-game UI bundle, `storage.w3champions.com/{env}/integration/w3champions.js` | `ladder/search`, from `StatisticsClient.prototype.searchRankings` | A live call, shipped by the deprecated Electron launcher. Its source repository has not been identified. |
+
+`launcher-e` is unaffected: the context-free response is unchanged.
+
+## Rollout and rollback
+
+The frontend carries the flag, because it is the side with two code paths. `USE_NEW_SEARCH` is
+runtime config read from the deployed `public/env.js`, so flipping it needs no rebuild. The backend
+has no flag; it serves both endpoint sets and lets the frontend choose.
+
+1. **Backend first.** The new endpoints go live, the legacy ones are untouched, and nothing calls the
+   new ones yet. Deploying the frontend first would fail hard rather than gracefully: the `POST`
+   would match the `GET {leagueId}` route, get a 405 with an empty body, and the parse would throw
+   inside a debounce timer, leaving the spinner up.
+2. **Frontend next.** The flag reads `window._env_.USE_NEW_SEARCH ?? true` and production's `env.js`
+   carries no such key, so merging the frontend *is* the rollout.
+3. **Rollback.** Add `USE_NEW_SEARCH: false` to production's `env.js`. The legacy paths are still
+   there, unmodified, which is what makes the fallback trustworthy.
+
+**Verifying the backend deploy.** Three checks against the freshly rolled backend:
+
+- The startup log. The first boot prints `Rank MemberIds backfill filled <n> row(s) in <ms>ms`;
+  later boots print nothing, because nothing is missing. The two error shapes to watch for are a
+  logged `IndexOptionsConflict` — the failure mode described under
+  [Rank storage and lookup](#rank-storage-and-lookup) — and `Rank MemberIds backfill failed`.
+- `db.Rank.getIndexes()` lists `MemberIds_Season_Gateway_GameMode`.
+- `db.Rank.countDocuments({ MemberIds: { $exists: false } })` returns 0.
+
+The backend stays additive at the API surface. `POST ladder/ranks-for-players` is a new route,
+verb-disjoint from the `GET {leagueId}` it sits beside. `LoadRanksForPlayers` gains the ladder
+context as an overload, so `ClanCommandHandler` and `ChatDetailsQueryHandler` stay bound to the
+season-only original. Every legacy route keeps its path, verb, request and response shape.
+
+## Rank storage and lookup
+
+This design changes one existing production collection, `Rank`, in three ways: the row gains a list
+of its members, the collection gains one multikey index over that list, and a startup backfill
+brings the existing rows up to the new shape.
+
+A rank row is one ladder entry. The new `MemberIds` field (`Rank.cs:60`) lists every member of that
+entry; the long-standing `Player1Id` and `Player2Id` keep holding the first two. The list exists for
+the lookup alone and stays off the wire — `[JsonIgnore]`, pinned by a contract test — because
+serializing it would change the response shape of every legacy endpoint that returns ranks.
+
+The list is what lets an index answer the search's question. A row's id concatenates season, member
+tags and mode into one string, and the old ladder search substring-matched it. That finds every
+member, but it reads every row and matches the id's structure as readily as the names inside it —
+searching `1v1`, `GM_` or `13_` returns the whole ladder, 5,946 rows on season 13 in Europe. The new
+search hands the database exact battleTags and asks which of them hold a rank here. With the members
+stored as a list of their own, every one of them — third and fourth included — is a key the index
+can seek.
+
+| Index | Keys |
+|---|---|
+| `MemberIds_Season_Gateway_GameMode` | `MemberIds` (multikey), `Season`, `Gateway`, `GameMode` |
+
+Multikey means one index entry per member, which is what makes every member findable. Leading with
+the member lets the bounded `$in` seek straight to the matching rows instead of scanning the season
+and mode bucket. On a season-13 dataset of 173,571 documents the index adds ~3.5 MB and the member
+list grows the documents themselves by ~6.5 MB (49.3 → 55.8 MB measured after a full backfill); the
+collection grows with players × seasons × modes × gateways, not with match volume. A context search costs one query against those rows, measured at a few tens of
+milliseconds; a search with no context never reaches the database at all — the directory it matches
+is held in memory.
+
+**The backfill.** A row written before the field existed would answer "not ranked" forever: a row
+only rewrites itself when its league next syncs, which for a finished season never happens.
+`RankRepository.EnsureIndexesAsync`, run at startup by `MongoIndexInitializationService`, creates
+the index first, then backfills in an isolated step, so a failure there cannot cost the lookups
+their index and is logged as a backfill error, not an index error. Members come from the joined
+`PlayerOverview`, which carries the whole team as structured data — teams of three and four are
+repaired rather than left at the two members the old fields held, 829 three-member and 293
+four-member rows on the season-13 snapshot. Rows with no `PlayerOverview` fall back to the two
+fields; they are the orphan ranks the lookup drops anyway. The run logs a count-and-duration line
+when it fills anything, and deciding whether there is work is a single `$exists` count, free once
+the collection is filled. The probe is also what makes rollback safe: if an older image runs for a
+while and writes rows without the field, the next startup finds and fills them — there is no marker
+to reset.
+
+**Who reads the list.** The search pair — `LoadLadderStandings` and the context overload of
+`LoadRanksForPlayers` — match on the member list alone, through the shared `OnLadder` predicate,
+and the index serves them. `LoadPlayersOfCountry` and the season-only `LoadRanksForPlayers` (clan
+and chat) also read the list but keep the two-field match beside it in an `$or`: they sit outside
+the rollout flag, so they must keep working on rows a failed backfill has not reached. The `$or`
+keeps them on the season index they have always used, and the fallback is removed with the legacy
+retirement.
+
+**One failure mode.** If production already holds an index with these keys under a different name,
+`createIndexes` fails with `IndexOptionsConflict`. The initialization service logs per repository
+and continues, so startup still reports success. Results stay correct and the member lookups fall
+back to collection scans, visible only in the startup log.
+
+## Retirement
+
+Once the new search has been live and proven, the legacy one is deleted. That is a separate, later
+change, and it runs in two steps: a backend flag switches the legacy endpoints off first, and only
+after that has held does the code get deleted. An endpoint that is switched off can be switched back
+on; a deleted one cannot — which is why the backend flag belongs to this change rather than to
+rollout.
+
+1. Remove the flag branch from `PlayerSearch.vue` and `RankingService.ts`, then drop
+   `USE_NEW_SEARCH` from `public/env.js` and its declaration in `main.ts`.
+2. Delete `ProfileService.searchPlayer`.
+3. Delete the backend legacy surface: the `players?search=` and `ladder/search` actions,
+   `PlayerRepository.SearchForPlayer` with its interface entry, and `CreateUnrankedResponse`.
+4. Delete the orphaned clan `searchForPlayers` chain, which has had no callers for far longer than
+   this work and can go at any time.
+5. Remove the two-field fallback from `LoadPlayersOfCountry` and the season-only
+   `LoadRanksForPlayers`, leaving the member list as the sole match. The fallback exists so the
+   unflagged surfaces survive rows the backfill has not reached; by retirement the backfill is
+   proven in production and every image that writes ranks carries the field.
+
+Step 3 waits on the in-game UI bundle. It calls `ladder/search` live, so a website-side grep will
+report the route as unused and be wrong.

--- a/docs/PLAYER_SEARCH_CONSOLIDATION.md
+++ b/docs/PLAYER_SEARCH_CONSOLIDATION.md
@@ -207,12 +207,13 @@ has no flag; it serves both endpoint sets and lets the frontend choose.
 
 **Verifying the backend deploy.** Three checks against the freshly rolled backend:
 
-- The startup log. The first boot prints `Rank MemberIds backfill filled <n> row(s) in <ms>ms`;
-  later boots print nothing, because nothing is missing. The two error shapes to watch for are a
-  logged `IndexOptionsConflict` — the failure mode described under
-  [Rank storage and lookup](#rank-storage-and-lookup) — and `Rank MemberIds backfill failed`.
-- `db.Rank.getIndexes()` lists `MemberIds_Season_Gateway_GameMode`.
-- `db.Rank.countDocuments({ MemberIds: { $exists: false } })` returns 0.
+- `db.Rank.getIndexes()` lists `MemberIds_Season_Gateway_GameMode`. The startup-log failure shape
+  to watch for is `IndexOptionsConflict`, described under
+  [Rank storage and lookup](#rank-storage-and-lookup).
+- The backfill job, run once per environment: `POST api/admin/jobs/rank-member-ids-backfill/run`
+  (admin runner, `docs/admin-job-runner.md`) reaches `Completed`, its progress trail naming each
+  season and the rows it filled.
+- `db.Rank.countDocuments({ MemberIds: { $exists: false } })` returns 0 once the job has completed.
 
 The backend stays additive at the API surface. `POST ladder/ranks-for-players` is a new route,
 verb-disjoint from the `GET {leagueId}` it sits beside. `LoadRanksForPlayers` gains the ladder
@@ -222,8 +223,8 @@ season-only original. Every legacy route keeps its path, verb, request and respo
 ## Rank storage and lookup
 
 This design changes one existing production collection, `Rank`, in three ways: the row gains a list
-of its members, the collection gains one multikey index over that list, and a startup backfill
-brings the existing rows up to the new shape.
+of its members, the collection gains one multikey index over that list, and an admin-triggered
+backfill job brings the existing rows up to the new shape.
 
 A rank row is one ladder entry. The new `MemberIds` field (`Rank.cs:60`) lists every member of that
 entry; the long-standing `Player1Id` and `Player2Id` keep holding the first two. The list exists for
@@ -252,23 +253,27 @@ is held in memory.
 
 **The backfill.** A row written before the field existed would answer "not ranked" forever: a row
 only rewrites itself when its league next syncs, which for a finished season never happens.
-`RankRepository.EnsureIndexesAsync`, run at startup by `MongoIndexInitializationService`, creates
-the index first, then backfills in an isolated step, so a failure there cannot cost the lookups
-their index and is logged as a backfill error, not an index error. Members come from the joined
-`PlayerOverview`, which carries the whole team as structured data — teams of three and four are
-repaired rather than left at the two members the old fields held, 829 three-member and 293
-four-member rows on the season-13 snapshot. Rows with no `PlayerOverview` fall back to the two
-fields; they are the orphan ranks the lookup drops anyway. The run logs a count-and-duration line
-when it fills anything, and deciding whether there is work is a single `$exists` count, free once
-the collection is filled. The probe is also what makes rollback safe: if an older image runs for a
-while and writes rows without the field, the next startup finds and fills them — there is no marker
-to reset.
+`RankMemberIdsBackfillJob` fills those rows through the admin job runner
+(`docs/admin-job-runner.md`): triggered once per environment via
+`POST api/admin/jobs/rank-member-ids-backfill/run`, it works one season per batch, paces between
+seasons against database and CPU pressure, and checkpoints the last completed season, so an
+interrupted run resumes where it died. Members come from the joined `PlayerOverview`, which
+carries the whole team as structured data — teams of three and four are repaired rather than left
+at the two members the old fields held: 829 such rows on the 2022 prod dump (536 three-member,
+293 four-member, all in seasons 9–13). Rows with no `PlayerOverview` fall back to the two fields;
+they are the orphan ranks the lookup drops anyway. Deciding whether a season holds work is a single `$exists` count on the
+missing field, which is also what makes the job safe to re-run: a filled row no longer matches, so
+a redo finds nothing. The same property makes rollback safe: if an older image runs for a while
+and writes rows without the field, re-running the job finds and fills them — there is no marker to
+reset. The index stays a startup concern — `RankRepository.EnsureIndexesAsync`, run by
+`MongoIndexInitializationService` — so the lookups have their index whether or not the job has
+run, and a backfill failure cannot cost them it.
 
 **Who reads the list.** The search pair — `LoadLadderStandings` and the context overload of
 `LoadRanksForPlayers` — match on the member list alone, through the shared `OnLadder` predicate,
 and the index serves them. `LoadPlayersOfCountry` and the season-only `LoadRanksForPlayers` (clan
 and chat) also read the list but keep the two-field match beside it in an `$or`: they sit outside
-the rollout flag, so they must keep working on rows a failed backfill has not reached. The `$or`
+the rollout flag, so they must keep working on rows the backfill job has not reached. The `$or`
 keeps them on the season index they have always used, and the fallback is removed with the legacy
 retirement.
 


### PR DESCRIPTION
One search core serves every place the site looks a player up by name. `GET api/players/global-search` gains optional ladder-context relevance, and a new `POST api/ladder/ranks-for-players` annotates exact battleTags with their rank in one season, gateway and game mode. **Deploy this before the companion website PR** — the reverse order breaks: the old backend has no `POST` route there and answers 405 with an empty body, which wedges the new frontend's search spinner.

The full architecture reference ships in this PR — `docs/PLAYER_SEARCH_CONSOLIDATION.md` — with the deeper rationale for everything summarized below, including the retirement plan for the legacy endpoints.

```mermaid
flowchart LR
  H["Header"] --> CORE
  P["Player picker"] --> CORE
  R["Rankings"] -->|"+ season, gateway, gameMode"| CORE
  CORE["api/players/global-search<br/>relevance · cursor-paged"] --> REFS[/"lightweight player refs<br/>battleTag · name · seasons · avatar"/]
  REFS -->|"ladder only"| ENR["api/ladder/ranks-for-players"]
  ENR --> RANK[/"mmr · W-L · league · rankNumber<br/>absent = unranked"/]
```

## What changes when: live on deploy vs. dormant until the flag

Two different things ship here, and they activate at different moments:

**Live the moment this deploys** — independent of the website:

- **Country, clan and chat rank lists become complete.** These lookups match only the two stored member fields today, so the third and fourth members of an arranged team are missing from country rankings and clan rank lists. They now match the full member list. Response shapes are unchanged; the row *sets* grow — that growth is the fix.

- **`global-search` rejects unsearchable terms.** The route currently accepts any term: an empty search matches the entire player directory and pages it out anonymously, and a null search is a 500. It now requires three letters-or-digits (400 otherwise). This is a deliberate behaviour change on a shipped endpoint, and its one external caller is verified safe: launcher-e gates its own input at three characters in two places and treats any non-200 as an empty result. Counting letters and digits rather than raw length closes a real bypass — matching is collation-aware, so a term of three zero-width characters passes a length check and matches every battleTag.
-  **The `Rank` storage change and its backfill** (next section).

**Dormant until the website flag flips** — the new capability, called by nobody at deploy time:

- Ladder-context relevance in `global-search`: given `season`/`gateWay`/`gameMode`, players ranked on that ladder come first, ordered by ranking points (league ids follow creation order, so divisions added mid-season sort wrong by id). Sending a partial context is a 400 — the relevance id doubles as the pagination cursor, and a caller that dropped a parameter between pages would silently get nothing. The parameters are new; no existing caller can hit either behaviour.
- `POST api/ladder/ranks-for-players`: rank lookup for up to 50 exact battleTags — a request-size bound on an anonymous route, not a result cap.
- **Context-free responses are unchanged**: same ordering, same relevance-id format, pinned by tests. launcher-e and the header keep receiving exactly what they receive today.

## Why the context must reach the core

Filtering a name-ordered page afterwards cannot work: how well a name matches says nothing about being ranked. Measured on the 2022 dump: `man` on season 13 / EU / 1v1 matches 766 players, 55 of them ranked on that ladder — and the first name-ordered page of 20 contains **none of them**. Ordered by standing, page one holds 20 ranked players and the rest follow as the list scrolls.

## Schema change: the `Rank.MemberIds` list

A rank row now names **every** member of the entry; the long-standing `Player1Id`/`Player2Id` keep holding the first two. The list exists for the lookups alone and stays out of API responses (`[JsonIgnore]`, pinned by a contract test), so no rank-returning endpoint changes shape.

**What the backfill repairs** — rows written before the field existed. Real examples from the
2022-11-27 prod dump (173,568 rows across 14 seasons, filled in 13.3s, every row verified against its expected outcome):

| Row (`_id`) | Before: `Player1Id`/`Player2Id` | After: `MemberIds` |
|---|---|---|
| `13_Teror#21981@20_GM_1v1_OC` | `Teror#21981` / null | `[Teror#21981]` |
| `13_KraV#21403@20_StarBuck#2732@20_GM_2v2_AT` | `StarBuck#2732` / `KraV#21403` | `[StarBuck#2732, KraV#21403]` |
| `13_FEWA418#1895@20_HumanKingTom#11421@20_Spark#12912@20_GM_4v4_AT` | `HumanKingTom#11421` / `Spark#12912` | `[HumanKingTom#11421, Spark#12912, FEWA418#1895]` |
| `13_InSaNe#12987@20_JmA#11680@20_Nymph#11746@20_RandomsTyLe#1383@20_GM_4v4_AT` | `InSaNe#12987` / `RandomsTyLe#1383` | `[InSaNe#12987, JmA#11680, Nymph#11746, RandomsTyLe#1383]` |
| `13_Seal#21311@20_Wing#21498@20_GM_2v2_AT` — no `PlayerOverview` exists | `Wing#21498` / `Seal#21311` | `[Wing#21498, Seal#21311]` (from the two stored fields) |

The last two members of the fourth row are the point: a row can store only two members, so the rest of the team exists only inside the `_id` string and the `PlayerOverview` — searching them by name finds no rank until the backfill has run. The dump holds 829 rows like that (536 with three members, 293 with four), all in seasons 9–13.

**How the repair ships.** It is the `rank-member-ids-backfill` admin job — the first job on the
#541 runner, surfaced by the admin Jobs page (w3champions/website#1110) — run once per
environment. Until it has run, the new member lookups miss the old rows; the country, clan and chat pages keep working through their old two-field match, which is removed once the legacy search retires. The operator playbook — how to trigger, how to verify, what can fail — is in `docs/PLAYER_SEARCH_CONSOLIDATION.md` in this diff.

## Scope: directory search only

Directory search asks "which players match this name" — the header, the player picker and the
rankings page all ask it, and this core serves all three. "Who have I played" is match-scoped,
carries per-pair data, keeps its own endpoint, and is served by w3champions/website#1103. The two consolidations complement each other.

## External consumers, pinned by contract tests

| Client | Endpoint | Contract held |
|---|---|---|
| launcher-e (Tauri, active) | `global-search` | sends `pageSize=10` and infers a further page from receiving exactly 10 — honoured, and every field it reads is asserted |
| in-game UI bundle (deprecated Electron launcher, still live) | `ladder/search` | exact call shape and its response — one array holding the ranked block plus zeroed rows for unranked name matches — plus `MemberIds` absent from the serialized model |



