### PR TITLE
Add Jobs admin permission

### DIFF
--- a/W3C.Contracts/Admin/Permission/Permission.cs
+++ b/W3C.Contracts/Admin/Permission/Permission.cs
@@ -23,4 +23,5 @@ public enum EPermission
     SmurfCheckerQueryExplanation = 9,
     SmurfCheckerAdministration = 10,
     Warnings = 11,
+    Jobs = 12,
 }


### PR DESCRIPTION
Adds the `Jobs` permission (`12`), split out of #541 so it can be granted ahead of the runner landing. #541 carries the same line and rebases over this. Siblings: w3champions/identification-service#77, w3champions/website#1113, w3champions/chat-service#35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)