### PR TITLE
fix: restore friends/presence for released launchers (temporary JWT fallback on wb hub)

### DIFF
--- a/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
+++ b/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
@@ -29,7 +29,8 @@ public class WebsiteBackendHub(
     TracingService tracingService,
     IBattleTagResolver battleTagResolver,
     IRelationshipChangeNotifier relationshipChangeNotifier,
-    ITicketStore ticketStore
+    ITicketStore ticketStore,
+    IW3CAuthenticationService authenticationService
 ) : Hub
 {
     static WebsiteBackendHub()
@@ -59,6 +60,7 @@ public class WebsiteBackendHub(
     private readonly IBattleTagResolver _battleTagResolver = battleTagResolver;
     private readonly IRelationshipChangeNotifier _relationshipChangeNotifier = relationshipChangeNotifier;
     private readonly ITicketStore _ticketStore = ticketStore;
+    private readonly IW3CAuthenticationService _authenticationService = authenticationService;
 
 
     [NoTrace]
@@ -66,20 +68,44 @@ public class WebsiteBackendHub(
     {
         await _tracingService.ExecuteWithSpanAsync(this, async () =>
         {
-            // TICKET-ONLY auth (WB-1). The launcher is this hub's SOLE client; the browser website
-            // never connects here (it has had zero SignalR since PR #122 — browsers use REST +
-            // Authorization: Bearer <JWT> and never open this WebSocket). So, exactly like
-            // chat-service's hub, this is a HARD CUTOVER to single-use tickets with NO raw-JWT
-            // fallback: access_token MUST be a one-time 60s ticket minted by POST /auth/session;
-            // TryConsume burns it once and yields the validated identity. A missing / invalid /
-            // already-consumed ticket is rejected below. The cutover is lock-step with the forced
-            // launcher update — launchers that have not yet updated lose wb-hub friends/presence
-            // until they update in that coordinated window.
+            // Ticket-first auth (WB-1) with a TEMPORARY raw-JWT fallback.
+            //
+            // The original plan was a hard cutover to single-use tickets, lock-step with a forced
+            // launcher update. That update never shipped: the last launcher release (v1.6.5,
+            // 2026-06-16) predates the ticket flow entirely, so from the moment this hub's cutover
+            // deployed, every player on the released launcher presented a raw JWT, was rejected
+            // here, and lost friends/presence — a fleet-wide outage, not a coordinated window.
+            //
+            // Bridge: try the ticket path first (updated launchers), then fall back to validating
+            // access_token as a raw JWT (released launchers), exactly as this hub did before the
+            // cutover. validateLifetime: false mirrors the pre-cutover behavior.
+            //
+            // REMOVE the fallback once a launcher release containing the ticket mint
+            // (launcher-e #833) has shipped AND its forced-update rollout has completed.
             var accessToken = _contextAccessor?.HttpContext?.Request.Query["access_token"].ToString();
             W3CUserAuthenticationDto w3cUserAuthentication = null;
-            if (!string.IsNullOrEmpty(accessToken) && _ticketStore.TryConsume(accessToken, DateTime.UtcNow, out var ticketIdentity))
+            if (!string.IsNullOrEmpty(accessToken))
             {
-                w3cUserAuthentication = ticketIdentity;
+                if (_ticketStore.TryConsume(accessToken, DateTime.UtcNow, out var ticketIdentity))
+                {
+                    w3cUserAuthentication = ticketIdentity;
+                }
+                else
+                {
+                    // GetUserByToken THROWS on a malformed/invalid token (FromJWT validates bare);
+                    // every REST filter that calls it wraps in try/catch and 401s. Mirror that here:
+                    // an updated launcher whose single-use ticket was already consumed lands on this
+                    // path with a hex ticket, which must reject cleanly (AuthorizationFailed below),
+                    // not surface as a hub exception.
+                    try
+                    {
+                        w3cUserAuthentication = _authenticationService.GetUserByToken(accessToken, false);
+                    }
+                    catch (Exception)
+                    {
+                        w3cUserAuthentication = null;
+                    }
+                }
             }
             if (w3cUserAuthentication == null)
             {

--- a/WC3ChampionsStatisticService.UnitTests/Hubs/WebsiteBackendHubTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Hubs/WebsiteBackendHubTests.cs
@@ -110,6 +110,7 @@ public class WebsiteBackendHubTests
     private Mock<IBattleTagResolver> _battleTagResolverMock;
     private Mock<IRelationshipChangeNotifier> relationshipNotifier;
     private TicketStore ticketStore;
+    private Mock<IW3CAuthenticationService> authService;
 
     [SetUp]
     public void SetUp()
@@ -134,6 +135,13 @@ public class WebsiteBackendHubTests
             .ReturnsAsync((string input) => input);
         relationshipNotifier = new Mock<IRelationshipChangeNotifier>();
         ticketStore = new TicketStore();
+        // Default mirrors the REAL service contract: GetUserByToken THROWS on any invalid token
+        // (FromJWT validates bare — see W3CAuthenticationService). Fallback-accept tests override
+        // per-token; rejection tests exercise the hub's catch via this throwing default.
+        authService = new Mock<IW3CAuthenticationService>();
+        authService
+            .Setup(a => a.GetUserByToken(It.IsAny<string>(), It.IsAny<bool>()))
+            .Throws(new Microsoft.IdentityModel.Tokens.SecurityTokenException("invalid token"));
     }
 
     private WebsiteBackendHub CreateHub(IFriendCommandHandler friendCommandHandler)
@@ -147,7 +155,8 @@ public class WebsiteBackendHubTests
             tracingService,
             _battleTagResolverMock.Object,
             relationshipNotifier.Object,
-            ticketStore
+            ticketStore,
+            authService.Object
         );
         typeof(Hub).GetProperty("Clients").SetValue(hub, mockClients.Object);
         return hub;
@@ -471,7 +480,8 @@ public class WebsiteBackendHubTests
             tracingService,
             _battleTagResolverMock.Object,
             relationshipNotifier.Object,
-            ticketStore
+            ticketStore,
+            authService.Object
         );
         typeof(Hub).GetProperty("Clients").SetValue(hub, mockClients.Object);
         SetHubContext(hub, "connection-id-1");
@@ -530,7 +540,8 @@ public class WebsiteBackendHubTests
             tracingService,
             _battleTagResolverMock.Object,
             relationshipNotifier.Object,
-            ticketStore
+            ticketStore,
+            authService.Object
         );
         typeof(Hub).GetProperty("Clients").SetValue(hub, mockClients.Object);
         SetHubContext(hub, "connection-id-1");
@@ -592,7 +603,8 @@ public class WebsiteBackendHubTests
             tracingService,
             _battleTagResolverMock.Object,
             relationshipNotifier.Object,
-            ticketStore
+            ticketStore,
+            authService.Object
         );
         typeof(Hub).GetProperty("Clients").SetValue(hub, mockClients.Object);
         SetHubContext(hub, "connection-id-1");
@@ -649,7 +661,8 @@ public class WebsiteBackendHubTests
             tracingService,
             _battleTagResolverMock.Object,
             relationshipNotifier.Object,
-            ticketStore
+            ticketStore,
+            authService.Object
         );
         typeof(Hub).GetProperty("Clients").SetValue(hub, mockClients.Object);
         SetHubContext(hub, "connection-id-1");
@@ -769,6 +782,73 @@ public class WebsiteBackendHubTests
             c => c.SendCoreAsync("FriendOnlineStatus", It.IsAny<object[]>(), default),
             Times.Never
         );
+    }
+
+    // --- Raw-JWT fallback bridge (released launchers predating the ticket flow) ---------------
+
+    [Test]
+    public async Task OnConnectedAsync_RawJwtFallback_ConnectsLegacyLauncher()
+    {
+        // A v1.6.5-era launcher sends its raw JWT as access_token — no ticket was ever minted.
+        IFriendCommandHandler friendCommandHandler = new TestFriendCommandHandler(friendRepository, friendListCache, friendRequestCache);
+        var hub = CreateHub(friendCommandHandler);
+
+        authService
+            .Setup(a => a.GetUserByToken("legacy-jwt", false))
+            .Returns(new W3CUserAuthenticationDto { BattleTag = "Legacy#1234" });
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString("?access_token=legacy-jwt");
+        contextAccessor.Setup(a => a.HttpContext).Returns(httpContext);
+
+        SetHubContext(hub, "conn-legacy");
+
+        await hub.OnConnectedAsync();
+
+        Assert.That(connections.GetUser("conn-legacy")?.BattleTag, Is.EqualTo("Legacy#1234"));
+        mockCaller.Verify(c => c.SendCoreAsync("Connected", It.IsAny<object[]>(), default), Times.Once);
+        // The pre-cutover behavior is mirrored exactly: lifetime NOT validated on this path.
+        authService.Verify(a => a.GetUserByToken("legacy-jwt", false), Times.Once);
+    }
+
+    [Test]
+    public async Task OnConnectedAsync_ValidTicket_NeverConsultsJwtFallback()
+    {
+        // Pins ordering: ticket path first; the fallback must not run for updated launchers.
+        IFriendCommandHandler friendCommandHandler = new TestFriendCommandHandler(friendRepository, friendListCache, friendRequestCache);
+        var hub = CreateHub(friendCommandHandler);
+
+        var ticket = ticketStore.Mint(new W3CUserAuthenticationDto { BattleTag = "Ticket#1234" }, DateTime.UtcNow);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString($"?access_token={ticket}");
+        contextAccessor.Setup(a => a.HttpContext).Returns(httpContext);
+
+        SetHubContext(hub, "conn-ticket");
+
+        await hub.OnConnectedAsync();
+
+        Assert.That(connections.GetUser("conn-ticket")?.BattleTag, Is.EqualTo("Ticket#1234"));
+        authService.Verify(a => a.GetUserByToken(It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Test]
+    public async Task OnConnectedAsync_TokenInvalidOnBothPaths_Rejected()
+    {
+        // Not a ticket, and the JWT fallback rejects it too (SetUp default returns null).
+        IFriendCommandHandler friendCommandHandler = new TestFriendCommandHandler(friendRepository, friendListCache, friendRequestCache);
+        var hub = CreateHub(friendCommandHandler);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString("?access_token=garbage");
+        contextAccessor.Setup(a => a.HttpContext).Returns(httpContext);
+
+        SetHubContext(hub, "conn-bad");
+
+        await hub.OnConnectedAsync();
+
+        Assert.That(connections.GetUser("conn-bad"), Is.Null);
+        mockCaller.Verify(c => c.SendCoreAsync("AuthorizationFailed", It.IsAny<object[]>(), default), Times.Once);
+        mockCaller.Verify(c => c.SendCoreAsync("Connected", It.IsAny<object[]>(), default), Times.Never);
     }
 
     [Test]
@@ -1036,7 +1116,8 @@ public class WebsiteBackendHubTests
             tracingService,
             _battleTagResolverMock.Object,
             relationshipNotifier.Object,
-            ticketStore
+            ticketStore,
+            authService.Object
         );
         typeof(Hub).GetProperty("Clients").SetValue(hub, mockClients.Object);
         connections.Add("conn1", new WebSocketUser { BattleTag = "Receiver#1", ConnectionId = "conn1" });


### PR DESCRIPTION
## What broke

The #538 chat-revamp cutover made `WebsiteBackendHub` ticket-only ("NO raw-JWT fallback"), designed to ship lock-step with a forced launcher update. That launcher release never shipped — the latest is **v1.6.5 (June 16)**, which predates the ticket flow entirely. The cutover image (build 13352, July 7) sat unused until the recent statistic-service deploy put it live; from that moment every released launcher presents a raw JWT, gets `AuthorizationFailed`, and loses friends/presence. (This is why it "worked yesterday": merge was July 7, the deploy was recent.)

## Fix

Ticket-first with a **temporary** raw-JWT fallback: try `TryConsume` (updated launchers), fall back to `GetUserByToken(accessToken, false)` — the exact pre-cutover validation — for released launchers. `GetUserByToken` throws on invalid tokens (every REST filter wraps it in try/catch), so the fallback catches too: an updated launcher whose single-use ticket was already consumed rejects cleanly instead of surfacing a hub exception.

Deploying this restores friends for the entire playerbase immediately, **no launcher update or rollback required**. Once a launcher release containing the ticket mint (launcher-e #833) has shipped and its forced-update rollout completed, remove the fallback in a follow-up — that completes the original cutover as designed.

## Tests

3 new: legacy raw JWT connects via fallback; a valid ticket never consults the fallback (pins ordering); a token invalid on both paths rejects cleanly. The auth-service test mock **throws** on invalid tokens, mirroring the real service contract, so every rejection test exercises the catch path. 38/38 hub + 17/17 session tests green.

## Notes for reviewers

- Known cost while the bridge lives: released launchers keep the pre-cutover posture (JWT in the WS URL query string) — the thing tickets fix. Accepted temporarily; the removal follow-up closes it.
- `TicketStore` is single-instance in-memory by design — fine on one replica; if statistic-service is ever scaled out, tickets will fail randomly (mint on one instance, WS lands on another). Worth confirming prod topology.
- chat-service has the identical undeployed cutover (#33) and only works today because its server side never deployed. A matching bridge PR for chat-service follows so its next deploy is safe in any order.