### PR TITLE
Cancelled matches moderation page: backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,3 +339,6 @@ ASALocalRun/
 # Real test/prod env files (created locally with real secrets) are ignored so they never get committed.
 environments/*.env
 !environments/local-compose.env
+
+# Local NuGet cache used by dotnet-docker.sh (no dotnet SDK on some dev hosts).
+.nuget-docker/

--- a/W3C.Domain/GameModes/GameModesHelper.cs
+++ b/W3C.Domain/GameModes/GameModesHelper.cs
@@ -5,7 +5,15 @@ namespace W3C.Domain.GameModes;
 
 public class GameModesHelper
 {
-    public readonly static List<GameMode> FfaGameModes = [GameMode.FFA, GameMode.GM_SC_FFA_4, GameMode.GM_SC_OZ];
+    // Must stay in sync with the game modes whose matchmaking-service definition sets
+    // isAnonymous = true, since that is what drives flo's mask_player_names. GM_LTW_FFA is
+    // deliberately absent: gm-ltw-ffa.ts sets isAnonymous = false.
+    public readonly static List<GameMode> FfaGameModes = [
+        GameMode.FFA,
+        GameMode.GM_FOOTMEN_FRENZY,
+        GameMode.GM_SC_FFA_4,
+        GameMode.GM_SC_OZ,
+    ];
     public readonly static List<GameMode> MeleeGameModes = [
         GameMode.GM_1v1,
         GameMode.GM_1ON1_TOURNAMENT,

--- a/W3C.Domain/MatchmakingService/MatchEventDtos.cs
+++ b/W3C.Domain/MatchmakingService/MatchEventDtos.cs
@@ -1,9 +1,11 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using Serilog;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
+using JsonProperty = Newtonsoft.Json.JsonPropertyAttribute;
 using W3C.Contracts.GameObjects;
 using W3C.Contracts.Matchmaking;
 using W3C.Contracts.Matchmaking.Queue;
@@ -53,6 +55,10 @@ public class UnfinishedMatchPlayer : IMatchPlayerServerInfo
     public QueueQuantiles quantiles { get; set; }
     public string country { get; set; }
     public FloPing[] floPings { get; set; }
+
+    // 0-based FLO lobby slot. Flo masks anonymised names as "Player {slotIndex + 1}",
+    // so display must add one. Null for matches that never reached game creation.
+    public int? slotIndex { get; set; }
 }
 
 [BsonIgnoreExtraElements]
@@ -117,9 +123,25 @@ public class Match : IMatchServerInfo
     public bool publicGame { get; set; }
     public string gamename { get; set; }
 
+    // BsonElement covers reads from the raw event collections; JsonProperty covers
+    // the matchmaking admin API responses, which MatchmakingServiceClient
+    // deserialises with Newtonsoft. Newtonsoft ignores BsonElement, so without
+    // this the id silently comes back null.
     [BsonElement("_id")]
+    [JsonProperty("_id")]
     public string id { get; set; }
     public int? floGameId { get; set; }
+
+    [BsonElement("_created_at")]
+    [JsonProperty("_created_at")]
+    public DateTimeOffset? createdAt { get; set; }
+
+    // EntityRepo.save stamps _updated_at immediately before the write, and
+    // cancelMatch goes through save. For a match still in the CANCELED state this
+    // is when it was cancelled; a heal would move it to FINISHED.
+    [BsonElement("_updated_at")]
+    [JsonProperty("_updated_at")]
+    public DateTimeOffset? canceledAt { get; set; }
 
     [BsonElement("endTime")]
     private long? _endTimeNullable { get; set; }

--- a/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
+++ b/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
@@ -114,6 +114,32 @@ public class MatchmakingServiceClient
         return null;
     }
 
+    public async Task<CanceledMatchesResponse> GetCanceledMatches(CanceledMatchesGetRequest req)
+    {
+        var url = $"{MatchmakingApiUrl}/admin/canceled-matches?page={req.Page}&itemsPerPage={req.ItemsPerPage}";
+
+        if (req.GameMode != GameMode.Undefined)
+        {
+            url += $"&gameMode={(int)req.GameMode}";
+        }
+
+        if (!string.IsNullOrEmpty(req.BattleTag))
+        {
+            url += $"&battleTag={HttpUtility.UrlEncode(req.BattleTag)}";
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("x-admin-secret", AdminSecret);
+        var response = await _httpClient.SendAsync(request);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return await GetResult<CanceledMatchesResponse>(response);
+        }
+
+        return null;
+    }
+
     public async Task<List<PlayerWarningDefinition>> GetPlayerWarningDefinitions(bool includeDisabled = false)
     {
         var url = $"{MatchmakingApiUrl}/admin/warning-definitions";
@@ -761,6 +787,22 @@ public class PlayerWarningsGetRequest
     public int ItemsPerPage { get; set; } = 25;
     public string BattleTag { get; set; }
     public string Status { get; set; }
+}
+
+public class CanceledMatchesGetRequest
+{
+    public int Page { get; set; } = 1;
+    public int ItemsPerPage { get; set; } = 25;
+
+    // GameMode.Undefined (0) means "all game modes" and is not sent upstream.
+    public GameMode GameMode { get; set; }
+    public string BattleTag { get; set; }
+}
+
+public class CanceledMatchesResponse
+{
+    public int total { get; set; }
+    public List<Match> matches { get; set; }
 }
 
 public class PlayerWarningsResponse

--- a/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
+++ b/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -137,6 +138,9 @@ public class MatchmakingServiceClient
             return await GetResult<CanceledMatchesResponse>(response);
         }
 
+        var errorContent = await response.Content.ReadAsStringAsync();
+        Log.Error("Matchmaking service returned {StatusCode} fetching canceled matches (page {Page}, itemsPerPage {ItemsPerPage}, gameMode {GameMode}): {Content}",
+            response.StatusCode, req.Page, req.ItemsPerPage, req.GameMode, errorContent);
         return null;
     }
 

--- a/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
+++ b/W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
@@ -117,11 +117,16 @@ public class MatchmakingServiceClient
 
     public async Task<CanceledMatchesResponse> GetCanceledMatches(CanceledMatchesGetRequest req)
     {
-        var url = $"{MatchmakingApiUrl}/admin/canceled-matches?page={req.Page}&itemsPerPage={req.ItemsPerPage}";
+        var url = $"{MatchmakingApiUrl}/admin/canceled-matches?itemsPerPage={req.ItemsPerPage}";
 
-        if (req.GameMode != GameMode.Undefined)
+        if (req.Cursor != null)
         {
-            url += $"&gameMode={(int)req.GameMode}";
+            url += $"&cursor={HttpUtility.UrlEncode(req.Cursor)}";
+        }
+
+        if (req.GameMode.HasValue)
+        {
+            url += $"&gameMode={(int)req.GameMode.Value}";
         }
 
         if (!string.IsNullOrEmpty(req.BattleTag))
@@ -139,8 +144,18 @@ public class MatchmakingServiceClient
         }
 
         var errorContent = await response.Content.ReadAsStringAsync();
-        Log.Error("Matchmaking service returned {StatusCode} fetching canceled matches (page {Page}, itemsPerPage {ItemsPerPage}, gameMode {GameMode}): {Content}",
-            response.StatusCode, req.Page, req.ItemsPerPage, req.GameMode, errorContent);
+        Log.Error("Matchmaking service returned {StatusCode} fetching canceled matches (itemsPerPage {ItemsPerPage}, gameMode {GameMode}, cursor {HasCursor}): {Content}",
+            response.StatusCode, req.ItemsPerPage, req.GameMode, req.Cursor != null, errorContent);
+
+        if (response.StatusCode == HttpStatusCode.BadRequest)
+        {
+            // Matchmaking validates the game mode and the cursor, so a 400 is the
+            // caller's error - a stale or tampered cursor, or an unknown mode. Passing
+            // it back as a 502 would blame the upstream for a bad request.
+            // HttpRequestExceptionFilter turns this back into a 400 response.
+            throw new HttpRequestException(errorContent, null, HttpStatusCode.BadRequest);
+        }
+
         return null;
     }
 
@@ -795,18 +810,28 @@ public class PlayerWarningsGetRequest
 
 public class CanceledMatchesGetRequest
 {
-    public int Page { get; set; } = 1;
     public int ItemsPerPage { get; set; } = 25;
 
-    // GameMode.Undefined (0) means "all game modes" and is not sent upstream.
-    public GameMode GameMode { get; set; }
+    /// <summary>
+    /// Opaque cursor from a previous response's <c>nextCursor</c>. Null for the first
+    /// page. It is signed and bound to the filter it was issued under, so it must not
+    /// be reused after changing <see cref="GameMode"/> or <see cref="BattleTag"/> -
+    /// matchmaking rejects that with a 400 rather than silently skipping rows.
+    /// </summary>
+    public string Cursor { get; set; }
+
+    /// <summary>Null means every game mode. Not sent upstream when null.</summary>
+    public GameMode? GameMode { get; set; }
+
     public string BattleTag { get; set; }
 }
 
 public class CanceledMatchesResponse
 {
-    public int total { get; set; }
     public List<Match> matches { get; set; }
+
+    /// <summary>Cursor for the following page, or null when this was the last one.</summary>
+    public string nextCursor { get; set; }
 }
 
 public class PlayerWarningsResponse

--- a/W3C.Domain/ReplayService/ReplayServiceClient.cs
+++ b/W3C.Domain/ReplayService/ReplayServiceClient.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Serilog;
 using W3C.Contracts.Replay;
 using W3C.Domain.Tracing;
 
@@ -16,11 +18,25 @@ public class ReplayServiceClient(IHttpClientFactory httpClientFactory)
     private readonly HttpClient _httpClient = httpClientFactory.CreateClient();
 
     // A replay legitimately may not exist: it was never recorded, or it has aged
-    // into DeepArchive. Callers turn a null stream into a 404 rather than a 500.
+    // into DeepArchive (NotFound/Gone). Callers turn a null stream into a 404 rather
+    // than a 500. Any other non-success status is a genuine upstream failure (outage,
+    // timeout, etc.) and must not be mistaken for "no replay" -- it is logged and thrown
+    // so it surfaces as a server error instead of a misleading 404.
     public async Task<Stream> GenerateReplay(int gameId)
     {
-        var response = await _httpClient.GetAsync($"{ReplayServiceUrl}/generate/{gameId}?secret={AdminSecret}", HttpCompletionOption.ResponseHeadersRead);
-        if (!response.IsSuccessStatusCode) return null;
+        using var response = await _httpClient.GetAsync($"{ReplayServiceUrl}/generate/{gameId}?secret={AdminSecret}", HttpCompletionOption.ResponseHeadersRead);
+
+        if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone)
+        {
+            return null;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            Log.Error("Replay service returned {StatusCode} generating replay for game {GameId}: {Content}", response.StatusCode, gameId, errorContent);
+            throw new HttpRequestException(errorContent, null, response.StatusCode);
+        }
 
         var stream = await response.Content.ReadAsStreamAsync();
         var memStream = new MemoryStream();
@@ -31,8 +47,19 @@ public class ReplayServiceClient(IHttpClientFactory httpClientFactory)
 
     public async Task<ReplayChatsData> GetChatLogs(int gameId)
     {
-        var response = await _httpClient.GetAsync($"{ReplayServiceUrl}/chats/{gameId}?secret={AdminSecret}");
-        if (!response.IsSuccessStatusCode) return null;
+        using var response = await _httpClient.GetAsync($"{ReplayServiceUrl}/chats/{gameId}?secret={AdminSecret}");
+
+        if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone)
+        {
+            return null;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            Log.Error("Replay service returned {StatusCode} fetching chat logs for game {GameId}: {Content}", response.StatusCode, gameId, errorContent);
+            throw new HttpRequestException(errorContent, null, response.StatusCode);
+        }
 
         var content = await response.Content.ReadAsStringAsync();
         if (string.IsNullOrEmpty(content)) return null;

--- a/W3C.Domain/ReplayService/ReplayServiceClient.cs
+++ b/W3C.Domain/ReplayService/ReplayServiceClient.cs
@@ -15,9 +15,14 @@ public class ReplayServiceClient(IHttpClientFactory httpClientFactory)
     private static readonly string AdminSecret = Environment.GetEnvironmentVariable("ADMIN_SECRET") ?? "300C018C-6321-4BAB-B289-9CB3DB760CBB";
     private readonly HttpClient _httpClient = httpClientFactory.CreateClient();
 
+    // A replay legitimately may not exist: it was never recorded, or it has aged
+    // into DeepArchive. Callers turn a null stream into a 404 rather than a 500.
     public async Task<Stream> GenerateReplay(int gameId)
     {
-        var stream = await _httpClient.GetStreamAsync($"{ReplayServiceUrl}/generate/{gameId}?secret={AdminSecret}");
+        var response = await _httpClient.GetAsync($"{ReplayServiceUrl}/generate/{gameId}?secret={AdminSecret}", HttpCompletionOption.ResponseHeadersRead);
+        if (!response.IsSuccessStatusCode) return null;
+
+        var stream = await response.Content.ReadAsStreamAsync();
         var memStream = new MemoryStream();
         await stream.CopyToAsync(memStream);
         memStream.Seek(0, SeekOrigin.Begin);
@@ -27,6 +32,8 @@ public class ReplayServiceClient(IHttpClientFactory httpClientFactory)
     public async Task<ReplayChatsData> GetChatLogs(int gameId)
     {
         var response = await _httpClient.GetAsync($"{ReplayServiceUrl}/chats/{gameId}?secret={AdminSecret}");
+        if (!response.IsSuccessStatusCode) return null;
+
         var content = await response.Content.ReadAsStringAsync();
         if (string.IsNullOrEmpty(content)) return null;
         var result = JsonConvert.DeserializeObject<ReplayChatsData>(content);

--- a/W3C.Domain/ReplayService/ReplayServiceClient.cs
+++ b/W3C.Domain/ReplayService/ReplayServiceClient.cs
@@ -17,11 +17,19 @@ public class ReplayServiceClient(IHttpClientFactory httpClientFactory)
     private static readonly string AdminSecret = Environment.GetEnvironmentVariable("ADMIN_SECRET") ?? "300C018C-6321-4BAB-B289-9CB3DB760CBB";
     private readonly HttpClient _httpClient = httpClientFactory.CreateClient();
 
-    // A replay legitimately may not exist: it was never recorded, or it has aged
-    // into DeepArchive (NotFound/Gone). Callers turn a null stream into a 404 rather
-    // than a 500. Any other non-success status is a genuine upstream failure (outage,
-    // timeout, etc.) and must not be mistaken for "no replay" -- it is logged and thrown
-    // so it surfaces as a server error instead of a misleading 404.
+    // A replay legitimately may not exist: it was never recorded, or it has aged into
+    // DeepArchive. Callers turn a null stream into a 404 rather than a 500, while any
+    // other non-success status is a genuine upstream failure (outage, timeout) and must
+    // not be mistaken for "no replay".
+    //
+    // Caveat, checked against the replay service rather than assumed: it does not
+    // currently distinguish the two. Every variant of its error enum - including
+    // GetGameArchiveFailed, which is what an absent or archived replay produces - goes
+    // through one IntoResponse that sets 500 (replay-service error.rs). So the branch
+    // below never fires today and a missing replay surfaces as a server error.
+    // Distinguishing them has to be fixed in the replay service, by mapping
+    // GetGameInfoFailed/GetGameArchiveFailed to 404; the branch is kept so that this
+    // side needs no change when that lands.
     public async Task<Stream> GenerateReplay(int gameId)
     {
         using var response = await _httpClient.GetAsync($"{ReplayServiceUrl}/generate/{gameId}?secret={AdminSecret}", HttpCompletionOption.ResponseHeadersRead);
@@ -49,6 +57,8 @@ public class ReplayServiceClient(IHttpClientFactory httpClientFactory)
     {
         using var response = await _httpClient.GetAsync($"{ReplayServiceUrl}/chats/{gameId}?secret={AdminSecret}");
 
+        // See GenerateReplay: the replay service returns 500 for an absent replay today,
+        // so this branch is forward-looking rather than currently reachable.
         if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone)
         {
             return null;

--- a/W3C.Domain/ReplayService/ReplayServiceClient.cs
+++ b/W3C.Domain/ReplayService/ReplayServiceClient.cs
@@ -22,14 +22,11 @@ public class ReplayServiceClient(IHttpClientFactory httpClientFactory)
     // other non-success status is a genuine upstream failure (outage, timeout) and must
     // not be mistaken for "no replay".
     //
-    // Caveat, checked against the replay service rather than assumed: it does not
-    // currently distinguish the two. Every variant of its error enum - including
-    // GetGameArchiveFailed, which is what an absent or archived replay produces - goes
-    // through one IntoResponse that sets 500 (replay-service error.rs). So the branch
-    // below never fires today and a missing replay surfaces as a server error.
-    // Distinguishing them has to be fixed in the replay service, by mapping
-    // GetGameInfoFailed/GetGameArchiveFailed to 404; the branch is kept so that this
-    // side needs no change when that lands.
+    // Checked against the replay service rather than assumed. It used to answer 500
+    // for everything, so the two were indistinguishable; replay-service#12 splits them:
+    // a game or object that was never there is 404, an object aged into DeepArchive
+    // (S3 InvalidObjectState) is 410, and storage failures stay 500. Both 4xx are
+    // handled below. Deploy that before relying on a 404 here meaning "no replay".
     public async Task<Stream> GenerateReplay(int gameId)
     {
         using var response = await _httpClient.GetAsync($"{ReplayServiceUrl}/generate/{gameId}?secret={AdminSecret}", HttpCompletionOption.ResponseHeadersRead);
@@ -57,8 +54,7 @@ public class ReplayServiceClient(IHttpClientFactory httpClientFactory)
     {
         using var response = await _httpClient.GetAsync($"{ReplayServiceUrl}/chats/{gameId}?secret={AdminSecret}");
 
-        // See GenerateReplay: the replay service returns 500 for an absent replay today,
-        // so this branch is forward-looking rather than currently reachable.
+        // See GenerateReplay for how the replay service distinguishes these.
         if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone)
         {
             return null;

--- a/W3ChampionsStatisticService/Admin/AdminMatchesController.cs
+++ b/W3ChampionsStatisticService/Admin/AdminMatchesController.cs
@@ -26,11 +26,19 @@ public class AdminMatchesController(MatchmakingServiceClient matchmakingServiceC
     private readonly MatchmakingServiceClient _matchmakingServiceClient = matchmakingServiceClient;
 
     /// <param name="gameMode">GameMode.Undefined (0) lists every mode.</param>
+    /// <param name="playerBattleTag">
+    /// The player to filter matches by. Deliberately NOT named "battleTag": BearerHasPermissionFilter
+    /// unconditionally overwrites an action argument named exactly "battleTag" with the acting admin's
+    /// own tag (see BearerHasPermissionFilter.cs:33), which is the intended behaviour for endpoints that
+    /// use "battleTag" purely to capture who performed the action. Here it is a caller-supplied search
+    /// filter, so it must use a different name or the filter would silently clobber it. Do not rename
+    /// this back to "battleTag".
+    /// </param>
     [HttpGet("canceled")]
     [BearerHasPermissionFilter(Permission = EPermission.Moderation)]
     public async Task<IActionResult> GetCanceledMatches(
         [FromQuery] GameMode gameMode = GameMode.Undefined,
-        [FromQuery] string battleTag = null,
+        [FromQuery] string playerBattleTag = null,
         [FromQuery] int page = 1,
         [FromQuery] int itemsPerPage = 25)
     {
@@ -43,7 +51,7 @@ public class AdminMatchesController(MatchmakingServiceClient matchmakingServiceC
             Page = page,
             ItemsPerPage = itemsPerPage,
             GameMode = gameMode,
-            BattleTag = battleTag,
+            BattleTag = playerBattleTag,
         });
 
         if (result == null)

--- a/W3ChampionsStatisticService/Admin/AdminMatchesController.cs
+++ b/W3ChampionsStatisticService/Admin/AdminMatchesController.cs
@@ -1,0 +1,56 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using W3C.Contracts.Admin.Permission;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.MatchmakingService;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.WebApi.ActionFilters;
+
+namespace W3ChampionsStatisticService.Admin;
+
+/// <summary>
+/// Moderation-facing views over matches that never produced a ranked result.
+///
+/// Cancelled matches are read straight from matchmaking, which is the only
+/// complete record: the MatchCanceledEvent stream omits every game-creation
+/// failure, so a read model built from it would be missing exactly the matches
+/// moderators care about.
+/// </summary>
+[ApiController]
+[Route("api/admin/matches")]
+[Trace]
+public class AdminMatchesController(MatchmakingServiceClient matchmakingServiceClient) : ControllerBase
+{
+    private const int MaxPageSize = 100;
+
+    private readonly MatchmakingServiceClient _matchmakingServiceClient = matchmakingServiceClient;
+
+    /// <param name="gameMode">GameMode.Undefined (0) lists every mode.</param>
+    [HttpGet("canceled")]
+    [BearerHasPermissionFilter(Permission = EPermission.Moderation)]
+    public async Task<IActionResult> GetCanceledMatches(
+        [FromQuery] GameMode gameMode = GameMode.Undefined,
+        [FromQuery] string battleTag = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int itemsPerPage = 25)
+    {
+        if (page < 1) page = 1;
+        if (itemsPerPage < 1) itemsPerPage = 25;
+        if (itemsPerPage > MaxPageSize) itemsPerPage = MaxPageSize;
+
+        var result = await _matchmakingServiceClient.GetCanceledMatches(new CanceledMatchesGetRequest
+        {
+            Page = page,
+            ItemsPerPage = itemsPerPage,
+            GameMode = gameMode,
+            BattleTag = battleTag,
+        });
+
+        if (result == null)
+        {
+            return StatusCode(502, "The matchmaking service did not return cancelled matches.");
+        }
+
+        return Ok(result);
+    }
+}

--- a/W3ChampionsStatisticService/Admin/AdminMatchesController.cs
+++ b/W3ChampionsStatisticService/Admin/AdminMatchesController.cs
@@ -25,7 +25,8 @@ public class AdminMatchesController(MatchmakingServiceClient matchmakingServiceC
 
     private readonly MatchmakingServiceClient _matchmakingServiceClient = matchmakingServiceClient;
 
-    /// <param name="gameMode">GameMode.Undefined (0) lists every mode.</param>
+    /// <param name="gameMode">Omit to list every mode.</param>
+    /// <param name="cursor">From a previous response's nextCursor. Omit for the first page.</param>
     /// <param name="playerBattleTag">
     /// The player to filter matches by. Deliberately NOT named "battleTag": BearerHasPermissionFilter
     /// unconditionally overwrites an action argument named exactly "battleTag" with the acting admin's
@@ -37,25 +38,30 @@ public class AdminMatchesController(MatchmakingServiceClient matchmakingServiceC
     [HttpGet("canceled")]
     [BearerHasPermissionFilter(Permission = EPermission.Moderation)]
     public async Task<IActionResult> GetCanceledMatches(
-        [FromQuery] GameMode gameMode = GameMode.Undefined,
+        [FromQuery] GameMode? gameMode = null,
         [FromQuery] string playerBattleTag = null,
-        [FromQuery] int page = 1,
+        [FromQuery] string cursor = null,
         [FromQuery] int itemsPerPage = 25)
     {
-        if (page < 1) page = 1;
         if (itemsPerPage < 1) itemsPerPage = 25;
         if (itemsPerPage > MaxPageSize) itemsPerPage = MaxPageSize;
 
         var result = await _matchmakingServiceClient.GetCanceledMatches(new CanceledMatchesGetRequest
         {
-            Page = page,
             ItemsPerPage = itemsPerPage,
+            Cursor = cursor,
             GameMode = gameMode,
             BattleTag = playerBattleTag,
         });
 
         if (result == null)
         {
+            // Not a 404: the collection exists and the request was well-formed, we just
+            // could not reach the only service that knows the answer. A 404 would tell
+            // the client there are no cancelled matches, which is a different -- and
+            // wrong -- statement, and one a moderator might act on. Genuinely bad
+            // requests (unknown game mode, stale cursor) are rejected upstream with a
+            // 400 and surface as a 400, not here.
             return StatusCode(502, "The matchmaking service did not return cancelled matches.");
         }
 

--- a/W3ChampionsStatisticService/Replays/ReplaysController.cs
+++ b/W3ChampionsStatisticService/Replays/ReplaysController.cs
@@ -33,6 +33,10 @@ public class ReplaysController(
             return NotFound();
         }
         var replayStream = await _replayServiceClient.GenerateReplay(floMatchId);
+        if (replayStream == null)
+        {
+            return NotFound();
+        }
         return File(replayStream, "application/octet-stream", $"{gameId}.w3g");
     }
 
@@ -46,6 +50,10 @@ public class ReplaysController(
             return NotFound();
         }
         var data = await _replayServiceClient.GetChatLogs(floMatchId);
+        if (data == null)
+        {
+            return NotFound();
+        }
         return Ok(data);
     }
 
@@ -63,6 +71,10 @@ public class ReplaysController(
             return NotFound();
         }
         var replayStream = await _replayServiceClient.GenerateReplay(floMatchId);
+        if (replayStream == null)
+        {
+            return NotFound();
+        }
         return File(replayStream, "application/octet-stream", $"{floMatchId}.w3g");
     }
 
@@ -75,6 +87,10 @@ public class ReplaysController(
             return NotFound();
         }
         var data = await _replayServiceClient.GetChatLogs(floMatchId);
+        if (data == null)
+        {
+            return NotFound();
+        }
         return Ok(data);
     }
 }

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/ReplayRateLimitAttribute.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/ReplayRateLimitAttribute.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using W3C.Contracts.Admin.Permission;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.RateLimiting.Services;
 
@@ -36,6 +37,13 @@ public class ReplayRateLimitAttribute : RateLimitAttribute
     /// Threshold in days to determine if a match is recent
     /// </summary>
     public int MatchAgeThresholdDays { get; set; } = 7;
+
+    /// <summary>
+    /// Hourly limit for authenticated moderators. The daily limit deliberately stays
+    /// at the strict/relaxed value, so a moderator can spend a day's allowance in one
+    /// burst but not exceed it.
+    /// </summary>
+    public int ModeratorHourlyLimit { get; set; } = 50;
 
     public ReplayRateLimitAttribute()
     {
@@ -94,12 +102,58 @@ public class ReplayRateLimitAttribute : RateLimitAttribute
         }
 
         // Get the rate limit context (checks for API tokens, gets IP, etc.)
-        return await rateLimitService.DetermineRateLimitContext(
+        var rateLimitContext = await rateLimitService.DetermineRateLimitContext(
             context.HttpContext,
             Scope,
             policyName,
             hourlyLimit,
             dailyLimit);
+
+        // An API token already carries its own negotiated limits; never override them.
+        if (rateLimitContext.HasValidApiToken)
+        {
+            return rateLimitContext;
+        }
+
+        var moderatorBattleTag = TryGetModeratorBattleTag(context, logger);
+        if (moderatorBattleTag != null)
+        {
+            rateLimitContext.HourlyLimit = ModeratorHourlyLimit;
+            rateLimitContext.PolicyName = "replay-moderator";
+            // Partition per moderator rather than per IP so colleagues behind one
+            // address do not consume each other's budget.
+            rateLimitContext.PartitionKey = $"moderator:{moderatorBattleTag}:{Scope}";
+        }
+
+        return rateLimitContext;
+    }
+
+    private static string TryGetModeratorBattleTag(ActionExecutingContext context, ILogger logger)
+    {
+        try
+        {
+            string authHeader = context.HttpContext.Request.Headers["Authorization"];
+            if (string.IsNullOrEmpty(authHeader) || !authHeader.StartsWith("Bearer "))
+            {
+                return null;
+            }
+
+            var token = authHeader["Bearer ".Length..].Trim();
+            var authService = context.HttpContext.RequestServices.GetRequiredService<IW3CAuthenticationService>();
+            var user = authService.GetUserByToken(token, true);
+
+            if (user == null || string.IsNullOrEmpty(user.BattleTag)) return null;
+            if (!user.IsAdmin) return null;
+            if (user.Permissions == null || !user.Permissions.Contains(EPermission.Moderation)) return null;
+
+            return user.BattleTag;
+        }
+        catch (Exception ex)
+        {
+            // A bad token must not break the request; fall through to the IP-based limit.
+            logger.LogDebug(ex, "Could not resolve a moderator identity for replay rate limiting");
+            return null;
+        }
     }
 
     private async Task<bool?> CheckMatchAge(IMatchRepository matchRepository, string gameId, int? floMatchId, int thresholdDays, ILogger logger)

--- a/W3ChampionsStatisticService/WebApi/ActionFilters/ReplayRateLimitAttribute.cs
+++ b/W3ChampionsStatisticService/WebApi/ActionFilters/ReplayRateLimitAttribute.cs
@@ -39,9 +39,12 @@ public class ReplayRateLimitAttribute : RateLimitAttribute
     public int MatchAgeThresholdDays { get; set; } = 7;
 
     /// <summary>
-    /// Hourly limit for authenticated moderators. The daily limit deliberately stays
-    /// at the strict/relaxed value, so a moderator can spend a day's allowance in one
-    /// burst but not exceed it.
+    /// Hourly limit for authenticated moderators. The daily NUMBER deliberately stays
+    /// at the strict/relaxed value - but authenticating moves the caller onto a
+    /// separate "moderator:{battleTag}:{scope}" partition, which is counted
+    /// independently from the anonymous "ip:{ip}:{scope}" bucket. A moderator can
+    /// therefore spend the daily allowance once anonymously and again once
+    /// authenticated; the daily ceiling is not a hard cap across both identities.
     /// </summary>
     public int ModeratorHourlyLimit { get; set; } = 50;
 
@@ -118,7 +121,10 @@ public class ReplayRateLimitAttribute : RateLimitAttribute
         var moderatorBattleTag = TryGetModeratorBattleTag(context, logger);
         if (moderatorBattleTag != null)
         {
-            rateLimitContext.HourlyLimit = ModeratorHourlyLimit;
+            // Only ever raise the limit - never let the moderator override undercut
+            // whatever the strict/relaxed policy already granted (e.g. a recent match's
+            // relaxed hourly limit may already exceed ModeratorHourlyLimit).
+            rateLimitContext.HourlyLimit = Math.Max(rateLimitContext.HourlyLimit, ModeratorHourlyLimit);
             rateLimitContext.PolicyName = "replay-moderator";
             // Partition per moderator rather than per IP so colleagues behind one
             // address do not consume each other's budget.
@@ -133,7 +139,7 @@ public class ReplayRateLimitAttribute : RateLimitAttribute
         try
         {
             string authHeader = context.HttpContext.Request.Headers["Authorization"];
-            if (string.IsNullOrEmpty(authHeader) || !authHeader.StartsWith("Bearer "))
+            if (string.IsNullOrEmpty(authHeader) || !authHeader.StartsWith("Bearer ", StringComparison.Ordinal))
             {
                 return null;
             }

--- a/WC3ChampionsStatisticService.UnitTests/Admin/AdminMatchesControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/AdminMatchesControllerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -31,6 +32,25 @@ public class AdminMatchesControllerTests
 
         Assert.That(attribute, Is.Not.Null);
         Assert.That(attribute!.Permission, Is.EqualTo(EPermission.Moderation));
+    }
+
+    // Regression guard: BearerHasPermissionFilter.OnActionExecutionAsync (BearerHasPermissionFilter.cs:33)
+    // unconditionally does `context.ActionArguments["battleTag"] = res.BattleTag;` on every action it
+    // guards, overwriting that argument with the acting admin's own tag. That is intentional for
+    // audit-style parameters (e.g. AdminController.CreateWarningDefinition's trailing `battleTag`), but
+    // GetCanceledMatches's battle tag argument is a caller-supplied search filter, not an audit field. If
+    // a parameter here is ever named exactly "battleTag" again, the filter would silently replace the
+    // moderator's search value with their own battletag through the real HTTP pipeline -- invisible to
+    // the other tests in this file because they call the controller method directly and never run
+    // BearerHasPermissionFilter. Do not "clean up" this parameter name back to "battleTag".
+    [Test]
+    public void GetCanceledMatchesHasNoParameterNamedBattleTag()
+    {
+        var method = typeof(AdminMatchesController).GetMethod(nameof(AdminMatchesController.GetCanceledMatches))!;
+
+        Assert.That(method.GetCustomAttribute<BearerHasPermissionFilter>(), Is.Not.Null,
+            "This guard only matters while the action is BearerHasPermissionFilter-decorated.");
+        Assert.That(method.GetParameters().Select(p => p.Name), Has.None.EqualTo("battleTag"));
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/Admin/AdminMatchesControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/AdminMatchesControllerTests.cs
@@ -1,0 +1,117 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+using W3C.Contracts.Admin.Permission;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.MatchmakingService;
+using W3ChampionsStatisticService.Admin;
+using W3ChampionsStatisticService.WebApi.ActionFilters;
+
+namespace WC3ChampionsStatisticService.Tests.Admin;
+
+[TestFixture]
+public class AdminMatchesControllerTests
+{
+    private const string CanceledMatchesJson = """
+    {"total":3,"matches":[{"_id":"abc1234567","state":3,"gameMode":5,"floGameId":4242,
+    "players":[{"battleTag":"Tester#1234","team":0,"slotIndex":2}]}]}
+    """;
+
+    [Test]
+    public void CanceledMatchesRequiresModerationPermission()
+    {
+        var method = typeof(AdminMatchesController).GetMethod(nameof(AdminMatchesController.GetCanceledMatches))!;
+        var attribute = method.GetCustomAttribute<BearerHasPermissionFilter>();
+
+        Assert.That(attribute, Is.Not.Null);
+        Assert.That(attribute!.Permission, Is.EqualTo(EPermission.Moderation));
+    }
+
+    [Test]
+    public async Task CanceledMatchesForwardsFiltersAndAdminSecret()
+    {
+        var handler = new CapturingHandler(CanceledMatchesJson);
+        var controller = CreateController(handler);
+
+        var result = await controller.GetCanceledMatches(GameMode.FFA, "Tester#1234", 2, 10);
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        var uri = handler.Requests[0].RequestUri!;
+        Assert.That(uri.AbsolutePath, Does.EndWith("/admin/canceled-matches"));
+        Assert.That(uri.Query, Does.Contain("page=2"));
+        Assert.That(uri.Query, Does.Contain("itemsPerPage=10"));
+        Assert.That(uri.Query, Does.Contain("gameMode=5"));
+        Assert.That(uri.Query, Does.Contain("battleTag=Tester"));
+        Assert.That(handler.Requests[0].Headers.Contains("x-admin-secret"), Is.True);
+    }
+
+    [Test]
+    public async Task AllGameModesOmitsTheGameModeFilter()
+    {
+        var handler = new CapturingHandler(CanceledMatchesJson);
+        var controller = CreateController(handler);
+
+        await controller.GetCanceledMatches(GameMode.Undefined, null, 1, 25);
+
+        Assert.That(handler.Requests[0].RequestUri!.Query, Does.Not.Contain("gameMode="));
+    }
+
+    [Test]
+    public async Task PageSizeIsClampedBeforeItLeavesTheService()
+    {
+        var handler = new CapturingHandler(CanceledMatchesJson);
+        var controller = CreateController(handler);
+
+        await controller.GetCanceledMatches(GameMode.Undefined, null, 1, 5000);
+
+        Assert.That(handler.Requests[0].RequestUri!.Query, Does.Contain("itemsPerPage=100"));
+    }
+
+    [Test]
+    public async Task TheProxiedPayloadKeepsIdsSlotIndexesAndTotal()
+    {
+        var handler = new CapturingHandler(CanceledMatchesJson);
+        var controller = CreateController(handler);
+
+        var result = (OkObjectResult)await controller.GetCanceledMatches(GameMode.Undefined, null, 1, 25);
+        var payload = (CanceledMatchesResponse)result.Value!;
+
+        Assert.That(payload.total, Is.EqualTo(3));
+        Assert.That(payload.matches[0].id, Is.EqualTo("abc1234567"));
+        Assert.That(payload.matches[0].floGameId, Is.EqualTo(4242));
+        Assert.That(payload.matches[0].players[0].slotIndex, Is.EqualTo(2));
+    }
+
+    private static AdminMatchesController CreateController(CapturingHandler handler)
+    {
+        var client = new MatchmakingServiceClient(new TestHttpClientFactory(new HttpClient(handler)));
+        return new AdminMatchesController(client);
+    }
+
+    private class TestHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+
+    private class CapturingHandler(string responseBody) : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Admin/AdminMatchesControllerTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Admin/AdminMatchesControllerTests.cs
@@ -20,7 +20,7 @@ namespace WC3ChampionsStatisticService.Tests.Admin;
 public class AdminMatchesControllerTests
 {
     private const string CanceledMatchesJson = """
-    {"total":3,"matches":[{"_id":"abc1234567","state":3,"gameMode":5,"floGameId":4242,
+    {"nextCursor":"eyJmIjoiYWJjIn0.sig","matches":[{"_id":"abc1234567","state":3,"gameMode":5,"floGameId":4242,
     "players":[{"battleTag":"Tester#1234","team":0,"slotIndex":2}]}]}
     """;
 
@@ -59,13 +59,13 @@ public class AdminMatchesControllerTests
         var handler = new CapturingHandler(CanceledMatchesJson);
         var controller = CreateController(handler);
 
-        var result = await controller.GetCanceledMatches(GameMode.FFA, "Tester#1234", 2, 10);
+        var result = await controller.GetCanceledMatches(GameMode.FFA, "Tester#1234", "prev-cursor", 10);
 
         Assert.That(result, Is.InstanceOf<OkObjectResult>());
         Assert.That(handler.Requests, Has.Count.EqualTo(1));
         var uri = handler.Requests[0].RequestUri!;
         Assert.That(uri.AbsolutePath, Does.EndWith("/admin/canceled-matches"));
-        Assert.That(uri.Query, Does.Contain("page=2"));
+        Assert.That(uri.Query, Does.Contain("cursor=prev-cursor"));
         Assert.That(uri.Query, Does.Contain("itemsPerPage=10"));
         Assert.That(uri.Query, Does.Contain("gameMode=5"));
         Assert.That(uri.Query, Does.Contain("battleTag=Tester"));
@@ -78,8 +78,10 @@ public class AdminMatchesControllerTests
         var handler = new CapturingHandler(CanceledMatchesJson);
         var controller = CreateController(handler);
 
-        await controller.GetCanceledMatches(GameMode.Undefined, null, 1, 25);
+        await controller.GetCanceledMatches(null, null, null, 25);
 
+        // Null rather than GameMode.Undefined: "no filter" is now its own value instead
+        // of enum member 0 doing double duty.
         Assert.That(handler.Requests[0].RequestUri!.Query, Does.Not.Contain("gameMode="));
     }
 
@@ -89,24 +91,53 @@ public class AdminMatchesControllerTests
         var handler = new CapturingHandler(CanceledMatchesJson);
         var controller = CreateController(handler);
 
-        await controller.GetCanceledMatches(GameMode.Undefined, null, 1, 5000);
+        await controller.GetCanceledMatches(null, null, null, 5000);
 
         Assert.That(handler.Requests[0].RequestUri!.Query, Does.Contain("itemsPerPage=100"));
     }
 
     [Test]
-    public async Task TheProxiedPayloadKeepsIdsSlotIndexesAndTotal()
+    public async Task TheProxiedPayloadKeepsIdsSlotIndexesAndTheCursor()
     {
         var handler = new CapturingHandler(CanceledMatchesJson);
         var controller = CreateController(handler);
 
-        var result = (OkObjectResult)await controller.GetCanceledMatches(GameMode.Undefined, null, 1, 25);
+        var result = (OkObjectResult)await controller.GetCanceledMatches(null, null, null, 25);
         var payload = (CanceledMatchesResponse)result.Value!;
 
-        Assert.That(payload.total, Is.EqualTo(3));
+        Assert.That(payload.nextCursor, Is.EqualTo("eyJmIjoiYWJjIn0.sig"));
         Assert.That(payload.matches[0].id, Is.EqualTo("abc1234567"));
         Assert.That(payload.matches[0].floGameId, Is.EqualTo(4242));
         Assert.That(payload.matches[0].players[0].slotIndex, Is.EqualTo(2));
+    }
+
+
+    [Test]
+    public async Task AnUnreachableMatchmakingServiceIsABadGatewayRatherThanANotFound()
+    {
+        var handler = new CapturingHandler("upstream exploded", HttpStatusCode.InternalServerError);
+        var controller = CreateController(handler);
+
+        var result = (ObjectResult)await controller.GetCanceledMatches(null, null, null, 25);
+
+        // Not 404: the request was fine and the collection exists, we just could not
+        // reach the service that knows about it. A 404 would read as "there are no
+        // cancelled matches", which a moderator might act on.
+        Assert.That(result.StatusCode, Is.EqualTo(502));
+    }
+
+    [Test]
+    public void ARejectedCursorSurfacesAsABadRequestNotABadGateway()
+    {
+        var handler = new CapturingHandler("{\"errors\":[{\"msg\":\"Pagination cursor failed signature validation.\"}]}", HttpStatusCode.BadRequest);
+        var controller = CreateController(handler);
+
+        // Matchmaking validates the cursor and the game mode, so its 400 is the caller's
+        // fault. HttpRequestExceptionFilter turns this exception back into a 400.
+        var exception = Assert.ThrowsAsync<HttpRequestException>(
+            () => controller.GetCanceledMatches(null, null, "tampered", 25));
+
+        Assert.That(exception!.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
     }
 
     private static AdminMatchesController CreateController(CapturingHandler handler)
@@ -120,7 +151,7 @@ public class AdminMatchesControllerTests
         public HttpClient CreateClient(string name) => client;
     }
 
-    private class CapturingHandler(string responseBody) : HttpMessageHandler
+    private class CapturingHandler(string responseBody, HttpStatusCode status = HttpStatusCode.OK) : HttpMessageHandler
     {
         public List<HttpRequestMessage> Requests { get; } = [];
 
@@ -128,7 +159,7 @@ public class AdminMatchesControllerTests
         {
             Requests.Add(request);
 
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            return Task.FromResult(new HttpResponseMessage(status)
             {
                 Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
             });

--- a/WC3ChampionsStatisticService.UnitTests/GameModes/GameModesHelperTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/GameModes/GameModesHelperTests.cs
@@ -1,0 +1,95 @@
+using Newtonsoft.Json;
+using NUnit.Framework;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.GameModes;
+using W3C.Domain.MatchmakingService;
+
+namespace WC3ChampionsStatisticService.Tests.GameModes;
+
+[TestFixture]
+public class GameModesHelperTests
+{
+    [Test]
+    public void FootmenFrenzyIsAnFfaGameMode()
+    {
+        Assert.That(GameModesHelper.IsFfaGameMode(GameMode.GM_FOOTMEN_FRENZY), Is.True);
+    }
+
+    [Test]
+    public void TheEstablishedFfaGameModesAreStillFfa()
+    {
+        Assert.That(GameModesHelper.IsFfaGameMode(GameMode.FFA), Is.True);
+        Assert.That(GameModesHelper.IsFfaGameMode(GameMode.GM_SC_FFA_4), Is.True);
+        Assert.That(GameModesHelper.IsFfaGameMode(GameMode.GM_SC_OZ), Is.True);
+    }
+
+    [Test]
+    public void LtwFfaIsNotAnonymisedAndStaysOutOfTheFfaList()
+    {
+        Assert.That(GameModesHelper.IsFfaGameMode(GameMode.GM_LTW_FFA), Is.False);
+        Assert.That(GameModesHelper.IsFfaGameMode(GameMode.GM_1v1), Is.False);
+    }
+}
+
+[TestFixture]
+public class MatchJsonMappingTests
+{
+    private const string CanceledMatchJson = """
+    {
+      "_id": "abc1234567",
+      "_created_at": "2026-08-01T10:00:00.000Z",
+      "_updated_at": "2026-08-01T16:05:00.000Z",
+      "state": 3,
+      "gameMode": 5,
+      "gamename": "w3c-test",
+      "startTime": 1754042400000,
+      "floGameId": 4242,
+      "players": [
+        { "battleTag": "Tester#1234", "team": 0, "race": 1, "slotIndex": 2 }
+      ]
+    }
+    """;
+
+    [Test]
+    public void MatchIdIsReadFromTheUnderscoreIdJsonProperty()
+    {
+        var match = JsonConvert.DeserializeObject<Match>(CanceledMatchJson);
+
+        Assert.That(match.id, Is.EqualTo("abc1234567"));
+    }
+
+    [Test]
+    public void EntityTimestampsAreMapped()
+    {
+        var match = JsonConvert.DeserializeObject<Match>(CanceledMatchJson);
+
+        Assert.That(match.createdAt, Is.Not.Null);
+        Assert.That(match.canceledAt, Is.Not.Null);
+        Assert.That(match.canceledAt!.Value, Is.GreaterThan(match.createdAt!.Value));
+    }
+
+    [Test]
+    public void SlotIndexIsMappedOnPlayers()
+    {
+        var match = JsonConvert.DeserializeObject<Match>(CanceledMatchJson);
+
+        Assert.That(match.players[0].slotIndex, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void AMissingEndTimeStaysZeroRatherThanThrowing()
+    {
+        var match = JsonConvert.DeserializeObject<Match>(CanceledMatchJson);
+
+        Assert.That(match.endTime, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void AMissingFloGameIdDeserialisesToNull()
+    {
+        var match = JsonConvert.DeserializeObject<Match>("""{"_id":"x","state":3}""");
+
+        Assert.That(match.floGameId, Is.Null);
+        Assert.That(match.HasFloGameId(), Is.False);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Replay/ReplayServiceClientTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Replay/ReplayServiceClientTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using W3C.Domain.UpdateService;
+
+namespace WC3ChampionsStatisticService.Tests.Replay;
+
+[TestFixture]
+public class ReplayServiceClientTests
+{
+    [Test]
+    public async Task AMissingChatLogComesBackAsNullRatherThanAnEmptyObject()
+    {
+        var client = ClientReturning(HttpStatusCode.NotFound, "not found");
+
+        var chats = await client.GetChatLogs(4242);
+
+        Assert.That(chats, Is.Null);
+    }
+
+    [Test]
+    public async Task AMissingReplayComesBackAsNullRatherThanThrowing()
+    {
+        var client = ClientReturning(HttpStatusCode.NotFound, "not found");
+
+        var replay = await client.GenerateReplay(4242);
+
+        Assert.That(replay, Is.Null);
+    }
+
+    [Test]
+    public async Task AnArchivedReplayComesBackAsNull()
+    {
+        var client = ClientReturning(HttpStatusCode.Gone, "archived");
+
+        var replay = await client.GenerateReplay(4242);
+
+        Assert.That(replay, Is.Null);
+    }
+
+    private static ReplayServiceClient ClientReturning(HttpStatusCode status, string body)
+    {
+        var handler = new StubHandler(status, body);
+        return new ReplayServiceClient(new TestHttpClientFactory(new HttpClient(handler)));
+    }
+
+    private class TestHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+
+    private class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Replay/ReplayServiceClientTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Replay/ReplayServiceClientTests.cs
@@ -41,6 +41,35 @@ public class ReplayServiceClientTests
         Assert.That(replay, Is.Null);
     }
 
+    [Test]
+    public async Task AnArchivedChatLogComesBackAsNull()
+    {
+        var client = ClientReturning(HttpStatusCode.Gone, "archived");
+
+        var chats = await client.GetChatLogs(4242);
+
+        Assert.That(chats, Is.Null);
+    }
+
+    // A 5xx (or any other non-2xx that isn't NotFound/Gone) is a genuine upstream
+    // failure, not "no replay". It must not be swallowed into a null -- a moderator
+    // seeing "replay unavailable" for an outage instead of an error is worse than a 500.
+    [Test]
+    public void AnUpstreamOutageGeneratingAReplayThrowsRatherThanReturningNull()
+    {
+        var client = ClientReturning(HttpStatusCode.InternalServerError, "boom");
+
+        Assert.ThrowsAsync<HttpRequestException>(() => client.GenerateReplay(4242));
+    }
+
+    [Test]
+    public void AnUpstreamOutageFetchingChatLogsThrowsRatherThanReturningNull()
+    {
+        var client = ClientReturning(HttpStatusCode.BadGateway, "boom");
+
+        Assert.ThrowsAsync<HttpRequestException>(() => client.GetChatLogs(4242));
+    }
+
     private static ReplayServiceClient ClientReturning(HttpStatusCode status, string body)
     {
         var handler = new StubHandler(status, body);

--- a/WC3ChampionsStatisticService.UnitTests/Replays/ReplayRateLimitTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Replays/ReplayRateLimitTests.cs
@@ -1,0 +1,237 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using System.Threading.RateLimiting;
+using System.Threading.Tasks;
+using W3C.Contracts.Admin.Permission;
+using W3ChampionsStatisticService.Ports;
+using W3ChampionsStatisticService.RateLimiting.Models;
+using W3ChampionsStatisticService.RateLimiting.Services;
+using W3ChampionsStatisticService.WebApi.ActionFilters;
+
+namespace WC3ChampionsStatisticService.Tests.Replays;
+
+[TestFixture]
+public class ReplayRateLimitTests
+{
+    private Mock<IRateLimitService> _rateLimitServiceMock;
+    private Mock<IRateLimitBucketService> _bucketServiceMock;
+    private Mock<IMatchRepository> _matchRepositoryMock;
+    private Mock<IW3CAuthenticationService> _authServiceMock;
+    private ReplayRateLimitAttribute _attribute;
+    private ActionExecutingContext _context;
+    private HttpContext _httpContext;
+
+    private const string StrictPolicy = "replay-strict";
+    private const string ModeratorPolicy = "replay-moderator";
+
+    [SetUp]
+    public void Setup()
+    {
+        _rateLimitServiceMock = new Mock<IRateLimitService>();
+        _bucketServiceMock = new Mock<IRateLimitBucketService>();
+        _matchRepositoryMock = new Mock<IMatchRepository>();
+        _authServiceMock = new Mock<IW3CAuthenticationService>();
+
+        var services = new ServiceCollection();
+        services.AddSingleton(_rateLimitServiceMock.Object);
+        services.AddSingleton(_bucketServiceMock.Object);
+        services.AddSingleton(_matchRepositoryMock.Object);
+        services.AddSingleton(_authServiceMock.Object);
+        services.AddSingleton(Mock.Of<ILogger<ReplayRateLimitAttribute>>());
+        services.AddSingleton(Mock.Of<ILogger<RateLimitAttribute>>());
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        _httpContext = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider
+        };
+        _httpContext.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("192.168.1.1");
+
+        var actionContext = new ActionContext(
+            _httpContext,
+            new RouteData(),
+            new ActionDescriptor());
+
+        _context = new ActionExecutingContext(
+            actionContext,
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object>(),
+            Mock.Of<Controller>());
+
+        _attribute = new ReplayRateLimitAttribute();
+
+        // A lease that always succeeds - we only care about the RateLimitContext that gets
+        // computed and stored on HttpContext.Items, not the bucket accounting itself.
+        var lease = new Mock<RateLimitLease>();
+        lease.Setup(l => l.IsAcquired).Returns(true);
+        _bucketServiceMock
+            .Setup(b => b.TryAcquireAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(lease.Object);
+    }
+
+    private RateLimitContext SetupBaseContext(bool hasValidApiToken = false, int hourlyLimit = 10, int dailyLimit = 50, string partitionKey = "ip:192.168.1.1:replay")
+    {
+        var baseContext = new RateLimitContext
+        {
+            PolicyName = StrictPolicy,
+            HourlyLimit = hourlyLimit,
+            DailyLimit = dailyLimit,
+            HasValidApiToken = hasValidApiToken,
+            PartitionKey = partitionKey
+        };
+
+        _rateLimitServiceMock
+            .Setup(s => s.DetermineRateLimitContext(_httpContext, "replay", StrictPolicy, 10, 50))
+            .ReturnsAsync(baseContext);
+
+        return baseContext;
+    }
+
+    private async Task<RateLimitContext> Invoke()
+    {
+        var next = new ActionExecutionDelegate(() => Task.FromResult(
+            new ActionExecutedContext(
+                new ActionContext(_httpContext, new RouteData(), new ActionDescriptor()),
+                new List<IFilterMetadata>(),
+                Mock.Of<Controller>())));
+
+        await _attribute.OnActionExecutionAsync(_context, next);
+
+        return _httpContext.Items["RateLimitContext"] as RateLimitContext;
+    }
+
+    [Test]
+    public async Task ModeratorToken_RaisesHourlyLimit_KeepsDailyLimit_UsesModeratorPartition()
+    {
+        SetupBaseContext();
+
+        const string battleTag = "Moderator#123";
+        _httpContext.Request.Headers["Authorization"] = "Bearer valid-moderator-token";
+        _authServiceMock
+            .Setup(a => a.GetUserByToken("valid-moderator-token", true))
+            .Returns(new W3CUserAuthenticationDto
+            {
+                BattleTag = battleTag,
+                IsAdmin = true,
+                Permissions = new HashSet<EPermission> { EPermission.Moderation }
+            });
+
+        var result = await Invoke();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.HourlyLimit, Is.EqualTo(50));
+        Assert.That(result.DailyLimit, Is.EqualTo(50));
+        Assert.That(result.PolicyName, Is.EqualTo(ModeratorPolicy));
+        Assert.That(result.PartitionKey, Is.EqualTo($"moderator:{battleTag}:replay"));
+    }
+
+    [Test]
+    public async Task ValidTokenWithoutModerationPermission_LeavesLimitsUnchanged()
+    {
+        SetupBaseContext();
+
+        _httpContext.Request.Headers["Authorization"] = "Bearer valid-non-moderator-token";
+        _authServiceMock
+            .Setup(a => a.GetUserByToken("valid-non-moderator-token", true))
+            .Returns(new W3CUserAuthenticationDto
+            {
+                BattleTag = "Player#456",
+                IsAdmin = true,
+                Permissions = new HashSet<EPermission>()
+            });
+
+        var result = await Invoke();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.HourlyLimit, Is.EqualTo(10));
+        Assert.That(result.DailyLimit, Is.EqualTo(50));
+        Assert.That(result.PartitionKey, Is.EqualTo("ip:192.168.1.1:replay"));
+    }
+
+    [Test]
+    public async Task NoAuthorizationHeader_LeavesLimitsUnchanged()
+    {
+        SetupBaseContext();
+
+        var result = await Invoke();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.HourlyLimit, Is.EqualTo(10));
+        Assert.That(result.DailyLimit, Is.EqualTo(50));
+        Assert.That(result.PartitionKey, Is.EqualTo("ip:192.168.1.1:replay"));
+        _authServiceMock.Verify(a => a.GetUserByToken(It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Test]
+    public async Task MalformedToken_FallsBackToIpBasedLimit()
+    {
+        SetupBaseContext();
+
+        _httpContext.Request.Headers["Authorization"] = "Bearer garbage-token";
+        _authServiceMock
+            .Setup(a => a.GetUserByToken("garbage-token", true))
+            .Throws(new Microsoft.IdentityModel.Tokens.SecurityTokenValidationException("bad token"));
+
+        var result = await Invoke();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.HourlyLimit, Is.EqualTo(10));
+        Assert.That(result.DailyLimit, Is.EqualTo(50));
+        Assert.That(result.PartitionKey, Is.EqualTo("ip:192.168.1.1:replay"));
+    }
+
+    [Test]
+    public async Task ValidApiToken_WinsOverModeratorOverride()
+    {
+        var apiToken = new ApiToken
+        {
+            Token = "test-api-token",
+            Name = "Test Token",
+            Scopes = new Dictionary<string, ApiTokenScope>
+            {
+                ["replay"] = new ApiTokenScope { HourlyLimit = 200, DailyLimit = 2000, IsEnabled = true }
+            }
+        };
+
+        _rateLimitServiceMock
+            .Setup(s => s.DetermineRateLimitContext(_httpContext, "replay", StrictPolicy, 10, 50))
+            .ReturnsAsync(new RateLimitContext
+            {
+                PolicyName = StrictPolicy,
+                HourlyLimit = 200,
+                DailyLimit = 2000,
+                HasValidApiToken = true,
+                ApiToken = apiToken,
+                PartitionKey = "token:test-api-token:replay"
+            });
+
+        _httpContext.Request.Headers["X-API-Token"] = "test-api-token";
+        // Even a moderator bearer token must not override an already-valid API token.
+        _httpContext.Request.Headers["Authorization"] = "Bearer valid-moderator-token";
+        _authServiceMock
+            .Setup(a => a.GetUserByToken("valid-moderator-token", true))
+            .Returns(new W3CUserAuthenticationDto
+            {
+                BattleTag = "Moderator#123",
+                IsAdmin = true,
+                Permissions = new HashSet<EPermission> { EPermission.Moderation }
+            });
+
+        var result = await Invoke();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.HourlyLimit, Is.EqualTo(200));
+        Assert.That(result.DailyLimit, Is.EqualTo(2000));
+        Assert.That(result.PartitionKey, Is.EqualTo("token:test-api-token:replay"));
+        _authServiceMock.Verify(a => a.GetUserByToken(It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Replays/ReplayRateLimitTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Replays/ReplayRateLimitTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +12,7 @@ using NUnit.Framework;
 using System.Threading.RateLimiting;
 using System.Threading.Tasks;
 using W3C.Contracts.Admin.Permission;
+using W3ChampionsStatisticService.Matches;
 using W3ChampionsStatisticService.Ports;
 using W3ChampionsStatisticService.RateLimiting.Models;
 using W3ChampionsStatisticService.RateLimiting.Services;
@@ -187,6 +189,84 @@ public class ReplayRateLimitTests
         Assert.That(result.HourlyLimit, Is.EqualTo(10));
         Assert.That(result.DailyLimit, Is.EqualTo(50));
         Assert.That(result.PartitionKey, Is.EqualTo("ip:192.168.1.1:replay"));
+    }
+
+    [Test]
+    public async Task NonAdminWithModerationPermission_LeavesLimitsUnchanged()
+    {
+        // Regression coverage: holding EPermission.Moderation is not sufficient on its
+        // own. BearerHasPermissionFilter's own check requires IsAdmin == true as well,
+        // and ReplayRateLimitAttribute must copy that exactly.
+        SetupBaseContext();
+
+        _httpContext.Request.Headers["Authorization"] = "Bearer valid-non-admin-token";
+        _authServiceMock
+            .Setup(a => a.GetUserByToken("valid-non-admin-token", true))
+            .Returns(new W3CUserAuthenticationDto
+            {
+                BattleTag = "NotAnAdmin#789",
+                IsAdmin = false,
+                Permissions = new HashSet<EPermission> { EPermission.Moderation }
+            });
+
+        var result = await Invoke();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.HourlyLimit, Is.EqualTo(10));
+        Assert.That(result.DailyLimit, Is.EqualTo(50));
+        Assert.That(result.PolicyName, Is.EqualTo(StrictPolicy));
+        Assert.That(result.PartitionKey, Is.EqualTo("ip:192.168.1.1:replay"));
+    }
+
+    [Test]
+    public async Task ModeratorOnRecentMatch_KeepsHigherRelaxedLimit()
+    {
+        // The relaxed policy can already grant an hourly limit higher than
+        // ModeratorHourlyLimit. The override must raise, never lower, the limit.
+        const int relaxedHourlyLimit = 100;
+        const int relaxedDailyLimit = 150;
+        _attribute.RelaxedHourlyLimit = relaxedHourlyLimit;
+        _attribute.RelaxedDailyLimit = relaxedDailyLimit;
+
+        _context.ActionArguments["gameId"] = "recent-game-id";
+        _matchRepositoryMock
+            .Setup(m => m.LoadFinishedMatchDetailsByMatchId("recent-game-id"))
+            .ReturnsAsync(new MatchupDetail
+            {
+                Match = new Matchup { EndTime = DateTimeOffset.UtcNow.AddDays(-1) }
+            });
+
+        var relaxedContext = new RateLimitContext
+        {
+            PolicyName = "replay-relaxed",
+            HourlyLimit = relaxedHourlyLimit,
+            DailyLimit = relaxedDailyLimit,
+            HasValidApiToken = false,
+            PartitionKey = "ip:192.168.1.1:replay"
+        };
+        _rateLimitServiceMock
+            .Setup(s => s.DetermineRateLimitContext(_httpContext, "replay", "replay-relaxed", relaxedHourlyLimit, relaxedDailyLimit))
+            .ReturnsAsync(relaxedContext);
+
+        const string battleTag = "Moderator#123";
+        _httpContext.Request.Headers["Authorization"] = "Bearer valid-moderator-token";
+        _authServiceMock
+            .Setup(a => a.GetUserByToken("valid-moderator-token", true))
+            .Returns(new W3CUserAuthenticationDto
+            {
+                BattleTag = battleTag,
+                IsAdmin = true,
+                Permissions = new HashSet<EPermission> { EPermission.Moderation }
+            });
+
+        var result = await Invoke();
+
+        Assert.That(result, Is.Not.Null);
+        // Must stay at the relaxed 100, NOT be pulled down to ModeratorHourlyLimit (50).
+        Assert.That(result.HourlyLimit, Is.EqualTo(relaxedHourlyLimit));
+        Assert.That(result.DailyLimit, Is.EqualTo(relaxedDailyLimit));
+        Assert.That(result.PolicyName, Is.EqualTo(ModeratorPolicy));
+        Assert.That(result.PartitionKey, Is.EqualTo($"moderator:{battleTag}:replay"));
     }
 
     [Test]

--- a/docs/superpowers/plans/2026-08-05-cancelled-matches-admin-page.md
+++ b/docs/superpowers/plans/2026-08-05-cancelled-matches-admin-page.md
@@ -813,7 +813,14 @@ git commit -m "Proxy the matchmaking cancelled-matches endpoint"
 
 **Interfaces:**
 - Consumes: `MatchmakingServiceClient.GetCanceledMatches` from Task 5.
-- Produces: `GET api/admin/matches/canceled?gameMode=&battleTag=&page=&itemsPerPage=` returning `{ total, matches }`. Phase 3 calls this.
+- Produces: `GET api/admin/matches/canceled?gameMode=&playerBattleTag=&page=&itemsPerPage=` returning `{ total, matches }`. Phase 3 calls this.
+
+> **The search parameter MUST NOT be named `battleTag`.** `BearerHasPermissionFilter.cs:33`
+> does `context.ActionArguments["battleTag"] = res.BattleTag;` unconditionally, so on any
+> action it guards, a parameter with that exact name is silently overwritten with the acting
+> moderator's own battletag. A `battleTag` search filter would quietly return only the
+> moderator's own matches. Unit tests calling the controller method directly cannot see this,
+> because they bypass filters.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -981,7 +988,9 @@ public class AdminMatchesController(MatchmakingServiceClient matchmakingServiceC
     [BearerHasPermissionFilter(Permission = EPermission.Moderation)]
     public async Task<IActionResult> GetCanceledMatches(
         [FromQuery] GameMode gameMode = GameMode.Undefined,
-        [FromQuery] string battleTag = null,
+        // NOT named battleTag: BearerHasPermissionFilter overwrites an argument
+        // with that exact name with the acting moderator's own tag.
+        [FromQuery] string playerBattleTag = null,
         [FromQuery] int page = 1,
         [FromQuery] int itemsPerPage = 25)
     {
@@ -994,7 +1003,7 @@ public class AdminMatchesController(MatchmakingServiceClient matchmakingServiceC
             Page = page,
             ItemsPerPage = itemsPerPage,
             GameMode = gameMode,
-            BattleTag = battleTag,
+            BattleTag = playerBattleTag,
         });
 
         if (result == null)
@@ -1400,7 +1409,7 @@ test("getCancelledMatches omits an all-modes filter and an empty battle tag", as
   await service.getCancelledMatches("tok", { gameMode: 0, page: 1, itemsPerPage: 25, battleTag: "" });
 
   assert.ok(!calls[0].url.includes("gameMode="));
-  assert.ok(!calls[0].url.includes("battleTag="));
+  assert.ok(!calls[0].url.includes("playerBattleTag="));
 });
 
 test("getCancelledMatches sends the selected mode and encodes the battle tag", async () => {
@@ -1409,7 +1418,7 @@ test("getCancelledMatches sends the selected mode and encodes the battle tag", a
   await service.getCancelledMatches("tok", { gameMode: 5, page: 1, itemsPerPage: 25, battleTag: "Tester#1234" });
 
   assert.ok(calls[0].url.includes("gameMode=5"));
-  assert.ok(calls[0].url.includes("battleTag=Tester%231234"));
+  assert.ok(calls[0].url.includes("playerBattleTag=Tester%231234"));
 });
 
 test("getCancelledMatches surfaces a failure rather than an empty page", async () => {
@@ -1537,8 +1546,12 @@ export class CancelledMatchService {
       params.set("gameMode", String(query.gameMode));
     }
 
+    // The backend parameter is deliberately NOT called "battleTag":
+    // BearerHasPermissionFilter overwrites an action argument of that exact name
+    // with the acting moderator's own tag, which would silently turn this search
+    // into "matches I played in".
     if (query.battleTag) {
-      params.set("battleTag", query.battleTag);
+      params.set("playerBattleTag", query.battleTag);
     }
 
     return await this.client.getJson<CancelledMatchesPage>(

--- a/docs/superpowers/plans/2026-08-05-cancelled-matches-admin-page.md
+++ b/docs/superpowers/plans/2026-08-05-cancelled-matches-admin-page.md
@@ -17,7 +17,7 @@
 - **`dotnet` was not available in the environment where this plan was written.** Every C# task's verification step must actually be run by the implementer; do not assume the code compiles.
 - **Permission gate is `EPermission.Moderation`** on every new backend endpoint. `BearerHasPermissionFilter` is `AttributeTargets.Method`, so it must be repeated on every action — it cannot be applied at controller level.
 - **Never call the replay service from a list endpoint or during list rendering.** Replay-service calls cost money. Chat logs and replays are fetched only on an explicit per-match user action. Replay availability is inferred from `floGameId != null`, never by probing.
-- **PII:** this page exposes real battletags for modes anonymised in-game. Do not log battletags, do not commit fixtures containing real battletags, and keep the Moderation gate server-side.
+- **Disclosure:** battletags are public information and are not PII — they may be logged and traced freely, and no tracing exclusions are warranted on their account. What this page does that is sensitive is *linking* flo's anonymised `Player N` back to an account in modes that deliberately hide names in-game. That linkage is what the Moderation gate protects, and the gate must be enforced server-side on every action; a client-side flag is not sufficient.
 - **Never enable read model handlers locally** (`CLAUDE.md`) and never point local runs at the production database.
 - **`GameMode.Undefined` (0) means "all game modes"** everywhere in this feature.
 - **`slotIndex` is 0-based** (matches the `CreateGameSlot[]` index). Flo renders the mask as `Player {index + 1}`, so all user-facing display must add 1.

--- a/docs/superpowers/plans/2026-08-05-cancelled-matches-admin-page.md
+++ b/docs/superpowers/plans/2026-08-05-cancelled-matches-admin-page.md
@@ -1,0 +1,1887 @@
+# Cancelled Matches Admin Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give moderators an admin page listing cancelled (non-ranked) matches per game mode, with per-row replay download and chat log access, and enough identity information to attribute misbehaviour in anonymised FFA modes.
+
+**Architecture:** The statistic service does not store cancelled matches and the `MatchCanceledEvent` stream is incomplete (it misses every game-creation failure). Matchmaking's own `Match` collection records all of them, so `website-backend` proxies a new matchmaking admin endpoint rather than building a read model. The frontend adds a dedicated admin grid that reuses the existing match-history leaf components.
+
+**Tech Stack:** TypeScript + Express + MongoDB + mocha/chai/sinon/supertest (matchmaking-service); .NET 8 + ASP.NET Core + Newtonsoft.Json + NUnit/Moq (website-backend); Vue 3 + TypeScript + Vuetify + Pinia + vitest (website).
+
+**Design spec:** `docs/superpowers/specs/2026-08-05-cancelled-matches-admin-page-design.md`
+
+## Global Constraints
+
+- **Three repositories, in dependency order.** Phase 1 `/home/francis/repos/matchmaking-service`, Phase 2 `/home/francis/repos/w3c-backend`, Phase 3 `/home/francis/repos/w3c-website`. Each phase is independently deployable and must be merged and deployed before the next phase returns data.
+- **Create a branch in each repo before editing.** Never commit to `master`/`main`. The backend work already has a branch, `worktree-cancelled-matches-admin-spec`, containing the spec and the `GM_FOOTMEN_FRENZY` fix.
+- **`dotnet` was not available in the environment where this plan was written.** Every C# task's verification step must actually be run by the implementer; do not assume the code compiles.
+- **Permission gate is `EPermission.Moderation`** on every new backend endpoint. `BearerHasPermissionFilter` is `AttributeTargets.Method`, so it must be repeated on every action — it cannot be applied at controller level.
+- **Never call the replay service from a list endpoint or during list rendering.** Replay-service calls cost money. Chat logs and replays are fetched only on an explicit per-match user action. Replay availability is inferred from `floGameId != null`, never by probing.
+- **PII:** this page exposes real battletags for modes anonymised in-game. Do not log battletags, do not commit fixtures containing real battletags, and keep the Moderation gate server-side.
+- **Never enable read model handlers locally** (`CLAUDE.md`) and never point local runs at the production database.
+- **`GameMode.Undefined` (0) means "all game modes"** everywhere in this feature.
+- **`slotIndex` is 0-based** (matches the `CreateGameSlot[]` index). Flo renders the mask as `Player {index + 1}`, so all user-facing display must add 1.
+- **Spelling is deliberately inconsistent between layers.** Server-side identifiers use the single-l `Canceled` spelling to match the existing `EMatchState.CANCELED` and `MatchCanceledEvent` — this covers the matchmaking route (`/admin/canceled-matches`), the backend route (`api/admin/matches/canceled`) and all C# type names. Frontend identifiers and all user-visible copy use `Cancelled`. Do not "fix" either side to match the other; follow whichever convention the file you are editing already uses.
+
+---
+
+## File Structure
+
+**Phase 1 — matchmaking-service**
+
+| File | Responsibility |
+| --- | --- |
+| `src/app/flows/game-creation/helpers/player-slots.helper.ts` | Modify: persist the assigned slot index onto the match player |
+| `src/app/data/repos/matches.repo.ts` | Modify: paged cancelled-match query + supporting index |
+| `src/app/apis/admin.api.ts` | Modify: new `GET /admin/canceled-matches` route |
+| `src/tests/app/player-slots.helper.test.ts` | Create: slot index assignment test |
+| `src/tests/app/admin-canceled-matches.api.test.ts` | Create: route test |
+
+**Phase 2 — website-backend**
+
+| File | Responsibility |
+| --- | --- |
+| `W3C.Domain/MatchmakingService/MatchEventDtos.cs` | Modify: JSON mapping for `_id`, entity timestamps, `slotIndex` |
+| `W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs` | Modify: proxy method + request/response DTOs |
+| `W3ChampionsStatisticService/Admin/AdminMatchesController.cs` | Create: Moderation-gated `api/admin/matches/canceled` |
+| `W3C.Domain/ReplayService/ReplayServiceClient.cs` | Modify: map unavailable replay/chat to a 404-able outcome |
+| `W3ChampionsStatisticService/Replays/ReplaysController.cs` | Modify: return 404 when the replay service has nothing |
+| `W3ChampionsStatisticService/WebApi/ActionFilters/ReplayRateLimitAttribute.cs` | Modify: moderator hourly limit |
+| `WC3ChampionsStatisticService.UnitTests/GameModes/GameModesHelperTests.cs` | Create: FFA mode membership |
+| `WC3ChampionsStatisticService.UnitTests/Admin/AdminMatchesControllerTests.cs` | Create: proxy + permission tests |
+
+**Phase 3 — website**
+
+| File | Responsibility |
+| --- | --- |
+| `src/types/admin/CancelledMatch.ts` | Create: DTOs |
+| `src/services/admin/CancelledMatchService.ts` | Create: list + chat-log-by-flo-id calls |
+| `src/services/admin/CancelledMatchService.test.ts` | Create: service tests |
+| `src/components/matches/PlayerMatchInfo.vue` | Modify: `noWinner` prop |
+| `src/components/matches/TeamMatchInfo.vue` | Modify: pass `noWinner` through |
+| `src/components/matches/DownloadReplayIcon.vue` | Modify: optional `floGameId` prop |
+| `src/store/admin/replayManagement/store.ts` | Modify: `loadChatLogByFloId` |
+| `src/components/admin/replays/AdminReplayChatLogMessages.vue` | Modify: optional `floGameId` prop |
+| `src/components/admin/AdminCancelledMatches.vue` | Create: the page |
+| `src/router/types.ts`, `src/router/index.ts`, `src/components/admin/AdminNavigation.vue` | Modify: route + nav entry |
+
+---
+
+# Phase 1 — matchmaking-service
+
+Work in `/home/francis/repos/matchmaking-service`. Run `git checkout -b feat/cancelled-matches-admin` before Task 1.
+
+Commands: `npm run build` (tsc), `npm run lint`, `npm test` (mocha).
+
+---
+
+### Task 1: Persist the FLO slot index on match players
+
+`IMatchPlayer.slotIndex` already exists and is documented as the canonical 0-based FLO slot index, but only custom games populate it. `setPlayersToSlots` computes the assignment for matchmaking games and discards it. Persisting it lets the admin page show `Player N` next to a battletag with no replay-service call.
+
+**Files:**
+- Modify: `src/app/flows/game-creation/helpers/player-slots.helper.ts:14-29`
+- Test: `src/tests/app/player-slots.helper.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `IMatchPlayer.slotIndex` populated (0-based) on every non-computer player of a match that reached flo game creation. Phase 2 reads this as `slotIndex` on the player JSON.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/app/player-slots.helper.test.ts`:
+
+```ts
+import { expect } from 'chai';
+import { generateEmptySlots, setPlayersToSlots } from 'app/flows/game-creation/helpers/player-slots.helper';
+import { GameCreationPlayer } from 'app/flows/game-creation/game-creation.models';
+import { MapEntity } from 'app/data/models/mapEntity';
+
+function playerStub(team: number, floPlayerId: number): GameCreationPlayer {
+    return {
+        matchPlayer: { team, battleTag: `player-${floPlayerId}` },
+        playerInstance: { floPlayer: { id: floPlayerId } },
+    } as unknown as GameCreationPlayer;
+}
+
+function mapStub(): MapEntity {
+    return { gameMap: { twelve_p: false }, mappedForces: undefined } as unknown as MapEntity;
+}
+
+describe('setPlayersToSlots', function() {
+    it('records the assigned slot index on each match player', function() {
+        const slots = generateEmptySlots(false);
+        const players = [playerStub(0, 101), playerStub(1, 102)];
+
+        setPlayersToSlots(players, slots, mapStub());
+
+        for (const player of players) {
+            const slotIndex = player.matchPlayer.slotIndex;
+            expect(slotIndex).to.be.a('number');
+            expect(slots[slotIndex!].player_id).to.equal(player.playerInstance.floPlayer.id);
+        }
+    });
+
+    it('assigns a distinct slot index per player', function() {
+        const slots = generateEmptySlots(false);
+        const players = [playerStub(0, 101), playerStub(1, 102)];
+
+        setPlayersToSlots(players, slots, mapStub());
+
+        const indexes = players.map(p => p.matchPlayer.slotIndex);
+        expect(new Set(indexes).size).to.equal(players.length);
+    });
+});
+```
+
+If `generateEmptySlots` or `getNextAvailableSlot` requires more of `MapEntity` than the stub provides (for example map forces), extend `mapStub()` with the minimum fields those functions actually read — read `player-slots.helper.ts` and match it. Do not change production code to accommodate the stub.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx mocha src/tests/app/player-slots.helper.test.ts --require src/tests/load-environment-variables.ts`
+Expected: FAIL — `expected undefined to be a number`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/app/flows/game-creation/helpers/player-slots.helper.ts`, inside `setPlayersToSlots`, after the slot is resolved:
+
+```ts
+export const setPlayersToSlots = (allPlayers: GameCreationPlayer[], slots: CreateGameSlot[], map: MapEntity) => {
+    allPlayers.forEach(x => {
+        const slot = getNextAvailableSlot(slots, x.matchPlayer.team, map);
+        const isObs = x.matchPlayer.team == OBS_TEAM;
+
+        slot.player_id = x.playerInstance.floPlayer.id;
+        // Persist the lobby slot so downstream consumers can map flo's masked
+        // "Player N" names (N = slotIndex + 1) back to a battleTag without
+        // re-reading the replay. Custom games already set this earlier.
+        x.matchPlayer.slotIndex = slots.indexOf(slot);
+        slot.settings = {
+            color: null,
+            team: x.matchPlayer.team,
+            computer: null,
+            handicap: 100,
+            status: SlotStatus.Occupied,
+            race: isObs ? 0 : convertToFloRace(x.matchPlayer.race),
+        };
+    });
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx mocha src/tests/app/player-slots.helper.test.ts --require src/tests/load-environment-variables.ts`
+Expected: PASS (2 passing)
+
+- [ ] **Step 5: Verify nothing else regressed**
+
+Run: `npm run build && npm run lint && npm test`
+Expected: build succeeds, lint clean, full suite passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/flows/game-creation/helpers/player-slots.helper.ts src/tests/app/player-slots.helper.test.ts
+git commit -m "Record the assigned FLO slot index on matchmaking match players"
+```
+
+---
+
+### Task 2: Paged cancelled-match query on MatchesRepo
+
+**Files:**
+- Modify: `src/app/data/repos/matches.repo.ts` (imports, `initialize`, new method)
+- Test: `src/tests/app/matches.repo.canceled.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `export interface CanceledMatchesQuery { gameMode?: EGameMode; battleTag?: string; page: number; itemsPerPage: number; }`
+  - `export interface CanceledMatchesPage { total: number; matches: Match[]; }`
+  - `MatchesRepo.getCanceledMatches(query: CanceledMatchesQuery): Promise<CanceledMatchesPage>`
+
+  Task 3 calls `dbContext.matchesRepo.getCanceledMatches(...)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/app/matches.repo.canceled.test.ts`:
+
+```ts
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { MatchesRepo } from 'app/data/repos/matches.repo';
+import { EMatchState } from 'app/data/models/match';
+import { EGameMode } from 'shared/data/enums';
+
+function repoWith(findResult: any[], countResult: number) {
+    const repo = Object.create(MatchesRepo.prototype) as MatchesRepo;
+    const find = sinon.stub().resolves(findResult);
+    const count = sinon.stub().resolves(countResult);
+    (repo as any).find = find;
+    (repo as any).count = count;
+    return { repo, find, count };
+}
+
+describe('MatchesRepo.getCanceledMatches', function() {
+    it('filters to cancelled matches and returns the total', async function() {
+        const { repo, find, count } = repoWith([{ _id: 'abc' }], 7);
+
+        const result = await repo.getCanceledMatches({ page: 1, itemsPerPage: 25 });
+
+        expect(result.total).to.equal(7);
+        expect(result.matches).to.have.length(1);
+        expect(find.firstCall.args[0]).to.deep.equal({ state: EMatchState.CANCELED });
+        expect(count.firstCall.args[0]).to.deep.equal({ state: EMatchState.CANCELED });
+    });
+
+    it('applies the game mode and battle tag filters', async function() {
+        const { repo, find } = repoWith([], 0);
+
+        await repo.getCanceledMatches({
+            page: 1,
+            itemsPerPage: 25,
+            gameMode: EGameMode.GM_1ON1,
+            battleTag: 'Player#1234',
+        });
+
+        expect(find.firstCall.args[0]).to.deep.equal({
+            state: EMatchState.CANCELED,
+            gameMode: EGameMode.GM_1ON1,
+            'players.battleTag': 'Player#1234',
+        });
+    });
+
+    it('sorts newest first and computes the offset from the page', async function() {
+        const { repo, find } = repoWith([], 0);
+
+        await repo.getCanceledMatches({ page: 3, itemsPerPage: 10 });
+
+        expect(find.firstCall.args[1]).to.equal(10);
+        expect(find.firstCall.args[2]).to.deep.equal({ '_updated_at': -1 });
+        expect(find.firstCall.args[3]).to.equal(20);
+    });
+
+    it('falls back to safe paging values and caps the page size', async function() {
+        const { repo, find } = repoWith([], 0);
+
+        await repo.getCanceledMatches({ page: 0, itemsPerPage: 5000 });
+
+        expect(find.firstCall.args[1]).to.equal(100);
+        expect(find.firstCall.args[3]).to.equal(0);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx mocha src/tests/app/matches.repo.canceled.test.ts --require src/tests/load-environment-variables.ts`
+Expected: FAIL — `repo.getCanceledMatches is not a function`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/app/data/repos/matches.repo.ts`, add the mongodb types to the imports:
+
+```ts
+import { Filter, Sort } from 'mongodb';
+```
+
+Add the exported types above the `MatchesRepo` class (mirroring `PlayerWarningsQuery`/`PlayerWarningsPage` in `player-warnings.repo.ts:9-19`):
+
+```ts
+export const MaxCanceledMatchesPageSize = 100;
+
+export interface CanceledMatchesQuery {
+    gameMode?: EGameMode;
+    battleTag?: string;
+    page: number;
+    itemsPerPage: number;
+}
+
+export interface CanceledMatchesPage {
+    total: number;
+    matches: Match[];
+}
+```
+
+Add the method to `MatchesRepo`:
+
+```ts
+/**
+ * Cancelled matches are never in the in-memory `matches` cache - `initialize`
+ * only loads non-cancelled matches and `cancelMatch` removes them - so this
+ * always queries Mongo.
+ *
+ * Sorted by `_updated_at`, which `EntityRepo.save` stamps immediately before the
+ * write. For a document still in the CANCELED state that is the moment it was
+ * cancelled: nothing rewrites it afterwards except a heal, which moves it to
+ * FINISHED and out of this result set.
+ */
+public async getCanceledMatches(query: CanceledMatchesQuery): Promise<CanceledMatchesPage> {
+    const filter: Filter<Match> = { state: EMatchState.CANCELED };
+
+    if (query.gameMode !== undefined) {
+        filter.gameMode = query.gameMode;
+    }
+
+    if (query.battleTag) {
+        filter['players.battleTag'] = query.battleTag;
+    }
+
+    const page = Number.isFinite(query.page) && query.page > 0 ? query.page : 1;
+    const requestedPageSize = Number.isFinite(query.itemsPerPage) && query.itemsPerPage > 0 ? query.itemsPerPage : 25;
+    const itemsPerPage = Math.min(requestedPageSize, MaxCanceledMatchesPageSize);
+    const sort: Sort = { '_updated_at': -1 };
+    const offset = (page - 1) * itemsPerPage;
+
+    const [matches, total] = await Promise.all([
+        this.find(filter, itemsPerPage, sort, offset),
+        this.count(filter),
+    ]);
+
+    return { total, matches };
+}
+```
+
+Add the supporting index in `initialize()`, alongside the existing two:
+
+```ts
+public async initialize(): Promise<void> {
+    await this.createIndex({ '_created_at': -1 });
+    await this.createIndex({ 'players.battleTag': 1 });
+    await this.createIndex({ 'state': 1, 'gameMode': 1, '_updated_at': -1 });
+    // ... unchanged below
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx mocha src/tests/app/matches.repo.canceled.test.ts --require src/tests/load-environment-variables.ts`
+Expected: PASS (4 passing)
+
+- [ ] **Step 5: Verify the whole suite**
+
+Run: `npm run build && npm run lint && npm test`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/data/repos/matches.repo.ts src/tests/app/matches.repo.canceled.test.ts
+git commit -m "Add a paged cancelled-match query and its index"
+```
+
+---
+
+### Task 3: `GET /admin/canceled-matches` route
+
+**Files:**
+- Modify: `src/app/apis/admin.api.ts` (new route beside `/warnings` at `:55-73`)
+- Test: `src/tests/app/admin-canceled-matches.api.test.ts`
+
+**Interfaces:**
+- Consumes: `dbContext.matchesRepo.getCanceledMatches(query)` from Task 2.
+- Produces: `GET /admin/canceled-matches?page=&itemsPerPage=&gameMode=&battleTag=` returning `{ total: number, matches: Match[] }`, guarded by `requireAdmin` (header `x-admin-secret`). Phase 2 Task 5 calls this.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/app/admin-canceled-matches.api.test.ts`:
+
+```ts
+import { expect } from 'chai';
+import express from 'express';
+import request from 'supertest';
+import sinon from 'sinon';
+import { AdminAPI } from 'app/apis/admin.api';
+import { dbContext } from 'app/data/dbContext';
+import { EGameMode } from 'shared/data/enums';
+
+describe('AdminAPI cancelled matches', function() {
+    const previousAdminSecret = process.env.ADMIN_API_SECRET;
+    let app: express.Express;
+    let sandbox: sinon.SinonSandbox;
+    let originalMatchesRepo: any;
+
+    before(function() {
+        process.env.ADMIN_API_SECRET = 'test-secret';
+    });
+
+    after(function() {
+        process.env.ADMIN_API_SECRET = previousAdminSecret;
+    });
+
+    beforeEach(function() {
+        sandbox = sinon.createSandbox();
+        originalMatchesRepo = (dbContext as any).matchesRepo;
+        app = express();
+        app.use(express.json());
+        app.use('/admin', new AdminAPI(app).getHandler());
+    });
+
+    afterEach(function() {
+        (dbContext as any).matchesRepo = originalMatchesRepo;
+        sandbox.restore();
+    });
+
+    it('rejects requests without the admin secret', async function() {
+        const res = await request(app).get('/admin/canceled-matches');
+
+        expect(res.status).to.equal(403);
+    });
+
+    it('lists cancelled matches through the repo', async function() {
+        const getCanceledMatches = sandbox.stub().resolves({ total: 1, matches: [{ _id: 'match-1' }] });
+        (dbContext as any).matchesRepo = { getCanceledMatches };
+
+        const res = await request(app)
+            .get('/admin/canceled-matches?page=2&itemsPerPage=10&gameMode=1&battleTag=Player%231234')
+            .set('x-admin-secret', 'test-secret');
+
+        expect(res.status).to.equal(200);
+        expect(res.body.total).to.equal(1);
+        expect(res.body.matches[0]._id).to.equal('match-1');
+        expect(getCanceledMatches.calledOnceWith({
+            page: 2,
+            itemsPerPage: 10,
+            gameMode: EGameMode.GM_1ON1,
+            battleTag: 'Player#1234',
+        })).to.equal(true);
+    });
+
+    it('treats game mode 0 as all game modes', async function() {
+        const getCanceledMatches = sandbox.stub().resolves({ total: 0, matches: [] });
+        (dbContext as any).matchesRepo = { getCanceledMatches };
+
+        await request(app)
+            .get('/admin/canceled-matches?gameMode=0')
+            .set('x-admin-secret', 'test-secret');
+
+        expect(getCanceledMatches.firstCall.args[0].gameMode).to.equal(undefined);
+    });
+
+    it('rejects a non-numeric game mode', async function() {
+        (dbContext as any).matchesRepo = { getCanceledMatches: sandbox.stub() };
+
+        const res = await request(app)
+            .get('/admin/canceled-matches?gameMode=nope')
+            .set('x-admin-secret', 'test-secret');
+
+        expect(res.status).to.equal(400);
+    });
+});
+```
+
+`EGameMode.GM_1ON1` must equal `1`. Open `src/shared/data/enums.ts` and confirm; if the numeric value differs, use the correct member and matching query string rather than changing the assertion to a bare number.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx mocha src/tests/app/admin-canceled-matches.api.test.ts --require src/tests/load-environment-variables.ts`
+Expected: FAIL — the route 404s, so the first passing assertion is wrong (403 vs 404).
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/app/apis/admin.api.ts`, add this route immediately after the `/warnings` route block. `EGameMode` and `dbContext` are already imported in this file; confirm and add the import if not.
+
+```ts
+this.getRouter().get('/canceled-matches', requireAdmin, async (req: Request, res: Response, _next: NextFunction) => {
+    const page = Number(req.query.page || 1);
+    const itemsPerPage = Number(req.query.itemsPerPage || 25);
+    const battleTag = req.query.battleTag as string | undefined;
+
+    // Game mode 0 (Undefined) means "all modes", so it is simply left off the filter.
+    let gameMode: EGameMode | undefined;
+    const rawGameMode = req.query.gameMode;
+    if (rawGameMode !== undefined && rawGameMode !== '') {
+        const parsedGameMode = Number(rawGameMode);
+        if (!Number.isFinite(parsedGameMode)) {
+            return res.status(400).json({ errors: [{ msg: `Invalid game mode: ${rawGameMode}` }] });
+        }
+        if (parsedGameMode !== 0) {
+            gameMode = parsedGameMode as EGameMode;
+        }
+    }
+
+    const result = await dbContext.matchesRepo.getCanceledMatches({
+        page,
+        itemsPerPage,
+        gameMode,
+        battleTag,
+    });
+
+    return res.json(result);
+});
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx mocha src/tests/app/admin-canceled-matches.api.test.ts --require src/tests/load-environment-variables.ts`
+Expected: PASS (4 passing)
+
+- [ ] **Step 5: Verify the whole suite**
+
+Run: `npm run build && npm run lint && npm test`
+Expected: all green.
+
+- [ ] **Step 6: Commit and open the Phase 1 PR**
+
+```bash
+git add src/app/apis/admin.api.ts src/tests/app/admin-canceled-matches.api.test.ts
+git commit -m "Expose cancelled matches on the admin API"
+git push -u origin feat/cancelled-matches-admin
+```
+
+Open a PR. In the description, note that `matches.manager.ts:168` still omits the `pushMatchCanceled`/`pushMatchStart` calls that `:319` makes, so game-creation failures remain invisible to the event stream — this endpoint sidesteps that, but the inconsistency is worth fixing separately.
+
+---
+
+# Phase 2 — website-backend
+
+Work in `/home/francis/repos/w3c-backend`, on branch `worktree-cancelled-matches-admin-spec` (already contains the spec and the `GM_FOOTMEN_FRENZY` fix).
+
+Commands: `dotnet build`, `dotnet test`, `dotnet format --verify-no-changes`.
+
+---
+
+### Task 4: DTO mapping for the proxied payload
+
+The existing `Match` / `PlayerMMrChange` / `UnfinishedMatchPlayer` DTOs already model a matchmaking match document, so they are reused rather than duplicated. But they are annotated for **BSON only**, and `MatchmakingServiceClient` deserialises with **Newtonsoft**, which ignores `[BsonElement]`. Without a `[JsonProperty("_id")]` the match id silently deserialises as `null`.
+
+Verified safe: the event `Match` DTO is not returned by any controller (`MatchesController`'s `Ok(match)` calls return `MatchupDetail`, which holds a `Matchup`), so adding JSON attributes changes no existing response.
+
+**Files:**
+- Modify: `W3C.Domain/MatchmakingService/MatchEventDtos.cs` (`Match` at `:100-151`, `UnfinishedMatchPlayer` at `:44`)
+- Test: `WC3ChampionsStatisticService.UnitTests/GameModes/GameModesHelperTests.cs` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Match.id` populated from JSON `_id`; `Match.createdAt` (`DateTimeOffset?`) from `_created_at`; `Match.canceledAt` (`DateTimeOffset?`) from `_updated_at`; `UnfinishedMatchPlayer.slotIndex` (`int?`). Task 5 and Task 6 rely on these names.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `WC3ChampionsStatisticService.UnitTests/GameModes/GameModesHelperTests.cs`:
+
+```csharp
+using Newtonsoft.Json;
+using NUnit.Framework;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.GameModes;
+using W3C.Domain.MatchmakingService;
+
+namespace WC3ChampionsStatisticService.Tests.GameModes;
+
+[TestFixture]
+public class GameModesHelperTests
+{
+    [Test]
+    public void FootmenFrenzyIsAnFfaGameMode()
+    {
+        Assert.That(GameModesHelper.IsFfaGameMode(GameMode.GM_FOOTMEN_FRENZY), Is.True);
+    }
+
+    [Test]
+    public void TheEstablishedFfaGameModesAreStillFfa()
+    {
+        Assert.That(GameModesHelper.IsFfaGameMode(GameMode.FFA), Is.True);
+        Assert.That(GameModesHelper.IsFfaGameMode(GameMode.GM_SC_FFA_4), Is.True);
+        Assert.That(GameModesHelper.IsFfaGameMode(GameMode.GM_SC_OZ), Is.True);
+    }
+
+    [Test]
+    public void LtwFfaIsNotAnonymisedAndStaysOutOfTheFfaList()
+    {
+        Assert.That(GameModesHelper.IsFfaGameMode(GameMode.GM_LTW_FFA), Is.False);
+        Assert.That(GameModesHelper.IsFfaGameMode(GameMode.GM_1v1), Is.False);
+    }
+}
+
+[TestFixture]
+public class MatchJsonMappingTests
+{
+    private const string CanceledMatchJson = """
+    {
+      "_id": "abc1234567",
+      "_created_at": "2026-08-01T10:00:00.000Z",
+      "_updated_at": "2026-08-01T16:05:00.000Z",
+      "state": 3,
+      "gameMode": 5,
+      "gamename": "w3c-test",
+      "startTime": 1754042400000,
+      "floGameId": 4242,
+      "players": [
+        { "battleTag": "Tester#1234", "team": 0, "race": 1, "slotIndex": 2 }
+      ]
+    }
+    """;
+
+    [Test]
+    public void MatchIdIsReadFromTheUnderscoreIdJsonProperty()
+    {
+        var match = JsonConvert.DeserializeObject<Match>(CanceledMatchJson);
+
+        Assert.That(match.id, Is.EqualTo("abc1234567"));
+    }
+
+    [Test]
+    public void EntityTimestampsAreMapped()
+    {
+        var match = JsonConvert.DeserializeObject<Match>(CanceledMatchJson);
+
+        Assert.That(match.createdAt, Is.Not.Null);
+        Assert.That(match.canceledAt, Is.Not.Null);
+        Assert.That(match.canceledAt!.Value, Is.GreaterThan(match.createdAt!.Value));
+    }
+
+    [Test]
+    public void SlotIndexIsMappedOnPlayers()
+    {
+        var match = JsonConvert.DeserializeObject<Match>(CanceledMatchJson);
+
+        Assert.That(match.players[0].slotIndex, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void AMissingEndTimeStaysZeroRatherThanThrowing()
+    {
+        var match = JsonConvert.DeserializeObject<Match>(CanceledMatchJson);
+
+        Assert.That(match.endTime, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void AMissingFloGameIdDeserialisesToNull()
+    {
+        var match = JsonConvert.DeserializeObject<Match>("""{"_id":"x","state":3}""");
+
+        Assert.That(match.floGameId, Is.Null);
+        Assert.That(match.HasFloGameId(), Is.False);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test --filter "FullyQualifiedName~GameModes"`
+Expected: `MatchJsonMappingTests` fail (`match.id` is null; `createdAt`/`canceledAt`/`slotIndex` do not compile). `GameModesHelperTests` should already pass — the `GM_FOOTMEN_FRENZY` fix is committed on this branch. If they fail, that fix is missing; restore it before continuing.
+
+- [ ] **Step 3: Write the implementation**
+
+In `W3C.Domain/MatchmakingService/MatchEventDtos.cs`, add `using Newtonsoft.Json;` if absent.
+
+On `Match`, annotate `id` and add the two entity timestamps:
+
+```csharp
+    // BsonElement covers reads from the raw event collections; JsonProperty covers
+    // the matchmaking admin API responses, which MatchmakingServiceClient
+    // deserialises with Newtonsoft. Newtonsoft ignores BsonElement, so without
+    // this the id silently comes back null.
+    [BsonElement("_id")]
+    [JsonProperty("_id")]
+    public string id { get; set; }
+    public int? floGameId { get; set; }
+
+    [BsonElement("_created_at")]
+    [JsonProperty("_created_at")]
+    public DateTimeOffset? createdAt { get; set; }
+
+    // EntityRepo.save stamps _updated_at immediately before the write, and
+    // cancelMatch goes through save. For a match still in the CANCELED state this
+    // is when it was cancelled; a heal would move it to FINISHED.
+    [BsonElement("_updated_at")]
+    [JsonProperty("_updated_at")]
+    public DateTimeOffset? canceledAt { get; set; }
+```
+
+Add `using System;` to the file if `DateTimeOffset` is not already resolvable.
+
+On `UnfinishedMatchPlayer`, add the slot index:
+
+```csharp
+    public FloPing[] floPings { get; set; }
+
+    // 0-based FLO lobby slot. Flo masks anonymised names as "Player {slotIndex + 1}",
+    // so display must add one. Null for matches that never reached game creation.
+    public int? slotIndex { get; set; }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~GameModes"`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Verify no regressions in the existing event handling**
+
+Run: `dotnet build && dotnet test`
+Expected: full suite passes. The read-model handler tests exercise BSON deserialisation of these same DTOs, so a green suite confirms the added attributes did not disturb it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add W3C.Domain/MatchmakingService/MatchEventDtos.cs WC3ChampionsStatisticService.UnitTests/GameModes/GameModesHelperTests.cs
+git commit -m "Map matchmaking JSON onto the shared match DTOs"
+```
+
+---
+
+### Task 5: `MatchmakingServiceClient.GetCanceledMatches`
+
+**Files:**
+- Modify: `W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs` (method beside `GetPlayerWarnings` at `:90-113`; DTOs beside `PlayerWarningsGetRequest` at `:758-770`)
+- Test: covered by Task 6's controller test (the client has no standalone test fixture today)
+
+**Interfaces:**
+- Consumes: Phase 1 Task 3's route; `Match` from Task 4.
+- Produces:
+  - `CanceledMatchesGetRequest { int Page = 1; int ItemsPerPage = 25; GameMode GameMode; string BattleTag; }`
+  - `CanceledMatchesResponse { int total; List<Match> matches; }`
+  - `Task<CanceledMatchesResponse> GetCanceledMatches(CanceledMatchesGetRequest req)`
+
+  Task 6 calls `GetCanceledMatches`.
+
+- [ ] **Step 1: Add the request/response DTOs**
+
+In `W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs`, beside the other admin DTOs:
+
+```csharp
+public class CanceledMatchesGetRequest
+{
+    public int Page { get; set; } = 1;
+    public int ItemsPerPage { get; set; } = 25;
+
+    // GameMode.Undefined (0) means "all game modes" and is not sent upstream.
+    public GameMode GameMode { get; set; }
+    public string BattleTag { get; set; }
+}
+
+public class CanceledMatchesResponse
+{
+    public int total { get; set; }
+    public List<Match> matches { get; set; }
+}
+```
+
+Ensure `using W3C.Contracts.Matchmaking;` is present for `GameMode`.
+
+- [ ] **Step 2: Add the proxy method**
+
+Mirror `GetPlayerWarnings` exactly, including the `x-admin-secret` header:
+
+```csharp
+public async Task<CanceledMatchesResponse> GetCanceledMatches(CanceledMatchesGetRequest req)
+{
+    var url = $"{MatchmakingApiUrl}/admin/canceled-matches?page={req.Page}&itemsPerPage={req.ItemsPerPage}";
+
+    if (req.GameMode != GameMode.Undefined)
+    {
+        url += $"&gameMode={(int)req.GameMode}";
+    }
+
+    if (!string.IsNullOrEmpty(req.BattleTag))
+    {
+        url += $"&battleTag={HttpUtility.UrlEncode(req.BattleTag)}";
+    }
+
+    var request = new HttpRequestMessage(HttpMethod.Get, url);
+    request.Headers.Add("x-admin-secret", AdminSecret);
+    var response = await _httpClient.SendAsync(request);
+
+    if (response.IsSuccessStatusCode)
+    {
+        return await GetResult<CanceledMatchesResponse>(response);
+    }
+
+    return null;
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `dotnet build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add W3C.Domain/MatchmakingService/MatchmakingServiceClient.cs
+git commit -m "Proxy the matchmaking cancelled-matches endpoint"
+```
+
+---
+
+### Task 6: `AdminMatchesController`
+
+**Files:**
+- Create: `W3ChampionsStatisticService/Admin/AdminMatchesController.cs`
+- Test: `WC3ChampionsStatisticService.UnitTests/Admin/AdminMatchesControllerTests.cs`
+
+**Interfaces:**
+- Consumes: `MatchmakingServiceClient.GetCanceledMatches` from Task 5.
+- Produces: `GET api/admin/matches/canceled?gameMode=&battleTag=&page=&itemsPerPage=` returning `{ total, matches }`. Phase 3 calls this.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `WC3ChampionsStatisticService.UnitTests/Admin/AdminMatchesControllerTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+using W3C.Contracts.Admin.Permission;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.MatchmakingService;
+using W3ChampionsStatisticService.Admin;
+using W3ChampionsStatisticService.WebApi.ActionFilters;
+
+namespace WC3ChampionsStatisticService.Tests.Admin;
+
+[TestFixture]
+public class AdminMatchesControllerTests
+{
+    private const string CanceledMatchesJson = """
+    {"total":3,"matches":[{"_id":"abc1234567","state":3,"gameMode":5,"floGameId":4242,
+    "players":[{"battleTag":"Tester#1234","team":0,"slotIndex":2}]}]}
+    """;
+
+    [Test]
+    public void CanceledMatchesRequiresModerationPermission()
+    {
+        var method = typeof(AdminMatchesController).GetMethod(nameof(AdminMatchesController.GetCanceledMatches))!;
+        var attribute = method.GetCustomAttribute<BearerHasPermissionFilter>();
+
+        Assert.That(attribute, Is.Not.Null);
+        Assert.That(attribute!.Permission, Is.EqualTo(EPermission.Moderation));
+    }
+
+    [Test]
+    public async Task CanceledMatchesForwardsFiltersAndAdminSecret()
+    {
+        var handler = new CapturingHandler(CanceledMatchesJson);
+        var controller = CreateController(handler);
+
+        var result = await controller.GetCanceledMatches(GameMode.FFA, "Tester#1234", 2, 10);
+
+        Assert.That(result, Is.InstanceOf<OkObjectResult>());
+        Assert.That(handler.Requests, Has.Count.EqualTo(1));
+        var uri = handler.Requests[0].RequestUri!;
+        Assert.That(uri.AbsolutePath, Does.EndWith("/admin/canceled-matches"));
+        Assert.That(uri.Query, Does.Contain("page=2"));
+        Assert.That(uri.Query, Does.Contain("itemsPerPage=10"));
+        Assert.That(uri.Query, Does.Contain("gameMode=5"));
+        Assert.That(uri.Query, Does.Contain("battleTag=Tester"));
+        Assert.That(handler.Requests[0].Headers.Contains("x-admin-secret"), Is.True);
+    }
+
+    [Test]
+    public async Task AllGameModesOmitsTheGameModeFilter()
+    {
+        var handler = new CapturingHandler(CanceledMatchesJson);
+        var controller = CreateController(handler);
+
+        await controller.GetCanceledMatches(GameMode.Undefined, null, 1, 25);
+
+        Assert.That(handler.Requests[0].RequestUri!.Query, Does.Not.Contain("gameMode="));
+    }
+
+    [Test]
+    public async Task PageSizeIsClampedBeforeItLeavesTheService()
+    {
+        var handler = new CapturingHandler(CanceledMatchesJson);
+        var controller = CreateController(handler);
+
+        await controller.GetCanceledMatches(GameMode.Undefined, null, 1, 5000);
+
+        Assert.That(handler.Requests[0].RequestUri!.Query, Does.Contain("itemsPerPage=100"));
+    }
+
+    [Test]
+    public async Task TheProxiedPayloadKeepsIdsSlotIndexesAndTotal()
+    {
+        var handler = new CapturingHandler(CanceledMatchesJson);
+        var controller = CreateController(handler);
+
+        var result = (OkObjectResult)await controller.GetCanceledMatches(GameMode.Undefined, null, 1, 25);
+        var payload = (CanceledMatchesResponse)result.Value!;
+
+        Assert.That(payload.total, Is.EqualTo(3));
+        Assert.That(payload.matches[0].id, Is.EqualTo("abc1234567"));
+        Assert.That(payload.matches[0].floGameId, Is.EqualTo(4242));
+        Assert.That(payload.matches[0].players[0].slotIndex, Is.EqualTo(2));
+    }
+
+    private static AdminMatchesController CreateController(CapturingHandler handler)
+    {
+        var client = new MatchmakingServiceClient(new TestHttpClientFactory(new HttpClient(handler)));
+        return new AdminMatchesController(client);
+    }
+
+    private class TestHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+
+    private class CapturingHandler(string responseBody) : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~AdminMatchesControllerTests"`
+Expected: FAIL — `AdminMatchesController` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `W3ChampionsStatisticService/Admin/AdminMatchesController.cs`:
+
+```csharp
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using W3C.Contracts.Admin.Permission;
+using W3C.Contracts.Matchmaking;
+using W3C.Domain.MatchmakingService;
+using W3C.Domain.Tracing;
+using W3ChampionsStatisticService.WebApi.ActionFilters;
+
+namespace W3ChampionsStatisticService.Admin;
+
+/// <summary>
+/// Moderation-facing views over matches that never produced a ranked result.
+///
+/// Cancelled matches are read straight from matchmaking, which is the only
+/// complete record: the MatchCanceledEvent stream omits every game-creation
+/// failure, so a read model built from it would be missing exactly the matches
+/// moderators care about.
+/// </summary>
+[ApiController]
+[Route("api/admin/matches")]
+[Trace]
+public class AdminMatchesController(MatchmakingServiceClient matchmakingServiceClient) : ControllerBase
+{
+    private const int MaxPageSize = 100;
+
+    private readonly MatchmakingServiceClient _matchmakingServiceClient = matchmakingServiceClient;
+
+    /// <param name="gameMode">GameMode.Undefined (0) lists every mode.</param>
+    [HttpGet("canceled")]
+    [BearerHasPermissionFilter(Permission = EPermission.Moderation)]
+    public async Task<IActionResult> GetCanceledMatches(
+        [FromQuery] GameMode gameMode = GameMode.Undefined,
+        [FromQuery] string battleTag = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int itemsPerPage = 25)
+    {
+        if (page < 1) page = 1;
+        if (itemsPerPage < 1) itemsPerPage = 25;
+        if (itemsPerPage > MaxPageSize) itemsPerPage = MaxPageSize;
+
+        var result = await _matchmakingServiceClient.GetCanceledMatches(new CanceledMatchesGetRequest
+        {
+            Page = page,
+            ItemsPerPage = itemsPerPage,
+            GameMode = gameMode,
+            BattleTag = battleTag,
+        });
+
+        if (result == null)
+        {
+            return StatusCode(502, "The matchmaking service did not return cancelled matches.");
+        }
+
+        return Ok(result);
+    }
+}
+```
+
+Confirm `MatchmakingServiceClient` is registered in `Program.cs` (it is used by `AdminController` already, so no new registration should be needed). If controllers are not auto-discovered, register as the neighbouring admin controllers are.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~AdminMatchesControllerTests"`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Verify the whole suite and formatting**
+
+Run: `dotnet build && dotnet test && dotnet format --verify-no-changes`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add W3ChampionsStatisticService/Admin/AdminMatchesController.cs WC3ChampionsStatisticService.UnitTests/Admin/AdminMatchesControllerTests.cs
+git commit -m "Add the Moderation-gated cancelled matches endpoint"
+```
+
+---
+
+### Task 7: Make unavailable replays and chat logs return 404
+
+A replay may never have been recorded, or may have aged into DeepArchive. Today both paths behave wrongly in opposite directions: `GetChatLogs` returns HTTP 200 with a null body, and `GenerateReplay` throws and becomes a 500.
+
+**Files:**
+- Modify: `W3C.Domain/ReplayService/ReplayServiceClient.cs:18-33`
+- Modify: `W3ChampionsStatisticService/Replays/ReplaysController.cs:21-79`
+- Test: `WC3ChampionsStatisticService.UnitTests/Replays/ReplayServiceClientTests.cs` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `ReplayServiceClient.GenerateReplay` returns `null` when the replay service has nothing; `GetChatLogs` returns `null` on any non-success status. `ReplaysController` turns both nulls into `NotFound()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `WC3ChampionsStatisticService.UnitTests/Replays/ReplayServiceClientTests.cs`:
+
+```csharp
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using W3C.Domain.ReplayService;
+
+namespace WC3ChampionsStatisticService.Tests.Replays;
+
+[TestFixture]
+public class ReplayServiceClientTests
+{
+    [Test]
+    public async Task AMissingChatLogComesBackAsNullRatherThanAnEmptyObject()
+    {
+        var client = ClientReturning(HttpStatusCode.NotFound, "not found");
+
+        var chats = await client.GetChatLogs(4242);
+
+        Assert.That(chats, Is.Null);
+    }
+
+    [Test]
+    public async Task AMissingReplayComesBackAsNullRatherThanThrowing()
+    {
+        var client = ClientReturning(HttpStatusCode.NotFound, "not found");
+
+        var replay = await client.GenerateReplay(4242);
+
+        Assert.That(replay, Is.Null);
+    }
+
+    [Test]
+    public async Task AnArchivedReplayComesBackAsNull()
+    {
+        var client = ClientReturning(HttpStatusCode.Gone, "archived");
+
+        var replay = await client.GenerateReplay(4242);
+
+        Assert.That(replay, Is.Null);
+    }
+
+    private static ReplayServiceClient ClientReturning(HttpStatusCode status, string body)
+    {
+        var handler = new StubHandler(status, body);
+        return new ReplayServiceClient(new TestHttpClientFactory(new HttpClient(handler)));
+    }
+
+    private class TestHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+
+    private class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+    }
+}
+```
+
+Open `ReplayServiceClient.cs` first and match the constructor signature and the `GenerateReplay` return type in the test; adjust the assertions to that type (it streams, so the "nothing available" value is whatever null-ish result the implementation below returns).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~ReplayServiceClientTests"`
+Expected: FAIL — `GetChatLogs` returns a non-null deserialised object, and `GenerateReplay` throws `HttpRequestException`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `W3C.Domain/ReplayService/ReplayServiceClient.cs`, replace `GetStreamAsync` with a status-checked `GetAsync`, and add the missing status check to `GetChatLogs`:
+
+```csharp
+    // A replay legitimately may not exist: it was never recorded, or it has aged
+    // into DeepArchive. Callers turn null into a 404 rather than a 500.
+    public async Task<Stream> GenerateReplay(int gameId)
+    {
+        var url = $"{ReplayServiceUrl}/generate/{gameId}?secret={AdminSecret}";
+        var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        return await response.Content.ReadAsStreamAsync();
+    }
+
+    public async Task<ReplayChatsData> GetChatLogs(int gameId)
+    {
+        var url = $"{ReplayServiceUrl}/chats/{gameId}?secret={AdminSecret}";
+        var response = await _httpClient.GetAsync(url);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonConvert.DeserializeObject<ReplayChatsData>(content);
+    }
+```
+
+Add `using System.IO;` if needed, and keep the existing return type of `GenerateReplay` if it already returns a stream by another name.
+
+In `W3ChampionsStatisticService/Replays/ReplaysController.cs`, guard all four actions. For each replay download action:
+
+```csharp
+        var replay = await _replayServiceClient.GenerateReplay(floMatchId);
+        if (replay == null) return NotFound();
+        return File(replay, "application/octet-stream", $"{floMatchId}.w3g");
+```
+
+and for each chats action:
+
+```csharp
+        var chats = await _replayServiceClient.GetChatLogs(floMatchId);
+        if (chats == null) return NotFound();
+        return Ok(chats);
+```
+
+Preserve each action's existing attributes, file name and content type — only the null guard is new.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~ReplayServiceClientTests"`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Verify the whole suite**
+
+Run: `dotnet build && dotnet test && dotnet format --verify-no-changes`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add W3C.Domain/ReplayService/ReplayServiceClient.cs W3ChampionsStatisticService/Replays/ReplaysController.cs WC3ChampionsStatisticService.UnitTests/Replays/ReplayServiceClientTests.cs
+git commit -m "Return 404 when a replay or chat log is unavailable"
+```
+
+---
+
+### Task 8: Raise the hourly replay limit for moderators
+
+Cancelled matches always fall into the strict bucket (10/hour), because `CheckMatchAge` resolves age through `LoadFinishedMatchDetailsBy*`, which returns null for a cancelled match. Ten downloads an hour is too few for a moderator working a list.
+
+**Files:**
+- Modify: `W3ChampionsStatisticService/WebApi/ActionFilters/ReplayRateLimitAttribute.cs:46-103`
+- Test: `WC3ChampionsStatisticService.UnitTests/Replays/ReplayRateLimitTests.cs` (create)
+
+**Interfaces:**
+- Consumes: `IW3CAuthenticationService` (registered at `Program.cs:178`).
+- Produces: `ReplayRateLimitAttribute.ModeratorHourlyLimit` (default 50). No signature changes.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `WC3ChampionsStatisticService.UnitTests/Replays/ReplayRateLimitTests.cs`. Read `ReplayRateLimitAttribute` and `RateLimitService` first, then write tests asserting:
+
+```csharp
+// 1. A request whose bearer token carries EPermission.Moderation gets
+//    HourlyLimit == 50, DailyLimit unchanged at the strict value of 50,
+//    PolicyName "replay-moderator", and PartitionKey "moderator:{battleTag}:replay".
+// 2. A request with a valid token WITHOUT Moderation keeps HourlyLimit 10
+//    and PartitionKey "ip:{ip}:replay".
+// 3. A request with no Authorization header is unchanged.
+// 4. A request carrying a valid X-API-Token is unchanged - HasValidApiToken wins.
+```
+
+Build the `ActionExecutingContext` with a `DefaultHttpContext` whose `RequestServices` resolves stubbed `IMatchRepository`, `ILogger<ReplayRateLimitAttribute>` and `IW3CAuthenticationService`. `DetermineRateLimitContext` is `protected`, so either call it through a small test-only subclass in the fixture or exercise the filter through `OnActionExecutionAsync`; pick whichever the existing `RateLimit` tests already do, if any exist.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~ReplayRateLimitTests"`
+Expected: FAIL — `ModeratorHourlyLimit` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+In `ReplayRateLimitAttribute`, add the property beside the other limits:
+
+```csharp
+    /// <summary>
+    /// Hourly limit for authenticated moderators. The daily limit deliberately stays
+    /// at the strict/relaxed value, so a moderator can spend a day's allowance in one
+    /// burst but not exceed it.
+    /// </summary>
+    public int ModeratorHourlyLimit { get; set; } = 50;
+```
+
+At the end of `DetermineRateLimitContext`, after the existing call:
+
+```csharp
+        var rateLimitContext = await rateLimitService.DetermineRateLimitContext(
+            context.HttpContext,
+            Scope,
+            policyName,
+            hourlyLimit,
+            dailyLimit);
+
+        // An API token already carries its own negotiated limits; never override them.
+        if (rateLimitContext.HasValidApiToken)
+        {
+            return rateLimitContext;
+        }
+
+        var moderatorBattleTag = await TryGetModeratorBattleTag(context, logger);
+        if (moderatorBattleTag != null)
+        {
+            rateLimitContext.HourlyLimit = ModeratorHourlyLimit;
+            rateLimitContext.PolicyName = "replay-moderator";
+            // Partition per moderator rather than per IP so colleagues behind one
+            // address do not consume each other's budget.
+            rateLimitContext.PartitionKey = $"moderator:{moderatorBattleTag}:{Scope}";
+        }
+
+        return rateLimitContext;
+```
+
+Add the helper, resolving the auth service from DI rather than `new`-ing it as `BearerHasPermissionFilter` does:
+
+```csharp
+    private static async Task<string> TryGetModeratorBattleTag(ActionExecutingContext context, ILogger logger)
+    {
+        try
+        {
+            string authHeader = context.HttpContext.Request.Headers["Authorization"];
+            if (string.IsNullOrEmpty(authHeader) || !authHeader.StartsWith("Bearer "))
+            {
+                return null;
+            }
+
+            var token = authHeader["Bearer ".Length..].Trim();
+            var authService = context.HttpContext.RequestServices.GetRequiredService<IW3CAuthenticationService>();
+            var user = authService.GetUserByToken(token, false);
+
+            if (user == null || string.IsNullOrEmpty(user.BattleTag)) return null;
+            if (!user.IsAdmin) return null;
+            if (user.Permissions == null || !user.Permissions.Contains(EPermission.Moderation)) return null;
+
+            return user.BattleTag;
+        }
+        catch (Exception ex)
+        {
+            // A bad token must not break the request; fall through to the IP-based limit.
+            logger.LogDebug(ex, "Could not resolve a moderator identity for replay rate limiting");
+            return null;
+        }
+    }
+```
+
+Match `GetUserByToken`'s real signature and the shape of `user.Permissions` by reading `BearerHasPermissionFilter.cs:16-59` — copy its checks exactly rather than guessing. Remove the `async`/`await` if the auth call is synchronous. Add `using Microsoft.Extensions.DependencyInjection;`, `using W3C.Contracts.Admin.Permission;` and `using W3ChampionsStatisticService.Services;` as required.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~ReplayRateLimitTests"`
+Expected: PASS
+
+- [ ] **Step 5: Verify the whole suite**
+
+Run: `dotnet build && dotnet test && dotnet format --verify-no-changes`
+Expected: all green.
+
+- [ ] **Step 6: Commit and open the Phase 2 PR**
+
+```bash
+git add W3ChampionsStatisticService/WebApi/ActionFilters/ReplayRateLimitAttribute.cs WC3ChampionsStatisticService.UnitTests/Replays/ReplayRateLimitTests.cs
+git commit -m "Give authenticated moderators a higher hourly replay limit"
+git push
+```
+
+Open a PR covering Phase 2. Note in the description that it requires the Phase 1 matchmaking deployment to return data, and that `GM_FOOTMEN_FRENZY` is now treated as an FFA mode (previously ongoing Footmen Frenzy matches exposed real battletags through `/api/matches/ongoing`).
+
+---
+
+# Phase 3 — website
+
+Work in `/home/francis/repos/w3c-website`. Run `git checkout -b feat/cancelled-matches-admin` before Task 9.
+
+Commands: `npm run lint`, `npm run dprint`, `npm run type-check`, `npm test`.
+
+Note: vitest runs in `environment: "node"` with no vue plugin, so `.vue` files cannot be unit tested. Only the service layer gets tests.
+
+---
+
+### Task 9: Cancelled match types and service
+
+**Files:**
+- Create: `src/types/admin/CancelledMatch.ts`
+- Create: `src/services/admin/CancelledMatchService.ts`
+- Create: `src/services/admin/CancelledMatchService.test.ts`
+
+**Interfaces:**
+- Consumes: Phase 2's `GET api/admin/matches/canceled`, and the existing `GET api/replays/by-flo-id/{floMatchId}/chats`.
+- Produces:
+  - `interface CancelledMatchPlayer { battleTag: string; name?: string; race: number; team: number; slotIndex?: number; mmr?: { rating: number }; ranking?: { leagueOrder?: number }; country?: string; }`
+  - `interface CancelledMatch { id: string; gamename?: string; gameMode: number; mapName?: string; map?: string; gateway?: number; season?: number; startTime: number; createdAt?: string; canceledAt?: string; floGameId?: number | null; players: CancelledMatchPlayer[]; }`
+  - `interface CancelledMatchesPage { total: number; matches: CancelledMatch[]; }`
+  - `class CancelledMatchService { getCancelledMatches(token, opts): Promise<CancelledMatchesPage>; getChatLogByFloId(token, floGameId): Promise<ReplayChatLog>; }`
+
+  Tasks 11 and 12 consume these.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/services/admin/CancelledMatchService.test.ts`:
+
+```ts
+import { test } from "vitest";
+import { strict as assert } from "node:assert";
+import { CancelledMatchService } from "./CancelledMatchService";
+
+function urlOf(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function serviceWith(response: { status: number; body?: unknown }) {
+  const calls: { url: string; method: string }[] = [];
+  const impl: typeof globalThis.fetch = (input, init) => {
+    calls.push({ url: urlOf(input), method: init?.method ?? "GET" });
+    const body = response.body === undefined ? null : JSON.stringify(response.body);
+    return Promise.resolve(
+      new Response(body, {
+        status: response.status,
+        headers: body === null ? undefined : { "Content-Type": "application/json" },
+      }),
+    );
+  };
+  return {
+    calls,
+    service: new CancelledMatchService({ endpoint: "https://api.example.com/", fetch: impl }),
+  };
+}
+
+test("getCancelledMatches requests the admin endpoint with paging", async () => {
+  const { service, calls } = serviceWith({ status: 200, body: { total: 2, matches: [] } });
+
+  const page = await service.getCancelledMatches("tok", { gameMode: 0, page: 2, itemsPerPage: 25 });
+
+  assert.equal(page.total, 2);
+  assert.ok(calls[0].url.startsWith("https://api.example.com/api/admin/matches/canceled?"));
+  assert.ok(calls[0].url.includes("page=2"));
+  assert.ok(calls[0].url.includes("itemsPerPage=25"));
+});
+
+test("getCancelledMatches omits an all-modes filter and an empty battle tag", async () => {
+  const { service, calls } = serviceWith({ status: 200, body: { total: 0, matches: [] } });
+
+  await service.getCancelledMatches("tok", { gameMode: 0, page: 1, itemsPerPage: 25, battleTag: "" });
+
+  assert.ok(!calls[0].url.includes("gameMode="));
+  assert.ok(!calls[0].url.includes("battleTag="));
+});
+
+test("getCancelledMatches sends the selected mode and encodes the battle tag", async () => {
+  const { service, calls } = serviceWith({ status: 200, body: { total: 0, matches: [] } });
+
+  await service.getCancelledMatches("tok", { gameMode: 5, page: 1, itemsPerPage: 25, battleTag: "Tester#1234" });
+
+  assert.ok(calls[0].url.includes("gameMode=5"));
+  assert.ok(calls[0].url.includes("battleTag=Tester%231234"));
+});
+
+test("getCancelledMatches surfaces a failure rather than an empty page", async () => {
+  const { service } = serviceWith({ status: 403 });
+
+  await assert.rejects(() => service.getCancelledMatches("tok", { gameMode: 0, page: 1, itemsPerPage: 25 }));
+});
+
+test("getChatLogByFloId reads the by-flo-id chat route", async () => {
+  const { service, calls } = serviceWith({ status: 200, body: { players: [], messages: [], events: [] } });
+
+  await service.getChatLogByFloId("tok", 4242);
+
+  assert.equal(calls[0].url, "https://api.example.com/api/replays/by-flo-id/4242/chats");
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/services/admin/CancelledMatchService.test.ts`
+Expected: FAIL — cannot resolve `./CancelledMatchService`.
+
+- [ ] **Step 3: Write the types**
+
+Create `src/types/admin/CancelledMatch.ts`:
+
+```ts
+/** A player in a cancelled match, as matchmaking recorded them. */
+export interface CancelledMatchPlayer {
+  battleTag: string;
+  name?: string;
+  inviteName?: string;
+  race: number;
+  team: number;
+  country?: string;
+  /**
+   * 0-based FLO lobby slot. Flo shows anonymised players as `Player {slotIndex + 1}`,
+   * so always add one before displaying. Absent for matches cancelled before the
+   * FLO game was created.
+   */
+  slotIndex?: number;
+  mmr?: { rating: number };
+  ranking?: { leagueOrder?: number };
+}
+
+/**
+ * A match that ended without a result. There is no winner, no score and no MMR
+ * change - those fields do not exist for these matches, so nothing here should be
+ * rendered as a win or a loss.
+ */
+export interface CancelledMatch {
+  id: string;
+  gamename?: string;
+  gameMode: number;
+  map?: string;
+  mapName?: string;
+  gateway?: number;
+  season?: number;
+  startTime: number;
+  createdAt?: string;
+  /** When the match was cancelled. */
+  canceledAt?: string;
+  /** Null when the match was cancelled before the FLO game existed: no replay, no chat log. */
+  floGameId?: number | null;
+  players: CancelledMatchPlayer[];
+}
+
+export interface CancelledMatchesPage {
+  total: number;
+  matches: CancelledMatch[];
+}
+
+/** A replay or chat log can only exist once FLO created the game. */
+export function hasReplayArtifacts(match: CancelledMatch): boolean {
+  return match.floGameId != null && match.floGameId > 0;
+}
+
+/** The number a player saw in game for an anonymised match. */
+export function displaySlot(player: CancelledMatchPlayer): number | undefined {
+  return player.slotIndex == null ? undefined : player.slotIndex + 1;
+}
+```
+
+- [ ] **Step 4: Write the service**
+
+Create `src/services/admin/CancelledMatchService.ts`:
+
+```ts
+import { AuthorizedClient, type AuthorizedClientDeps } from "@/services/http/AuthorizedClient";
+import type { CancelledMatchesPage } from "@/types/admin/CancelledMatch";
+import type { ReplayChatLog } from "@/store/admin/replayManagement/types";
+
+export interface CancelledMatchQuery {
+  /** 0 (Undefined) means every game mode. */
+  gameMode: number;
+  page: number;
+  itemsPerPage: number;
+  battleTag?: string;
+}
+
+/**
+ * Reads cancelled matches and, on demand, the chat log for one of them.
+ *
+ * Takes its endpoint (and optionally a fetch) rather than importing API_URL, so
+ * it can be constructed in tests - `@/config/env` reads `window` at module load
+ * and cannot be imported outside a browser.
+ *
+ * The chat log call hits the replay service, which costs money per call. Only
+ * ever call it for a single match in response to an explicit user action - never
+ * to enrich a list.
+ */
+export class CancelledMatchService {
+  private readonly client: AuthorizedClient;
+
+  constructor(deps: AuthorizedClientDeps) {
+    this.client = new AuthorizedClient(deps);
+  }
+
+  async getCancelledMatches(token: string, query: CancelledMatchQuery): Promise<CancelledMatchesPage> {
+    const params = new URLSearchParams();
+    params.set("page", String(query.page));
+    params.set("itemsPerPage", String(query.itemsPerPage));
+
+    if (query.gameMode) {
+      params.set("gameMode", String(query.gameMode));
+    }
+
+    if (query.battleTag) {
+      params.set("battleTag", query.battleTag);
+    }
+
+    return await this.client.getJson<CancelledMatchesPage>(
+      `api/admin/matches/canceled?${params}`,
+      token,
+    );
+  }
+
+  /**
+   * Cancelled matches have no Matchup row, so the id-based chat route cannot find
+   * them. The FLO game id is the only key the replay service understands.
+   */
+  async getChatLogByFloId(token: string, floGameId: number): Promise<ReplayChatLog> {
+    return await this.client.getJson<ReplayChatLog>(
+      `api/replays/by-flo-id/${encodeURIComponent(floGameId)}/chats`,
+      token,
+    );
+  }
+}
+```
+
+Open `src/store/admin/replayManagement/types.ts` and import the chat log type by its real exported name; if it lives elsewhere, follow `AdminReplayChatLogMessages.vue`'s import.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/services/admin/CancelledMatchService.test.ts`
+Expected: PASS (5 tests)
+
+- [ ] **Step 6: Verify and commit**
+
+Run: `npm run lint && npm run dprint && npm run type-check && npm test`
+
+```bash
+git add src/types/admin/CancelledMatch.ts src/services/admin/CancelledMatchService.ts src/services/admin/CancelledMatchService.test.ts
+git commit -m "Add the cancelled match admin service and types"
+```
+
+---
+
+### Task 10: Neutral result rendering and by-flo-id replay download
+
+`won` is the only field the match-history leaf components hard-depend on. The proxied payload **will** contain `won: false`, because `PlayerMMrChange.won` is a non-nullable `bool` in C#, so without a flag every player renders as a loser.
+
+**Files:**
+- Modify: `src/components/matches/PlayerMatchInfo.vue` (`won` computed at `:135-143`, `playerColorClass` at `:167-173`, template at `:21`, `:27-28`, `:33-35`)
+- Modify: `src/components/matches/TeamMatchInfo.vue`
+- Modify: `src/components/matches/DownloadReplayIcon.vue`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `PlayerMatchInfo` and `TeamMatchInfo` accept `noWinner?: boolean`; `DownloadReplayIcon` accepts `floGameId?: number | null`. Task 12 sets all three.
+
+- [ ] **Step 1: Add `noWinner` to `PlayerMatchInfo.vue`**
+
+Add to the component's props:
+
+```ts
+    noWinner: {
+      type: Boolean,
+      default: false,
+    },
+```
+
+and make the `won` computed return no colour when set. Keep the existing `unfinishedMatch` branch — do not merge the two, because `unfinishedMatch` also suppresses spoiler logic, which is not wanted here:
+
+```ts
+    const won = computed<string>(() => {
+      if (props.unfinishedMatch) return "";
+      // Cancelled matches have no result. The payload still carries won: false
+      // because the backend field is a non-nullable bool, so it must be ignored
+      // rather than trusted.
+      if (props.noWinner) return "";
+      if (Object.prototype.hasOwnProperty.call(props.player, "won")) {
+        return props.player.won ? "w3-won" : "w3-lost";
+      }
+      return "";
+    });
+```
+
+Match the existing code's exact shape when editing — read `:135-143` first. `playerColorClass` already feeds the name link and both MMR-delta spans, so no template change is needed.
+
+- [ ] **Step 2: Pass `noWinner` through `TeamMatchInfo.vue`**
+
+Add the same prop declaration, and bind it on the `PlayerMatchInfo` usage:
+
+```vue
+      :no-winner="noWinner"
+```
+
+- [ ] **Step 3: Add `floGameId` to `DownloadReplayIcon.vue`**
+
+Change the props and the URL construction:
+
+```ts
+const { gameId, floGameId } = defineProps({
+  gameId: {
+    type: String,
+    required: false,
+    default: "",
+  },
+  /**
+   * Download by FLO game id instead of match id. Cancelled matches have no
+   * Matchup row, so the id-based route cannot resolve them.
+   */
+  floGameId: {
+    type: Number,
+    required: false,
+    default: null,
+  },
+});
+```
+
+and inside `downloadReplay`:
+
+```ts
+    const url = floGameId != null
+      ? `${API_URL}api/replays/by-flo-id/${floGameId}`
+      : `${API_URL}api/replays/${gameId}`;
+```
+
+and the download filename:
+
+```ts
+    a.download = `${floGameId ?? gameId}.w3g`;
+```
+
+The existing 404 and 429 handling already covers "replay unavailable", which Phase 2 Task 7 now returns correctly.
+
+- [ ] **Step 4: Verify existing usages still type-check**
+
+Run: `npm run type-check && npm run lint`
+Expected: clean. `gameId` becoming optional must not break `MatchesGrid.vue:118` or `MatchDetail.vue:87`, which still pass it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/matches/PlayerMatchInfo.vue src/components/matches/TeamMatchInfo.vue src/components/matches/DownloadReplayIcon.vue
+git commit -m "Support result-less matches and by-flo-id replays in match components"
+```
+
+---
+
+### Task 11: Load a chat log by FLO game id
+
+**Files:**
+- Modify: `src/store/admin/replayManagement/store.ts` (beside `loadChatLog` at `:11`)
+- Modify: `src/components/admin/replays/AdminReplayChatLogMessages.vue` (props at `:93-95`, load at `:206`)
+
+**Interfaces:**
+- Consumes: `CancelledMatchService.getChatLogByFloId` from Task 9.
+- Produces: `replayManagementStore.loadChatLogByFloId(floGameId: number)`; `AdminReplayChatLogMessages` accepts `floGameId?: number | null` and loads by it when present. Task 12 renders this component with `floGameId`.
+
+- [ ] **Step 1: Add the store action**
+
+In `src/store/admin/replayManagement/store.ts`, beside `loadChatLog`, using the same lazy-singleton pattern the other admin stores use:
+
+```ts
+    /**
+     * Cancelled matches have no Matchup row, so the id-based chat route 404s for
+     * them. This is the only way to reach their chat log.
+     */
+    async loadChatLogByFloId(floGameId: number) {
+      const token = useOauthStore().token;
+      this.chatLog = await getCancelledMatchService().getChatLogByFloId(token, floGameId);
+    },
+```
+
+Match the surrounding code exactly: read `loadChatLog` first and mirror how it obtains the token, where it assigns the result, and how it reports errors. Add the lazy service accessor at module level:
+
+```ts
+let _cancelledMatchService: CancelledMatchService | null = null;
+function getCancelledMatchService(): CancelledMatchService {
+  // API_URL reads window at module load, so the service cannot be constructed
+  // at module top level.
+  return (_cancelledMatchService ??= new CancelledMatchService({ endpoint: API_URL }));
+}
+```
+
+- [ ] **Step 2: Accept `floGameId` in the messages component**
+
+In `src/components/admin/replays/AdminReplayChatLogMessages.vue`, add the prop beside `matchId`:
+
+```ts
+    floGameId: {
+      type: Number,
+      required: false,
+      default: null,
+    },
+```
+
+and branch at the load site (`:206`):
+
+```ts
+        if (props.floGameId != null) {
+          await replayManagementStore.loadChatLogByFloId(props.floGameId);
+        } else {
+          await replayManagementStore.loadChatLog(props.matchId);
+        }
+```
+
+Also relax `matchId` to `required: false, default: ""` so the component can be used with only a FLO id.
+
+The existing `getPlayerName` join at `:157` (`log.value.players.find((x) => x.id == playerId)?.name`) needs no change: `players[].id` from the replay service is already the in-game slot number and carries the real, unmasked name.
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run type-check && npm run lint && npm test`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/store/admin/replayManagement/store.ts src/components/admin/replays/AdminReplayChatLogMessages.vue
+git commit -m "Allow loading a chat log by FLO game id"
+```
+
+---
+
+### Task 12: The Cancelled Matches admin page
+
+**Files:**
+- Create: `src/components/admin/AdminCancelledMatches.vue`
+- Modify: `src/router/types.ts` (`EAdminRouteName`)
+- Modify: `src/router/index.ts` (import near `:66`, child route in the `/admin` children array at `:266-304`)
+- Modify: `src/components/admin/AdminNavigation.vue` (icon import at `:65-73`, child entry in the Moderation group at `:157-205`)
+
+**Interfaces:**
+- Consumes: `CancelledMatchService`, `CancelledMatch`, `hasReplayArtifacts`, `displaySlot` (Task 9); `noWinner` and `floGameId` props (Task 10); `AdminReplayChatLogMessages` with `floGameId` (Task 11).
+- Produces: route `admin-cancelled-matches`.
+
+- [ ] **Step 1: Add the route name**
+
+In `src/router/types.ts`, in `EAdminRouteName`:
+
+```ts
+  CANCELLED_MATCHES = "Admin - Cancelled Matches",
+```
+
+- [ ] **Step 2: Register the route**
+
+In `src/router/index.ts`, add the import beside the other admin components:
+
+```ts
+import AdminCancelledMatches from "@/components/admin/AdminCancelledMatches.vue";
+```
+
+and the child entry in the `/admin` children array:
+
+```ts
+        { path: "admin-cancelled-matches", name: EAdminRouteName.CANCELLED_MATCHES, component: AdminCancelledMatches },
+```
+
+- [ ] **Step 3: Add the nav entry**
+
+In `src/components/admin/AdminNavigation.vue`, import an icon in the `@mdi/js` block (for example `mdiCancel`), then add a child **inside the existing Moderation group** (`:157-205`):
+
+```ts
+          {
+            title: "Cancelled Matches",
+            icon: mdiCancel,
+            permission: EPermission.Moderation,
+            component: "admin-cancelled-matches",
+            routeName: EAdminRouteName.CANCELLED_MATCHES,
+          },
+```
+
+`component` **must** equal the route's `path` segment — the `/admin` landing redirect pushes `admin/${firstItem.component}` (`:129-138`). Do not create a new top-level group.
+
+- [ ] **Step 4: Create the page**
+
+Create `src/components/admin/AdminCancelledMatches.vue`, following `AdminJobs.vue` for structure (lazy service singleton, token from `useOauthStore`, local refs, `v-alert` errors, hardcoded English strings — recent admin pages use no `$t`).
+
+It must include:
+
+1. **A permission guard.** There is no router guard anywhere in this app, so any admin can deep-link here:
+
+```ts
+const canModerate = computed(() =>
+  oauthStore.permissions.includes(EPermission[EPermission.Moderation]));
+```
+
+Render a refusal message instead of the table when false.
+
+2. **Filters:** the existing `GameModeSelect` component (`@/components/common/GameModeSelect.vue`, as used at `Matches.vue:23`) defaulting to all modes, a battletag text field, and a `v-pagination` driven by `total`.
+
+3. **A notes panel** (a `v-alert type="info"` above the table) with exactly these points:
+
+```
+- Drawn and stalled matches are only marked cancelled by a cleanup sweep that runs
+  6 hours after the match started, so a match that just ended will not appear yet.
+- Replay and chat log are unavailable for matches cancelled before the game server
+  was created.
+- No cancellation reason is recorded, so this list cannot show why a match ended.
+```
+
+4. **Rows** showing the game mode, map, start time, cancellation time (`canceledAt`), and the players. Render players grouped by team using `TeamMatchInfo` with `:no-winner="true"`, or a simple per-player list — but every player must show `Player {displaySlot(player)} — {battleTag}` when `slotIndex` is present, and the battletag alone when it is not.
+
+5. **Per-row actions:** a `DownloadReplayIcon` with `:flo-game-id="match.floGameId"`, and a button opening a `v-dialog` containing `<admin-replay-chat-log-messages :flo-game-id="match.floGameId" />`. Both disabled with an explanatory tooltip when `hasReplayArtifacts(match)` is false.
+
+**The chat log must only be fetched when the dialog is opened** — render the component with `v-if="openChatMatchId === match.id"` so it mounts on demand. Never fetch chat logs while rendering the list; each call costs money.
+
+- [ ] **Step 5: Verify**
+
+Run: `npm run lint && npm run dprint && npm run type-check && npm test`
+Expected: all clean.
+
+- [ ] **Step 6: Manual verification**
+
+Run the app against a backend with the Phase 2 endpoint available. Confirm:
+- The page appears in the Moderation section of the admin sidebar for a Moderation account, and not for an admin without it.
+- Switching game mode and searching a battletag refetches and resets to page 1.
+- No player is coloured as a winner or loser.
+- A match with `floGameId: null` shows both actions disabled.
+- Opening the chat dialog issues exactly one request, and closing and reopening does not spam the replay service.
+- In an anonymised FFA match, slot numbers line up with the names in the chat log.
+
+- [ ] **Step 7: Commit and open the Phase 3 PR**
+
+```bash
+git add src/components/admin/AdminCancelledMatches.vue src/router/types.ts src/router/index.ts src/components/admin/AdminNavigation.vue
+git commit -m "Add the cancelled matches admin page"
+git push -u origin feat/cancelled-matches-admin
+```
+
+---
+
+## Self-Review Notes
+
+Checked against the spec:
+
+- **Read model rejected in favour of the proxy** — Tasks 2, 3, 5, 6.
+- **`slotIndex` persisted upstream and displayed +1** — Tasks 1, 4, 9, 12.
+- **`canceledAt` from `_updated_at`, never from an ObjectId timestamp** — Task 2 (sort), Task 4 (mapping), Task 12 (display).
+- **Reuse existing DTOs rather than new ones** — Task 4 reuses `Match`/`PlayerMMrChange`/`UnfinishedMatchPlayer`; the `[JsonProperty("_id")]` requirement is a correction discovered while planning, since Newtonsoft ignores `[BsonElement]` and the id would otherwise be null.
+- **`api/admin/matches/canceled` sub-layering** — Task 6.
+- **Moderator replay limit: hourly 50, daily untouched** — Task 8.
+- **Replay/chat unavailability returns 404** — Task 7.
+- **`GM_FOOTMEN_FRENZY` as FFA** — already committed; regression test in Task 4.
+- **No replay-service calls in the list path** — enforced in Task 9's service docstring and Task 12 Step 4/6.
+- **`noWinner`** — Task 10, with the `won: false` explanation.
+- **Moderation gate, no audit logging** — Task 6 (server) and Task 12 (in-page).
+- **Notes panel** — Task 12, copy supplied verbatim.
+
+Spec items intentionally **not** given tasks, matching the spec's out-of-scope list: the missing `pushMatchCanceled`/`pushMatchStart` (raised in the Phase 1 PR description), `LeaveDraw` handling, persisting the cancellation reason, and displaying `MatchLogs`.
+
+`playerScores: []` needs no task: the new endpoint returns matchmaking match documents and never populates `playerScores`, and the page does not route through `MatchDetail.vue`. The constraint is recorded in the spec so a future change does not reintroduce it.

--- a/docs/superpowers/specs/2026-08-05-cancelled-matches-admin-page-design.md
+++ b/docs/superpowers/specs/2026-08-05-cancelled-matches-admin-page-design.md
@@ -63,10 +63,97 @@ nothing else — no reason, no `endTime`, no `lengthSeconds`. A rich
 and metrics, never onto the `Match` entity, so it cannot ride along on the
 event. The page therefore cannot show *why* a match was cancelled.
 
+The reason is not simply discarded, though: `gameCreationFailed` passes it to
+`sendGameCancelledDialog(cancellationData)` (`game-creation.flow.ts:255-257`),
+and the launcher has translated strings for every one of the 23 values
+(`launcher-e/src/translations/*.ts`, e.g. `"Game cancelled: PLAYER_CAUSED_JOINBUG"`).
+So the reason exists and is already transmitted to clients at the moment of
+failure — it is only the stats hook that never receives it. That makes adding it
+to the event a small change, should it be wanted later.
+
+### `MatchLogs` exist but are not reachable from this backend
+
+There is a per-match event log: collection `MatchLogs`
+(`matchmaking-service/src/app/data/models/match-event-log.ts:23-24`), keyed by
+`matchId`, written via `MatchCreationLogsRepo.findOrCreateMatchLog`. It captures
+the whole creation state machine — system events, per-player game-creation
+events, host commands, client-submitted events — including the explicit
+`game creation failure reason: <EGameCreationResult>` line
+(`game-creation.flow.ts:253`).
+
+It is, however, **not exposed over HTTP**: there is no route referencing match
+logs anywhere in `src/app/apis/`, and it lives in the matchmaking database, not
+the statistic-service one. Surfacing it would need a new matchmaking-service
+endpoint plus a `MatchmakingServiceClient` proxy method.
+
+Deliberately **out of scope for v1**, per review: the logs are not intended for
+human consumption and carry a very large volume per match. Reconciling them
+against the cancelled-match list is a plausible follow-up, and the join key
+(`matchId`) is already on the `CanceledMatch` read model, so nothing in this
+design blocks it.
+
 ### There are four `EMatchState` values and no draw state
 
 `INIT`, `STARTED`, `FINISHED`, `CANCELED` (`match.ts:44-49`). A draw is
 indistinguishable from "nobody reported a win".
+
+### Every path that can cancel a match
+
+This was challenged in review as likely incomplete, so it was re-verified
+exhaustively rather than trusted. The enumeration below is what the code
+actually supports.
+
+`MatchCanceledEvent` has **exactly one producer and one call site**:
+
+- `grep -rn "pushMatchCanceled" src/` → the definition at `stats-hook.ts:106`
+  and a single call at `matches.manager.ts:319`.
+- `grep -rn "MATCH_CANCELED\|MatchCanceledEvent" src/` → only the enum member,
+  the `uniqueQueueTypes` list, and that one push.
+- `cancelMatch` has exactly two call sites: `matches.manager.ts:168`
+  (creation failure, **no** push) and `:317` (the sweeper, followed by the push
+  at `:319`).
+- No other repository writes the collection: grepping `MatchCanceledEvent` and
+  `W3Champions-Statistic-Service` across `flo`, `launcher-e` and `w3c-replay`
+  returns nothing. The launcher only *receives* cancellations — its
+  `cancelMatchmaking` (`backend.service.ts:290`) cancels queue search, not a
+  match, and clients never report a match as cancelled.
+
+So the paths are:
+
+| Path | Emits `MatchCanceledEvent`? |
+| --- | --- |
+| `INIT` older than 2 min (sweeper) | **Yes**, ladder only |
+| `STARTED` older than 6 h (sweeper — the draw bucket) | **Yes**, ladder only |
+| Game-creation failure (flo error, join bug, disbanded team, leaver, every per-state timeout) | **No** |
+| 1v1 disconnect-forfeit | No — becomes `FINISHED` with a 0-second duration |
+| `FINISHED` older than 6 h | No — evicted from memory only |
+| Tournament cancellations | No — ladder-gated, and a winner is still assigned |
+| Custom matches | No — ladder-gated |
+| Client/launcher report | Does not exist |
+
+Two clarifications that came out of re-checking, both of which make the
+creation-failure gap worse than first described:
+
+1. **A failed creation emits no `MatchStartedEvent` either.**
+   `statsHook.pushMatchStart` is called only from `gameCreationSuccess()`
+   (`game-creation.flow.ts:175`); `gameCreationFailed()` never calls it. So these
+   matches are not merely missing a *cancellation* — they are entirely invisible
+   to this backend, with no record of the attempt at all. That is precisely the
+   data wanted for match-creation abuse scenarios.
+2. **The sweeper cannot pick them up as a fallback.**
+   `decideMatchOutcomeDuringFailedGameCreation` calls `removeCurrentMatch` at
+   `:169`, evicting the match from the in-memory map that `cleanUpMatches`
+   iterates. And `processLeavers` calls that method **unconditionally**, even
+   when the leavers array is empty (`game-creation.flow.ts:524-531`), so every
+   creation failure takes this path.
+
+For completeness, one hypothesis raised in review that the code does not support:
+there is no "joining a new game cancels the old one" path. `latestMatch` is used
+only to route a disconnect to the right in-flight creation flow
+(`game-creation.manager.ts:79-87`), never to cancel a prior match. Matches are
+also rehydrated from the database on startup for any non-`FINISHED` state
+(`matches.manager.ts:26-32`), so a process restart does not orphan `STARTED`
+matches.
 
 ## Scope
 
@@ -74,15 +161,27 @@ indistinguishable from "nobody reported a win".
 2 minutes, and `STARTED` older than 6 hours (the bucket that swallows draws).
 These are the only cancellations that reach this backend today.
 
+Also in scope, as a drive-by fix: **adding `GM_FOOTMEN_FRENZY` to
+`GameModesHelper.FfaGameModes`**. Its matchmaking-service definition sets
+`isAnonymous = true`, so flo masks names in-game, but the backend was not
+treating it as an FFA mode — meaning ongoing Footmen Frenzy matches leaked real
+battletags through `/api/matches/ongoing` and were lookupable by player. Anon-FFA
+Footmen Frenzy is returning, so this needs to be correct. The three call sites
+(`MatchesController.cs:201`, `PlayersObfuscator.cs:12`, `Matchup.cs:160`) are all
+anonymization behaviours, which is exactly what the mode should now get.
+`GM_LTW_FFA` remains correctly absent — `gm-ltw-ffa.ts:30` sets
+`isAnonymous = false`.
+
 **Out of scope, to be raised at PR review:**
 
-1. **Game-creation-failure cancellations emit no event at all.**
-   `decideMatchOutcomeDuringFailedGameCreation` (`matches.manager.ts:148-171`)
-   calls `cancelMatch` directly and, unlike `:319`, never calls
-   `statsHook.pushMatchCanceled`. This silently drops flo create-game errors,
-   join bugs, disbanded teams, leavers, and every per-state timeout. This looks
-   like a genuine inconsistency rather than a design decision, and the page will
-   not show any of these matches until it is fixed.
+1. **Game-creation failures are invisible — no event of any kind.** Not just the
+   missing `pushMatchCanceled` at `matches.manager.ts:168`, but no
+   `MatchStartedEvent` either, since `pushMatchStart` fires only on success. See
+   "Every path that can cancel a match" above for the full trace. This is the
+   highest-value follow-up: it covers flo create-game errors, join bugs,
+   disbanded teams, leavers and every per-state timeout, and it is exactly the
+   population relevant to match-creation abuse. It looks like a genuine
+   inconsistency rather than a design decision.
 2. **`LeaveDraw` is not treated as a first-class outcome** — see above. Would
    remove the ~6h delay.
 3. **Tournament and custom matches never reach the stats hook** (the
@@ -90,9 +189,8 @@ These are the only cancellations that reach this backend today.
    `CANCELED` as an outcome marker while still assigning a winner
    (`tournament.manager.ts:306-365`), so including them needs semantics
    untangled first.
-4. **`GM_FOOTMEN_FRENZY` mismatch.** It sets `isAnonymous = true` upstream but is
-   absent from `GameModesHelper.FfaGameModes` in the backend. (`GM_LTW_FFA` being
-   absent is correct — `gm-ltw-ffa.ts:30` sets `isAnonymous = false`.)
+4. **Displaying `MatchLogs`** alongside each cancelled match — see the
+   `MatchLogs` section above for why this is deferred and what it would take.
 
 ## Backend design
 
@@ -135,24 +233,50 @@ the handler walks `_id` order, so a fresh handler replays the entire historical
 | `GameMode`, `GameName` | `match` | |
 | `Map`, `MapId`, `MapName` | `match` | |
 | `Gateway`, `Season`, `ServerProvider`, `FloNode` | `match` | |
-| `StartTime` | `match.startTime` | unix ms |
-| `CanceledAt` | **event `ObjectId` timestamp** | see below |
-| `Players` | `match.players` | dedicated DTO, see below |
+| `StartTime` | `match.startTime` | unix ms; the sort key |
+| `CanceledAt` | none available | **nullable, left null** — see below |
+| `Players` | `match.players` | dedicated DTO, see below; includes `SlotIndex` if the upstream change lands |
 
-**`CanceledAt` must derive from the event ObjectId's timestamp, not `endTime`.**
-`endTime` is never set upstream on a cancellation and the C# `Match` DTO coerces
-the null to `0` (`MatchEventDtos.cs:124-136`), so it cannot be used as a sort
-key. `StartTime` is a viable alternative but is further from "when did this get
-cancelled".
+**`CanceledAt` is nullable and stays null.** `endTime` is never set upstream on a
+cancellation and the C# `Match` DTO coerces the null to `0`
+(`MatchEventDtos.cs:124-136`), so it cannot be used. An earlier draft proposed
+deriving the timestamp from the event `ObjectId`; that is rejected — ObjectIds
+should not be inspected for their embedded timestamp, and the value would in any
+case be "when the sweeper ran", not when the match actually ended. Since the
+sweeper only runs every 5 minutes and fires on a 6-hour threshold, that number
+would be misleading by up to hours.
 
-**Use a dedicated `CanceledMatchPlayer` DTO — do not reuse `PlayerOverviewMatches`.**
-Fields: `BattleTag`, `Name`, `Race`, `Team`, `OldMmr`, `Ranking`, `Country`,
-`InviteName`. Deliberately **no** `Won`, `CurrentMmr`, `MmrGain` or
-`MatchRanking`. Reusing the existing DTO would be actively harmful:
-`PlayerOverviewMatches.Won` is a non-nullable `bool` and `Team.Won` is a computed
-getter, so `won: false` would always be on the wire, and
-`PlayerMatchInfo.vue:135-143` would paint every player as a loser. Omitting the
-field is cleaner than shipping a falsy value and suppressing it downstream.
+An honest null beats an inferred value. Recovering a real cancellation time would
+require parsing replays or `MatchLogs`, both explicitly out of scope.
+
+**Sort by `StartTime` descending instead.** `startTime` is set at match creation
+and is always present, so it is a reliable ordering key. It is also the more
+useful one for a moderator: "which matches started most recently".
+
+**Player DTO: extract a shared base rather than a standalone type.** The
+direction of a dedicated type is right — `PlayerOverviewMatches.Won` is a
+non-nullable `bool` and `Team.Won` is a computed getter, so reusing it as-is would
+put `won: false` on the wire and `PlayerMatchInfo.vue:135-143` would paint every
+player as a loser. But it should not be built from scratch: the event DTOs already
+demonstrate this pattern (`PlayerMMrChange : UnfinishedMatchPlayer :
+IMatchPlayerServerInfo`, `MatchEventDtos.cs:24,44`), while the read-model
+`PlayerOverviewMatches` is a flat standalone class.
+
+Introduce a base holding the identity and pre-match fields, and derive both:
+
+- **Base** (`MatchPlayerBase` or similar): `Race`, `RndRace`, `OldMmr`,
+  `OldMmrQuantile`, `OldRankDeviation`, `BattleTag`, `InviteName`, `Name`,
+  `Location`, `CountryCode`, `Country`, `Twitch`, `Ranking`.
+- **`PlayerOverviewMatches : base`** adds the result fields: `CurrentMmr`,
+  `MmrGain`, `Won`, `MatchRanking`, `Heroes`.
+- **`CanceledMatchPlayer : base`** adds only `Team`, plus `SlotIndex` if the
+  upstream change below lands.
+
+Confirm the exact split against `Matchup.CreatePlayerArray` during
+implementation — anything sourced from the Blizzard result (`Heroes` in
+particular) belongs on the derived result type, not the base. This is a
+refactor of a serialized public DTO, so it changes JSON property *order* but not
+names or semantics; verify no consumer depends on ordering.
 
 #### Indexes and dedup
 
@@ -161,8 +285,8 @@ dedup, and the producer's 300-entry queue can re-send on failure, so the same
 match can legitimately arrive twice.
 
 - unique `MatchId`
-- `{ GameMode: 1, CanceledAt: -1 }` — the by-mode listing
-- `{ CanceledAt: -1 }` — the all-modes listing
+- `{ GameMode: 1, StartTime: -1 }` — the by-mode listing
+- `{ StartTime: -1 }` — the all-modes listing
 - `{ "Players.BattleTag": 1 }` — battletag filter
 
 Follow the existing `IRequiresIndexes` pattern (see `MatchRepository.EnsureIndexesAsync`).
@@ -184,15 +308,21 @@ affects the genuine cancel-then-finish race.)
 
 ### 3. New endpoint
 
-New `AdminCanceledMatchesController`. Every action carries
-`[BearerHasPermissionFilter(Permission = EPermission.Moderation)]` — the
-attribute is `AttributeTargets.Method`, so it cannot be applied at controller
-level and must be repeated per action.
+New `AdminMatchesController` with route prefix **`api/admin/matches`**. Every
+action carries `[BearerHasPermissionFilter(Permission = EPermission.Moderation)]`
+— the attribute is `AttributeTargets.Method`, so it cannot be applied at
+controller level and must be repeated per action.
 
 ```
-GET api/admin/canceled-matches?gameMode=&battleTag=&offset=&pageSize=
+GET api/admin/matches/canceled?gameMode=&battleTag=&offset=&pageSize=
     -> { matches, count }
 ```
+
+The extra layer is deliberate and has precedent: `api/admin` already sub-layers
+into `api/admin/permissions`, `api/admin/logs`, `api/admin/storage` and
+`api/admin/api-tokens` (only `AdminController` itself sits at the bare
+`api/admin`). Grouping under `api/admin/matches` leaves room for further
+match-related admin endpoints without another controller prefix.
 
 - Envelope `{ matches, count }` matches the match-domain convention the frontend
   already consumes (`MatchesController` uses it for `/api/matches` and
@@ -204,7 +334,11 @@ GET api/admin/canceled-matches?gameMode=&battleTag=&offset=&pageSize=
 - `battleTag` is an optional filter; moderation workflows usually start from a
   player.
 - Clamp `pageSize` to 100, consistent with `MatchesController`.
-- Sort `CanceledAt` descending.
+- Sort `StartTime` descending.
+
+**This endpoint must not call the replay service.** Listing is a pure Mongo read.
+See the note under FFA de-anonymization — replay-service calls cost money and must
+stay out of the list path.
 
 Do **not** apply `PlayersObfuscator`. It exists for ongoing FFA matches and for
 MMR/rank-deviation masking on public endpoints; this is a Moderation-gated admin
@@ -272,17 +406,25 @@ pattern, and the daily ceiling still holds.
 
 Unauthenticated and non-moderator behaviour is unchanged.
 
-#### 4b. Make a missing chat log return 404
+#### 4b. Handle unavailable replays and chat logs properly
 
-`ReplayServiceClient.GetChatLogs` (`ReplayServiceClient.cs:29-33`) uses
-`GetAsync` + `ReadAsStringAsync` with **no status check**, so an upstream 404
-deserializes to null and surfaces as HTTP 200 with a null body. This page will
-hit missing chat logs routinely (pre-flo cancels, unarchived replays), so it
-should return a clean 404.
+Both directions are currently wrong, and both must be fixed — a replay being
+unavailable is a normal, expected outcome, not an error. It may never have been
+recorded, or it may have aged into DeepArchive.
 
-(`GenerateReplay` does not have this problem — `GetStreamAsync` applies
-`EnsureSuccessStatusCode` internally. It has the opposite one: an upstream 404
-becomes an unhandled exception → 500. Worth tidying while in there.)
+- **`GetChatLogs`** (`ReplayServiceClient.cs:29-33`) uses `GetAsync` +
+  `ReadAsStringAsync` with **no status check**, so an upstream 404 deserializes to
+  null and surfaces as HTTP 200 with a null body. Must map a non-success status to
+  a clean 404.
+- **`GenerateReplay`** (`:18-25`) has the opposite problem: `GetStreamAsync`
+  applies `EnsureSuccessStatusCode` internally, so an upstream 404 becomes an
+  unhandled exception → HTTP 500. Must map upstream 404 (and the
+  archived/unavailable case) to a 404 the client can render as "replay
+  unavailable" rather than a generic failure.
+
+The frontend already distinguishes 404 from other failures
+(`DownloadReplayIcon.vue` has separate `notFound` and `unavailable` strings), so
+correct status codes are immediately usable.
 
 #### 4c. Never return `playerScores: []`
 
@@ -296,7 +438,10 @@ score screen, and unlocks the unguarded FFA dereferences at `:335` and `:487-499
 ## FFA de-anonymization
 
 The requirement is to reconcile who is who in modes that hide names in-game.
-**This works with no new mapping table and no upstream change.**
+**No new mapping table is needed.** Real battletags are already available for the
+list, and the chat log already resolves `Player N` → real name. One small upstream
+change is recommended so the list can show slot numbers without paying for a
+replay-service call per row.
 
 ### Where "Player N" comes from
 
@@ -334,19 +479,64 @@ matches (`PlayersObfuscator.cs:18-19`, called from `MatchesController.cs:190,206
    `AdminReplayChatLogMessages.vue:157-167` does
    `log.value.players.find(x => x.id == playerId)?.name` on `message.fromPlayer`.
 
-So the entire FFA requirement reduces to **making the chat log reachable by flo
-game id**, which 4a–4b above already cover.
+So the chat log, once reachable by flo game id, resolves `Player N` → battletag.
 
-### The one thing that is not recoverable
+### Requirement: show both the battletag and the slot number
 
-If no replay/chat log exists (pre-flo-creation cancels), there is no way to map a
-slot number to a battletag. Matchmaking computes slot assignment transiently in
-`player-slots.helper.ts:14-29` for the flo `CreateGame` request and discards it;
-it is never written to the `Match` object. `LagReport.ServerSidePing[].PlayerName`
-is no help — it stores flo's *masked* `Player N` strings, and the backend has no
-flo-player-id → battletag mapping anywhere. Fixing this properly would mean
-persisting the slot map on the `Match` object upstream. Not needed for v1, since
-the participant set is always available from the list.
+Moderators need to map a report ("Player 3 was toxic") onto a battletag, so the UI
+must present **both identifiers together**, not just real names. Where the slot
+number is known, render it beside the battletag (e.g. `Player 3 — <battletag>`) in
+both the list row and the chat log view.
+
+### Constraint: never call the replay service in the list path
+
+Replay-service calls incur real cost, so they must be strictly on-demand:
+
+- The list endpoint does a Mongo read only. No replay or chat call, ever — not to
+  enrich names, not to check replay availability, not to resolve slots.
+- Chat logs are fetched only when a moderator explicitly opens one for a single
+  match. No prefetching, no fetch-on-hover, no batch resolution across the page.
+- Availability is inferred from `FloGameId` being non-null, which is free. Do not
+  probe the replay service to find out whether a replay exists.
+
+This constraint is what makes the upstream change below worth doing: without a
+persisted slot map, the *only* source of slot numbers is the chat log — which
+would mean a paid call per row to populate the list.
+
+### Recommended upstream change: persist the slot index
+
+Verified as a genuinely small change. `setPlayersToSlots`
+(`player-slots.helper.ts:14-29`) already computes exactly the needed mapping — it
+walks `allPlayers`, obtains each player's slot via
+`getNextAvailableSlot(slots, team, map)`, and assigns
+`slot.player_id = x.playerInstance.floPlayer.id`. At that moment the slot array
+index, the flo player id and `x.matchPlayer` (the persisted player object) are all
+in hand. The same flow already builds a `playerBattleTagsByFloPlayerId` map for
+custom-game colours (`flo-game-creation.flow.ts:137-144`), so the concept exists.
+
+The change is to write the slot index onto the match player so it rides along on
+every event:
+
+1. In `setPlayersToSlots`, set `x.matchPlayer.slotIndex = slots.indexOf(slot)`.
+2. Add `slotIndex?: number` to `IMatchPlayer` (`match.ts`).
+3. Add the matching property to the C# `UnfinishedMatchPlayer` DTO
+   (`MatchEventDtos.cs:44`), which `PlayerMMrChange` already inherits from.
+
+`CanceledMatch` then carries `SlotIndex` per player, and the list can render
+`Player N` alongside the battletag with **no replay-service call at all**.
+
+Caveat: this only helps matches that reached flo game creation. For `INIT` timeout
+cancels, `createGame` never ran, so there are no slots — but those matches also
+have no replay and no chat log, so there is nothing to reconcile against.
+
+Note the numbering: flo's mask is `slot_index + 1` and replay-service's
+`PlayerInfo.id` is likewise `idx + 1`, so if `slotIndex` is stored 0-based it must
+be displayed as `slotIndex + 1` to match what players saw in-game. Pick one
+convention and document it on the field.
+
+Without this change, v1 still works — the participant set with real battletags is
+always available from the list, and the slot mapping appears when a moderator opens
+the chat log — but the list itself cannot show slot numbers.
 
 ### PII
 
@@ -433,6 +623,18 @@ Everything else degrades safely already, verified by reading the components:
 - `mmrGain` from the backend is dead on the frontend — the delta is always
   recomputed client-side. Another reason to omit it from the DTO.
 
+### Slot number display
+
+For anonymizing modes, render the slot number next to the battletag so a report
+naming "Player 3" can be matched to an account — `Player 3 — <battletag>`. Source
+it from the per-player `SlotIndex` on the list payload (remember the `+ 1`
+convention). When `SlotIndex` is absent — either because the upstream change has
+not landed or because the match never reached flo game creation — show the
+battletag alone and let the chat log supply the mapping on demand.
+
+Do **not** fetch chat logs to populate slot numbers in the list. See the
+replay-service cost constraint under FFA de-anonymization.
+
 ### Replay and chat buttons
 
 `DownloadReplayIcon` currently hardcodes `${API_URL}api/replays/${gameId}` and
@@ -489,11 +691,16 @@ Cover:
 - Handler is idempotent — same match twice yields one row.
 - `FloGameId == null` is persisted without error.
 - Repository: gameMode filter, `Undefined` = all modes, battleTag filter, paging,
-  `CanceledAt` descending.
+  `StartTime` descending.
 - `CanceledMatchRemovalOnFinishHandler` deletes the row on a matching finish.
 - `ReplayRateLimitAttribute`: moderator token → hourly 50, daily unchanged,
   battleTag partition key; non-moderator and API-token paths unchanged.
-- `GetChatLogs` maps an upstream non-success status to 404.
+- `GetChatLogs` maps an upstream non-success status to 404; `GenerateReplay` maps
+  an upstream 404 to 404 rather than throwing.
+- `GameModesHelper.IsFfaGameMode(GameMode.GM_FOOTMEN_FRENZY)` is true, and the
+  existing FFA modes still are. `GM_LTW_FFA` is still false.
+- The list endpoint issues **no** replay-service call — assert against a mock
+  `ReplayServiceClient` that it is never invoked.
 
 **Frontend.** vitest runs in `environment: "node"` with no vue plugin
 (`vitest.config.ts:13-19`), so **`.vue` files cannot be unit tested** without

--- a/docs/superpowers/specs/2026-08-05-cancelled-matches-admin-page-design.md
+++ b/docs/superpowers/specs/2026-08-05-cancelled-matches-admin-page-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-05
 **Status:** Approved design, ready for implementation planning
-**Repos affected:** `w3c-backend`, `w3c-website`
+**Repos affected:** `website-backend`, `website` (frontend)
 **Permission gate:** `EPermission.Moderation` (existing — no new permission)
 
 ## Problem
@@ -513,10 +513,3 @@ backfill until that is set correctly in the target environment.
 
 Per `CLAUDE.md`: read model handling is off by default locally, and connecting to
 the wrong database can overwrite prod/test data.
-
-## Correction to `CLAUDE.md`
-
-`CLAUDE.md` names `../website` as the Vue 3 frontend. In this checkout
-`../website` is the **Caddy web server's site** (remote:
-`git@github.com:caddyserver/website.git`). The actual frontend is
-`../w3c-website`. Worth fixing in the same PR.

--- a/docs/superpowers/specs/2026-08-05-cancelled-matches-admin-page-design.md
+++ b/docs/superpowers/specs/2026-08-05-cancelled-matches-admin-page-design.md
@@ -1,0 +1,522 @@
+# Cancelled Matches Admin Page — Design
+
+**Date:** 2026-08-05
+**Status:** Approved design, ready for implementation planning
+**Repos affected:** `w3c-backend`, `w3c-website`
+**Permission gate:** `EPermission.Moderation` (existing — no new permission)
+
+## Problem
+
+Matches that end without a recorded result are invisible on the website. Only
+completed, ranked matches reach the `Matchup` read model and the public
+`/api/matches` surface. Moderators therefore have no way to review a cancelled
+game — no participant list, no replay, no chat log — which is exactly the
+population most likely to contain misbehaviour worth acting on.
+
+The goal is an admin page listing cancelled matches for a given game mode,
+reusing the existing match-history presentation, with per-row access to the
+replay download and the chat log. There is no score screen, no winner/loser and
+no MMR change, because none of that data exists for these matches.
+
+## Background: how a match becomes cancelled
+
+Understanding this chain matters, because it bounds what the page can show.
+
+### The `-draw` vote is map-side
+
+`-draw` is implemented in the ladder maps, not in any service:
+`map-updater-scripts/src/player_features/draw.ts`. It registers a chat trigger
+per playing slot and, once enough players have voted, calls
+`RemovePlayerPreserveUnitsBJ(Player(i), PLAYER_GAME_RESULT_NEUTRAL, false)` for
+every player.
+
+Two constraints come from that file:
+
+- The command is rejected after 120 seconds of gameplay
+  (`getElapsedTime() > 120`).
+- The vote threshold is `playerCount - 1` when there are 4 or more players,
+  otherwise `playerCount` (unanimous).
+
+Because every player leaves with a neutral result, **nobody wins**.
+
+### No winner means no valid result, which means a timeout cancellation
+
+`MatchResultLog.isValid` requires `hasWinner`
+(`matchmaking-service/src/app/data/models/match-result-log.ts:21-23`), computed
+as `result.players.find(p => p.won) !== undefined`. A drawn game therefore never
+produces a valid result, never enters `winnerResultMap`, and
+`getValidResult()` returns null indefinitely. The match sits in `STARTED` until
+the 5-minute `cleanUpMatches` sweep cancels it for exceeding 6 hours
+(`matches.manager.ts:296-301`), which is the only path that emits
+`MatchCanceledEvent` (`:316-322`, ladder-only).
+
+**Consequence: a drawn match does not appear for roughly 6 hours.** Accepted for
+v1; the page carries an explanatory note (see Frontend). Revisiting this by
+plumbing the W3GS `LeaveDraw` reason (`flo/crates/w3gs/src/protocol/constants.rs:188`,
+already decoded by flo's observer edge) through to matchmaking is deferred.
+
+### No cancellation reason is recorded anywhere
+
+`MatchesRepo.cancelMatch` (`matches.repo.ts:79-84`) sets `state = CANCELED` and
+nothing else — no reason, no `endTime`, no `lengthSeconds`. A rich
+`EGameCreationResult` enum (23 values) exists but is only written to match logs
+and metrics, never onto the `Match` entity, so it cannot ride along on the
+event. The page therefore cannot show *why* a match was cancelled.
+
+### There are four `EMatchState` values and no draw state
+
+`INIT`, `STARTED`, `FINISHED`, `CANCELED` (`match.ts:44-49`). A draw is
+indistinguishable from "nobody reported a win".
+
+## Scope
+
+**In scope:** ladder matches cancelled by the timeout sweeps — `INIT` older than
+2 minutes, and `STARTED` older than 6 hours (the bucket that swallows draws).
+These are the only cancellations that reach this backend today.
+
+**Out of scope, to be raised at PR review:**
+
+1. **Game-creation-failure cancellations emit no event at all.**
+   `decideMatchOutcomeDuringFailedGameCreation` (`matches.manager.ts:148-171`)
+   calls `cancelMatch` directly and, unlike `:319`, never calls
+   `statsHook.pushMatchCanceled`. This silently drops flo create-game errors,
+   join bugs, disbanded teams, leavers, and every per-state timeout. This looks
+   like a genuine inconsistency rather than a design decision, and the page will
+   not show any of these matches until it is fixed.
+2. **`LeaveDraw` is not treated as a first-class outcome** — see above. Would
+   remove the ~6h delay.
+3. **Tournament and custom matches never reach the stats hook** (the
+   `isLadderMatch` gate at `matches.manager.ts:318`). Tournament code also uses
+   `CANCELED` as an outcome marker while still assigning a winner
+   (`tournament.manager.ts:306-365`), so including them needs semantics
+   untangled first.
+4. **`GM_FOOTMEN_FRENZY` mismatch.** It sets `isAnonymous = true` upstream but is
+   absent from `GameModesHelper.FfaGameModes` in the backend. (`GM_LTW_FFA` being
+   absent is correct — `gm-ltw-ffa.ts:30` sets `isAnonymous = false`.)
+
+## Backend design
+
+### 1. New `CanceledMatch` read model
+
+Nothing queryable exists today. The only trace of a cancellation is the raw
+`MatchCanceledEvent` document, inserted directly by matchmaking's stats hook
+(`stats-hook.ts:106-111`, `insertOne` with no top-level `_id`, so no dedup). The
+backend never inserts into, indexes, or deletes that collection; its sole read is
+`MatchEventRepository.Load<T>(lastObjectId, pageSize)`, a forward-only
+ascending-`_id` cursor with no filters, no descending sort and no count. Only two
+handlers consume the event, and neither records anything reusable:
+`OngoingRemovalMatchCanceledHandler` deletes the ongoing-match row, and
+`LagReportMatchCanceledHandler` enriches an already-existing lag report.
+`Matchup` has no state field and its only factory is `Create(MatchFinishedEvent)`.
+
+Add `CanceledMatchReadModelHandler : IMatchCanceledReadModelHandler`, registered
+in `Program.cs` via the existing `AddMatchCanceledReadModelService`.
+
+**Backfill is free.** A new handler gets its own `HandlerVersions` row, and
+`VersionRepository.GetLastVersion` defaults to `LastVersion = ObjectId.Empty`,
+`Season = 0`. `UpdateSeasonIfNeeded` raises the stored season monotonically as
+the handler walks `_id` order, so a fresh handler replays the entire historical
+`MatchCanceledEvent` backlog on first deploy.
+
+> **Verify before relying on full history.** No TTL index and no delete path
+> exists for that collection anywhere in either repo (the only TTLs are
+> `LagReport` at 90 days and `PlayerMatchTelemetry`; the only event delete is
+> `DeleteStartedEvent`). That is a claim about *code* — a manually-created TTL
+> index or an ops-side prune job would not be visible in the repos. Check the
+> live cluster before promising complete history.
+
+#### Entity
+
+| Field | Source | Notes |
+| --- | --- | --- |
+| `Id` | source event `ObjectId` | |
+| `MatchId` | `match._id` | 10-char nanoid; unique key |
+| `FloGameId` | `match.floGameId` | `int?` — genuinely absent for pre-flo cancels |
+| `GameMode`, `GameName` | `match` | |
+| `Map`, `MapId`, `MapName` | `match` | |
+| `Gateway`, `Season`, `ServerProvider`, `FloNode` | `match` | |
+| `StartTime` | `match.startTime` | unix ms |
+| `CanceledAt` | **event `ObjectId` timestamp** | see below |
+| `Players` | `match.players` | dedicated DTO, see below |
+
+**`CanceledAt` must derive from the event ObjectId's timestamp, not `endTime`.**
+`endTime` is never set upstream on a cancellation and the C# `Match` DTO coerces
+the null to `0` (`MatchEventDtos.cs:124-136`), so it cannot be used as a sort
+key. `StartTime` is a viable alternative but is further from "when did this get
+cancelled".
+
+**Use a dedicated `CanceledMatchPlayer` DTO — do not reuse `PlayerOverviewMatches`.**
+Fields: `BattleTag`, `Name`, `Race`, `Team`, `OldMmr`, `Ranking`, `Country`,
+`InviteName`. Deliberately **no** `Won`, `CurrentMmr`, `MmrGain` or
+`MatchRanking`. Reusing the existing DTO would be actively harmful:
+`PlayerOverviewMatches.Won` is a non-nullable `bool` and `Team.Won` is a computed
+getter, so `won: false` would always be on the wire, and
+`PlayerMatchInfo.vue:135-143` would paint every player as a loser. Omitting the
+field is cleaner than shipping a falsy value and suppressing it downstream.
+
+#### Indexes and dedup
+
+Upsert by `MatchId` with a unique index — upstream uses `insertOne` with no
+dedup, and the producer's 300-entry queue can re-send on failure, so the same
+match can legitimately arrive twice.
+
+- unique `MatchId`
+- `{ GameMode: 1, CanceledAt: -1 }` — the by-mode listing
+- `{ CanceledAt: -1 }` — the all-modes listing
+- `{ "Players.BattleTag": 1 }` — battletag filter
+
+Follow the existing `IRequiresIndexes` pattern (see `MatchRepository.EnsureIndexesAsync`).
+
+### 2. Remove healed matches
+
+`healMatches` runs every 12 hours and retroactively converts a `CANCELED` ladder
+match from the last 2 days into `FINISHED` when a matching winner-bearing result
+log turns up (`matches.manager.ts:326-357`). So a match can emit
+`MatchCanceledEvent` first and `MatchFinishedEvent` later.
+
+Add `CanceledMatchRemovalOnFinishHandler : IMatchFinishedReadModelHandler` that
+deletes the `CanceledMatch` row by `MatchId`. This mirrors the existing
+`OngoingRemovalMatchCanceledHandler` pattern exactly. Without it, healed matches
+linger as phantom rows on the admin page.
+
+(True draws are never healed — a heal still requires a winner — so this only
+affects the genuine cancel-then-finish race.)
+
+### 3. New endpoint
+
+New `AdminCanceledMatchesController`. Every action carries
+`[BearerHasPermissionFilter(Permission = EPermission.Moderation)]` — the
+attribute is `AttributeTargets.Method`, so it cannot be applied at controller
+level and must be repeated per action.
+
+```
+GET api/admin/canceled-matches?gameMode=&battleTag=&offset=&pageSize=
+    -> { matches, count }
+```
+
+- Envelope `{ matches, count }` matches the match-domain convention the frontend
+  already consumes (`MatchesController` uses it for `/api/matches` and
+  `/api/matches/search`); the newer `{ items, total }` shape used by lag reports
+  is the other option, but consistency with the match endpoints wins here.
+- `gameMode` accepts `GameMode.Undefined` (0) to mean **all modes**. This needs
+  an explicit bypass branch — the existing `MatchRepository.GetLoadFilter` does a
+  bare `builder.Eq(m => m.GameMode, gameMode)` with no Undefined handling.
+- `battleTag` is an optional filter; moderation workflows usually start from a
+  player.
+- Clamp `pageSize` to 100, consistent with `MatchesController`.
+- Sort `CanceledAt` descending.
+
+Do **not** apply `PlayersObfuscator`. It exists for ongoing FFA matches and for
+MMR/rank-deviation masking on public endpoints; this is a Moderation-gated admin
+surface that needs real values.
+
+### 4. Replay and chat log reachability
+
+Both the replay download and the chat log bottom out in the **same single
+identifier — the flo game id (int)**. There is no second id to be missing:
+`ReplaysController` `{gameId}` and `{gameId}/chats` both call
+`MatchRepository.GetFloIdFromId` and pass the resulting int to
+`ReplayServiceClient`, whose two methods format that int into
+`/generate/{id}` and `/chats/{id}`.
+
+`GetFloIdFromId` reads the **`Matchup` collection only** (`MatchRepository.cs:275-280`).
+A cancelled match has no `Matchup` row, so the `{gameId}` routes cannot ever
+serve one. Worse, `new ObjectId($"{gameId}")` at `:277` is unguarded, so passing
+the matchmaking nanoid yields a 500 rather than a clean 404.
+
+**Therefore: no new replay or chat endpoints. The list payload exposes
+`floGameId`, and the frontend uses the existing `by-flo-id` routes**, which do no
+DB lookup at all and only reject `0`.
+
+`FloGameId` is nullable and sometimes genuinely absent: it is assigned only after
+flo's `createGame` returns (`flo-game-creation.flow.ts:172-174`) and persisted
+only in `startMatch` (`match-maker.ts:149-152`). The 2-minute `INIT` sweep
+cancels matches that never got a flo game — `LagReportMatchCanceledHandler.cs:21-24`
+already early-returns on this. **For those matches no replay and no chat log can
+ever exist**; the UI must render the buttons as unavailable rather than failing.
+
+Three supporting changes:
+
+#### 4a. Raise the hourly replay rate limit for authenticated moderators
+
+Cancelled matches always land in the **strict** bucket, because
+`ReplayRateLimitAttribute.CheckMatchAge` resolves age via
+`LoadFinishedMatchDetailsBy*`, which returns null for a cancelled match →
+`isRecent == null` → strict (10/hour, 50/day). Ten downloads an hour is thin for
+a moderator working through a list.
+
+Change `ReplayRateLimitAttribute`:
+
+- Add `ModeratorHourlyLimit { get; set; } = 50`.
+- After `rateLimitService.DetermineRateLimitContext(...)` returns, if the request
+  carries a valid bearer token whose permissions include `EPermission.Moderation`
+  **and** `!ctx.HasValidApiToken`, then set `ctx.HourlyLimit = ModeratorHourlyLimit`,
+  `ctx.PolicyName = "replay-moderator"`, and
+  `ctx.PartitionKey = $"moderator:{battleTag}:{Scope}"`.
+- **Leave `DailyLimit` untouched** — it stays at whatever strict/relaxed
+  resolved (50 strict, 100 relaxed).
+
+Resolve the auth service from DI: `IW3CAuthenticationService` is registered at
+`Program.cs:178` as an intercepted transient, so use
+`RequestServices.GetRequiredService<IW3CAuthenticationService>()` rather than
+`BearerHasPermissionFilter`'s `new W3CAuthenticationService()`.
+
+Partitioning by battleTag rather than IP is deliberate: it keeps one moderator
+from consuming another's budget behind a shared IP, and matches the existing key
+conventions (`ip:{ip}:{scope}`, `token:{id}:{scope}`).
+
+Note that with hourly at 50 and strict daily at 50, the daily cap becomes the
+binding constraint — a moderator can spend the whole day's allowance in one hour.
+That is the intended trade-off: bursty review sessions are the actual usage
+pattern, and the daily ceiling still holds.
+
+Unauthenticated and non-moderator behaviour is unchanged.
+
+#### 4b. Make a missing chat log return 404
+
+`ReplayServiceClient.GetChatLogs` (`ReplayServiceClient.cs:29-33`) uses
+`GetAsync` + `ReadAsStringAsync` with **no status check**, so an upstream 404
+deserializes to null and surfaces as HTTP 200 with a null body. This page will
+hit missing chat logs routinely (pre-flo cancels, unarchived replays), so it
+should return a clean 404.
+
+(`GenerateReplay` does not have this problem — `GetStreamAsync` applies
+`EnsureSuccessStatusCode` internally. It has the opposite one: an upstream 404
+becomes an unhandled exception → 500. Worth tidying while in there.)
+
+#### 4c. Never return `playerScores: []`
+
+If any payload feeding `MatchDetail.vue` carries `playerScores: []` instead of
+`null`, the page silently flips into "complete game" mode: `isCompleteGame`
+(`MatchDetail.vue:303`) is typed `PlayerScore[]`, not boolean, and an empty array
+is truthy. That suppresses the `incompletedata` message, renders an all-zeros
+score screen, and unlocks the unguarded FFA dereferences at `:335` and `:487-499`.
+`null` is the correct value and is what the existing code already produces.
+
+## FFA de-anonymization
+
+The requirement is to reconcile who is who in modes that hide names in-game.
+**This works with no new mapping table and no upstream change.**
+
+### Where "Player N" comes from
+
+Not this backend. Flo masks names as exactly `format!("Player {}", i + 1)` where
+`i` is the **slot index**, at `observer-edge/src/game/snapshot.rs:187-191` and
+`observer-edge/src/game/mod.rs:173` among others. It is driven by
+`game.mask_player_names`, which matchmaking sets from
+`gameMode?.isAnonymous || match.hideCustomGamePlayerNames`
+(`flo-game-creation.flow.ts:160`). `isAnonymous` is true for `GM_FFA`,
+`GM_SC_FFA_4`, `GM_SC_OZ` and `GM_FOOTMEN_FRENZY`.
+
+The backend's own FFA obfuscation is a separate mechanism that produces `"*"`,
+not `Player N`, applies at API-response time only, and only to **ongoing**
+matches (`PlayersObfuscator.cs:18-19`, called from `MatchesController.cs:190,206`).
+
+### Both identity sources are already unmasked
+
+1. **`MatchCanceledEvent.match.players[].battleTag` is real.** Matchmaking pushes
+   the live `Match` object verbatim into the stats DB; it anonymizes nothing in
+   its event payloads. So the new read model captures real battletags directly,
+   and the list shows real names with no extra work.
+
+2. **The chat log already resolves slot → real name.** replay-service's chats
+   handler calls flo's gRPC `get_game`, and `Game::pack()`
+   (`controller/src/game/types.rs:45-68`) packs `slots` verbatim **without
+   masking** — masking lives only in the observer-edge, client and player-sender
+   paths. The handler then builds `PlayerInfo { id: idx + 1, name: player.name }`
+   over the same slot enumeration (`w3c-replay/binaries/replay-service/src/handlers/chats.rs:139-151`).
+
+   Because both use `slots.iter().enumerate()`, **`chatLog.players[].id` is
+   exactly the N in "Player N"**, and `.name` is the real name. "Player 3 was
+   toxic" resolves by looking up `players[].id == 3`.
+
+   The frontend already implements this join:
+   `AdminReplayChatLogMessages.vue:157-167` does
+   `log.value.players.find(x => x.id == playerId)?.name` on `message.fromPlayer`.
+
+So the entire FFA requirement reduces to **making the chat log reachable by flo
+game id**, which 4a–4b above already cover.
+
+### The one thing that is not recoverable
+
+If no replay/chat log exists (pre-flo-creation cancels), there is no way to map a
+slot number to a battletag. Matchmaking computes slot assignment transiently in
+`player-slots.helper.ts:14-29` for the flo `CreateGame` request and discards it;
+it is never written to the `Match` object. `LagReport.ServerSidePing[].PlayerName`
+is no help — it stores flo's *masked* `Player N` strings, and the backend has no
+flo-player-id → battletag mapping anywhere. Fixing this properly would mean
+persisting the slot map on the `Match` object upstream. Not needed for v1, since
+the participant set is always available from the list.
+
+### PII
+
+Per decision, the Moderation permission gate is the only control — no audit
+logging in v1. Worth stating plainly in the PR: this page shows real battletags
+for game modes that deliberately hide names in-game, so the Moderation gate is
+the sole thing standing between an admin without Moderation and that data.
+Enforce it server-side on every action; a client-side flag would be
+insufficient.
+
+## Frontend design
+
+A **new admin grid reusing the leaf components** — not an extension of
+`MatchesGrid`. `MatchesGrid`'s rows are inline in its template (there is no
+standalone row component), and its pagination is hard-bound to
+`playerStore`/`matchStore` through an `isPlayerProfile` boolean, so a third
+consumer cannot drive it without surgery. Its `unfinished` flag is also
+overloaded — it hides the replay column, disables detail navigation, replaces the
+duration with "onGoing" and zeroes the duration bar. Keeping the new page
+separate leaves the player profile and public Matches page untouched.
+
+### Files to create
+
+| File | Purpose |
+| --- | --- |
+| `src/components/admin/AdminCancelledMatches.vue` | The page: `v-container.w3-container-width` > `v-card`, game-mode select, battletag search, paging, notes panel, table |
+| `src/services/admin/CancelledMatchService.ts` | `AuthorizedClient` wrapper — **not** the deprecated `authorizedFetch` (`helpers/general.ts:31-42`) |
+| `src/types/admin/CancelledMatch.ts` | DTOs mirroring the backend |
+| `src/services/admin/CancelledMatchService.test.ts` | vitest + `node:assert`, fake `fetch` injected via constructor |
+
+Follow the Jobs page as the template (`AdminJobs.vue`, `AdminJobService.ts`):
+lazy module-level service singleton (`_service ??= new Service({ endpoint: API_URL })`,
+because `@/config/env` reads `window` at module load), token from
+`useOauthStore()` passed per call, `HttpError` status mapped to UI meaning at the
+boundary, component-local refs rather than a Pinia store, and hardcoded English
+strings — recent admin pages use no `$t` at all, and `src/locales/data.ts` is
+autogenerated and overwritten by the build, so adding locale keys is awkward.
+
+### Files to touch
+
+| File | Change |
+| --- | --- |
+| `src/router/types.ts` | Add `CANCELLED_MATCHES = "Admin - Cancelled Matches"` to `EAdminRouteName` (the value is also the document title) |
+| `src/router/index.ts` | Component import + one child entry in the `/admin` children array |
+| `src/components/admin/AdminNavigation.vue` | Icon import + one child object in the **existing Moderation group** (lines 157-205) |
+| `src/components/matches/PlayerMatchInfo.vue` | New `noWinner` prop |
+| `src/components/matches/TeamMatchInfo.vue` | Pass `noWinner` through |
+| `src/components/matches/DownloadReplayIcon.vue` | Optional `floGameId` prop |
+| `src/components/admin/replays/AdminReplayChatLogMessages.vue` | Optional `floGameId` prop (currently `matchId` only, `:94`; calls the store at `:206`) |
+| `src/store/admin/replayManagement/store.ts` | Add `loadChatLogByFloId(floGameId)` alongside `loadChatLog` (`:11`) |
+
+The by-flo-id chat fetch belongs on the **new `CancelledMatchService`** using
+`AuthorizedClient`, not beside `AdminService.getChatLog` (`:283`) — that method
+uses the deprecated `authorizedFetch`, and extending it would perpetuate the
+pattern the `AuthorizedClient` docstring explicitly steers new code away from.
+The store action can call the new service directly.
+
+The nav child's `component` value **must equal the route's `path` segment** — the
+`/admin` landing redirect pushes `admin/${firstItem.component}`
+(`AdminNavigation.vue:129-138`). Add it as a child of the existing Moderation
+group rather than a new top-level group; a childless top-level entry breaks that
+redirect.
+
+### `noWinner` prop
+
+`won` is the **only** genuine hard dependency. `PlayerMatchInfo.vue:135-143`
+returns `"w3-won"`/`"w3-lost"` and `playerColorClass` applies it to three places:
+the name link (`:21`) and **both** MMR-delta spans (`:27-28`, `:33-35`). When
+`noWinner` is set, the computed returns `""`.
+
+Do not reuse the existing `unfinishedMatch` flag for this — it also suppresses
+spoiler logic, which is not wanted here.
+
+Everything else degrades safely already, verified by reading the components:
+
+- **MMR** — `PlayerMatchInfo.vue:150` guards `oldMmr != null`; `:157-163`
+  requires both `oldMmr` and `currentMmr`; the template gates on
+  `displayRating !== null` and `displayMmrChange !== 0`.
+- **League/rank** — `:154-155`, `:203` optional-chain `ranking?.leagueOrder`,
+  falling back to `views_rankings.unranked`.
+- **Placement** — `TeamMatchInfo.vue:3,8` use `!isNil(...)` on `matchRanking`.
+- **Heroes** — `HeroIconRow` accepts `Hero[] | null` and `v-for` over null
+  renders nothing.
+- `mmrGain` from the backend is dead on the frontend — the delta is always
+  recomputed client-side. Another reason to omit it from the DTO.
+
+### Replay and chat buttons
+
+`DownloadReplayIcon` currently hardcodes `${API_URL}api/replays/${gameId}` and
+declares `gameId: String, required`. Add an optional `floGameId` prop that, when
+present, targets the `by-flo-id` route instead. It already handles 429 and 404
+distinctly, which is exactly what is needed here.
+
+Render both buttons as disabled with an explanatory tooltip when `floGameId` is
+null — those matches were cancelled before flo created the game and can never
+have a replay or chat log.
+
+### Notes panel
+
+Per decision, the page carries a visible note explaining:
+
+- Drawn and stalled matches appear only after the 6-hour cleanup sweep.
+- Matches cancelled during game creation (flo errors, join bugs, leavers) are
+  **not** listed, because they emit no event today.
+- Tournament and custom matches are not listed.
+- Replay and chat log are unavailable for matches cancelled before the flo game
+  was created.
+
+### In-page permission check
+
+There is **no router guard and no route `meta` anywhere** in this frontend — the
+whole `/admin` view is gated on `oauthStore.isAdmin` only, and any admin can
+deep-link to `/admin/<any-page>`. Client gating today is purely the sidebar
+filter. Add an in-page check following `AdminSmurfs.vue:220-221`:
+
+```ts
+const canModerate = computed(() =>
+  oauthStore.permissions.includes(EPermission[EPermission.Moderation]));
+```
+
+and render a refusal state instead of the table. The backend 403 is still the
+real enforcement; this stops the page rendering a broken shell.
+
+## Testing
+
+**Backend.** The established pattern for match code is NUnit repository fixtures
+against a live Mongo via `IntegrationTestBase`, built with AutoFixture through
+`TestDtoHelper` (see `WC3ChampionsStatisticService.UnitTests/Matchups/`). There
+are **no** controller-level tests for `MatchesController` to copy; controller test
+patterns exist elsewhere (`AdminWarningsControllerTests.cs`) using hand-built
+controllers plus Moq.
+
+> **Caution:** `IntegrationTestBase` drops and recreates the real shared
+> `W3Champions-Statistic-Service` database on a remote Mongo host in `[SetUp]`.
+
+Cover:
+
+- Handler writes a `CanceledMatch` from a `MatchCanceledEvent`
+  (`TestDtoHelper` already has cancelled-event helpers).
+- Handler is idempotent — same match twice yields one row.
+- `FloGameId == null` is persisted without error.
+- Repository: gameMode filter, `Undefined` = all modes, battleTag filter, paging,
+  `CanceledAt` descending.
+- `CanceledMatchRemovalOnFinishHandler` deletes the row on a matching finish.
+- `ReplayRateLimitAttribute`: moderator token → hourly 50, daily unchanged,
+  battleTag partition key; non-moderator and API-token paths unchanged.
+- `GetChatLogs` maps an upstream non-success status to 404.
+
+**Frontend.** vitest runs in `environment: "node"` with no vue plugin
+(`vitest.config.ts:13-19`), so **`.vue` files cannot be unit tested** without
+adding jsdom and `@vitejs/plugin-vue` first. Test the service layer only:
+assert URL, method, query params and status mapping with an injected fake fetch.
+
+Quality gates: `npm run lint` (`--max-warnings=0`), `npm run dprint`,
+`npm run type-check`, `npm test`. Backend: `dotnet build`, `dotnet test`,
+`dotnet format --verify-no-changes`.
+
+## Deployment note
+
+Read-model handlers are gated on `START_HANDLERS` and the comparison is
+**case-sensitive exact equality** with `"true"` (`Program.cs:267`) — `"True"`,
+`"TRUE"` and `"1"` all silently disable every handler. The new handler will not
+backfill until that is set correctly in the target environment.
+
+Per `CLAUDE.md`: read model handling is off by default locally, and connecting to
+the wrong database can overwrite prod/test data.
+
+## Correction to `CLAUDE.md`
+
+`CLAUDE.md` names `../website` as the Vue 3 frontend. In this checkout
+`../website` is the **Caddy web server's site** (remote:
+`git@github.com:caddyserver/website.git`). The actual frontend is
+`../w3c-website`. Worth fixing in the same PR.

--- a/docs/superpowers/specs/2026-08-05-cancelled-matches-admin-page-design.md
+++ b/docs/superpowers/specs/2026-08-05-cancelled-matches-admin-page-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-05
 **Status:** Approved design, ready for implementation planning
-**Repos affected:** `website-backend`, `website` (frontend)
+**Repos affected:** `matchmaking-service`, `website-backend`, `website` (frontend)
 **Permission gate:** `EPermission.Moderation` (existing — no new permission)
 
 ## Problem
@@ -47,29 +47,28 @@ as `result.players.find(p => p.won) !== undefined`. A drawn game therefore never
 produces a valid result, never enters `winnerResultMap`, and
 `getValidResult()` returns null indefinitely. The match sits in `STARTED` until
 the 5-minute `cleanUpMatches` sweep cancels it for exceeding 6 hours
-(`matches.manager.ts:296-301`), which is the only path that emits
-`MatchCanceledEvent` (`:316-322`, ladder-only).
+(`matches.manager.ts:296-301`).
 
-**Consequence: a drawn match does not appear for roughly 6 hours.** Accepted for
-v1; the page carries an explanatory note (see Frontend). Revisiting this by
-plumbing the W3GS `LeaveDraw` reason (`flo/crates/w3gs/src/protocol/constants.rs:188`,
-already decoded by flo's observer edge) through to matchmaking is deferred.
+**Consequence: a drawn match is not marked cancelled for roughly 6 hours.**
+Accepted for v1; the page carries an explanatory note (see Frontend). Revisiting
+this by plumbing the W3GS `LeaveDraw` reason
+(`flo/crates/w3gs/src/protocol/constants.rs:188`, already decoded by flo's
+observer edge) through to matchmaking is deferred.
 
-### No cancellation reason is recorded anywhere
+### No cancellation reason is recorded on the match
 
 `MatchesRepo.cancelMatch` (`matches.repo.ts:79-84`) sets `state = CANCELED` and
-nothing else — no reason, no `endTime`, no `lengthSeconds`. A rich
-`EGameCreationResult` enum (23 values) exists but is only written to match logs
-and metrics, never onto the `Match` entity, so it cannot ride along on the
-event. The page therefore cannot show *why* a match was cancelled.
+saves; it records no reason, and leaves `endTime` and `lengthSeconds` unset. A
+rich `EGameCreationResult` enum (23 values) exists but is written only to match
+logs and metrics, never onto the `Match` entity.
 
-The reason is not simply discarded, though: `gameCreationFailed` passes it to
+The reason is not discarded, though: `gameCreationFailed` passes it to
 `sendGameCancelledDialog(cancellationData)` (`game-creation.flow.ts:255-257`),
 and the launcher has translated strings for every one of the 23 values
 (`launcher-e/src/translations/*.ts`, e.g. `"Game cancelled: PLAYER_CAUSED_JOINBUG"`).
 So the reason exists and is already transmitted to clients at the moment of
-failure — it is only the stats hook that never receives it. That makes adding it
-to the event a small change, should it be wanted later.
+failure — it is only never persisted. Adding it to the `Match` entity would be a
+small change, should it be wanted later.
 
 ### `MatchLogs` exist but are not reachable from this backend
 
@@ -81,314 +80,314 @@ events, host commands, client-submitted events — including the explicit
 `game creation failure reason: <EGameCreationResult>` line
 (`game-creation.flow.ts:253`).
 
-It is, however, **not exposed over HTTP**: there is no route referencing match
-logs anywhere in `src/app/apis/`, and it lives in the matchmaking database, not
-the statistic-service one. Surfacing it would need a new matchmaking-service
-endpoint plus a `MatchmakingServiceClient` proxy method.
+It is not exposed over HTTP: no route in `src/app/apis/` references match logs.
 
 Deliberately **out of scope for v1**, per review: the logs are not intended for
 human consumption and carry a very large volume per match. Reconciling them
 against the cancelled-match list is a plausible follow-up, and the join key
-(`matchId`) is already on the `CanceledMatch` read model, so nothing in this
-design blocks it.
+(`matchId`) is on every row this design returns, so nothing here blocks it.
 
 ### There are four `EMatchState` values and no draw state
 
 `INIT`, `STARTED`, `FINISHED`, `CANCELED` (`match.ts:44-49`). A draw is
 indistinguishable from "nobody reported a win".
 
-### Every path that can cancel a match
+### Every path that can cancel a match, and where each is recorded
 
-This was challenged in review as likely incomplete, so it was re-verified
-exhaustively rather than trusted. The enumeration below is what the code
-actually supports.
+This was challenged in review, re-verified exhaustively, and the conclusion
+changed the design. The critical distinction is between **the `Match` collection**
+(matchmaking's own store) and **the `MatchCanceledEvent` stream** (what the
+statistic service consumes).
 
-`MatchCanceledEvent` has **exactly one producer and one call site**:
+`MatchCanceledEvent` has exactly one producer and one call site:
 
 - `grep -rn "pushMatchCanceled" src/` → the definition at `stats-hook.ts:106`
   and a single call at `matches.manager.ts:319`.
-- `grep -rn "MATCH_CANCELED\|MatchCanceledEvent" src/` → only the enum member,
-  the `uniqueQueueTypes` list, and that one push.
-- `cancelMatch` has exactly two call sites: `matches.manager.ts:168`
-  (creation failure, **no** push) and `:317` (the sweeper, followed by the push
-  at `:319`).
-- No other repository writes the collection: grepping `MatchCanceledEvent` and
-  `W3Champions-Statistic-Service` across `flo`, `launcher-e` and `w3c-replay`
+- `cancelMatch` has two call sites: `matches.manager.ts:168` (creation failure,
+  **no** push) and `:317` (the sweeper, followed by the push at `:319`).
+- No other repository writes the event collection: grepping `MatchCanceledEvent`
+  and `W3Champions-Statistic-Service` across `flo`, `launcher-e` and `w3c-replay`
   returns nothing. The launcher only *receives* cancellations — its
   `cancelMatchmaking` (`backend.service.ts:290`) cancels queue search, not a
   match, and clients never report a match as cancelled.
 
-So the paths are:
+**But `cancelMatch` always persists.** It calls `this.save(match)`
+(`matches.repo.ts:79-84`) on *both* paths, and the match document already exists:
+`createMatch` → `insertWithId` runs the instant the queue pairs players
+(`match-maker.ts:605`), before `gameCreationManager.addMatch` starts the creation
+flow. So every match is in Mongo at `INIT`, and every cancellation is written
+there regardless of which path took it.
 
-| Path | Emits `MatchCanceledEvent`? |
-| --- | --- |
-| `INIT` older than 2 min (sweeper) | **Yes**, ladder only |
-| `STARTED` older than 6 h (sweeper — the draw bucket) | **Yes**, ladder only |
-| Game-creation failure (flo error, join bug, disbanded team, leaver, every per-state timeout) | **No** |
-| 1v1 disconnect-forfeit | No — becomes `FINISHED` with a 0-second duration |
-| `FINISHED` older than 6 h | No — evicted from memory only |
-| Tournament cancellations | No — ladder-gated, and a winner is still assigned |
-| Custom matches | No — ladder-gated |
-| Client/launcher report | Does not exist |
+| Path | In `Match` collection | Emits `MatchCanceledEvent` |
+| --- | --- | --- |
+| `INIT` older than 2 min (sweeper) | **Yes** | Yes, ladder only |
+| `STARTED` older than 6 h (sweeper — the draw bucket) | **Yes** | Yes, ladder only |
+| Game-creation failure (flo error, join bug, disbanded team, leaver, per-state timeouts) | **Yes** | **No** |
+| Tournament cancellations | **Yes** | No — ladder-gated |
+| Custom matches | **Yes** | No — ladder-gated |
+| 1v1 disconnect-forfeit | Yes, as `FINISHED` with 0-second duration | No |
+| `FINISHED` older than 6 h | Yes, unchanged | No — evicted from memory only |
+| Client/launcher report | Does not exist | Does not exist |
 
-Two clarifications that came out of re-checking, both of which make the
-creation-failure gap worse than first described:
+**The `Match` collection is the complete source of truth; the event stream is a
+lossy projection of it.** This design therefore reads the former, not the latter.
+
+Two details that make the event stream unusable as the primary source:
 
 1. **A failed creation emits no `MatchStartedEvent` either.**
    `statsHook.pushMatchStart` is called only from `gameCreationSuccess()`
-   (`game-creation.flow.ts:175`); `gameCreationFailed()` never calls it. So these
-   matches are not merely missing a *cancellation* — they are entirely invisible
-   to this backend, with no record of the attempt at all. That is precisely the
+   (`game-creation.flow.ts:175`). So those matches are entirely invisible to the
+   statistic service — no record of the attempt at all. That is precisely the
    data wanted for match-creation abuse scenarios.
 2. **The sweeper cannot pick them up as a fallback.**
    `decideMatchOutcomeDuringFailedGameCreation` calls `removeCurrentMatch` at
    `:169`, evicting the match from the in-memory map that `cleanUpMatches`
-   iterates. And `processLeavers` calls that method **unconditionally**, even
-   when the leavers array is empty (`game-creation.flow.ts:524-531`), so every
-   creation failure takes this path.
+   iterates. And `processLeavers` calls that method **unconditionally**, even when
+   the leavers array is empty (`game-creation.flow.ts:524-531`), so every creation
+   failure takes this path.
 
-For completeness, one hypothesis raised in review that the code does not support:
-there is no "joining a new game cancels the old one" path. `latestMatch` is used
-only to route a disconnect to the right in-flight creation flow
-(`game-creation.manager.ts:79-87`), never to cancel a prior match. Matches are
-also rehydrated from the database on startup for any non-`FINISHED` state
-(`matches.manager.ts:26-32`), so a process restart does not orphan `STARTED`
-matches.
+For completeness, two hypotheses raised in review that the code does not support:
+there is no "joining a new game cancels the old one" path (`latestMatch` only
+routes a disconnect to the right in-flight creation flow,
+`game-creation.manager.ts:79-87`), and matches are rehydrated from the database on
+startup for any non-`FINISHED` state (`matches.manager.ts:26-32`), so a process
+restart does not orphan `STARTED` matches.
 
 ## Scope
 
-**In scope:** ladder matches cancelled by the timeout sweeps — `INIT` older than
-2 minutes, and `STARTED` older than 6 hours (the bucket that swallows draws).
-These are the only cancellations that reach this backend today.
+**In scope:** all cancelled matches recorded in matchmaking's `Match` collection —
+including game-creation failures, which no event ever reported. Reading the
+collection directly means coverage is complete from day one with no backfill.
 
 Also in scope, as a drive-by fix: **adding `GM_FOOTMEN_FRENZY` to
 `GameModesHelper.FfaGameModes`**. Its matchmaking-service definition sets
-`isAnonymous = true`, so flo masks names in-game, but the backend was not
-treating it as an FFA mode — meaning ongoing Footmen Frenzy matches leaked real
-battletags through `/api/matches/ongoing` and were lookupable by player. Anon-FFA
-Footmen Frenzy is returning, so this needs to be correct. The three call sites
+`isAnonymous = true`, so flo masks names in-game, but the backend was not treating
+it as an FFA mode — meaning ongoing Footmen Frenzy matches leaked real battletags
+through `/api/matches/ongoing` and were lookupable by player. Anon-FFA Footmen
+Frenzy is returning, so this needs to be correct. The three call sites
 (`MatchesController.cs:201`, `PlayersObfuscator.cs:12`, `Matchup.cs:160`) are all
-anonymization behaviours, which is exactly what the mode should now get.
-`GM_LTW_FFA` remains correctly absent — `gm-ltw-ffa.ts:30` sets
-`isAnonymous = false`.
+anonymization behaviours. `GM_LTW_FFA` remains correctly absent —
+`gm-ltw-ffa.ts:30` sets `isAnonymous = false`.
 
 **Out of scope, to be raised at PR review:**
 
-1. **Game-creation failures are invisible — no event of any kind.** Not just the
-   missing `pushMatchCanceled` at `matches.manager.ts:168`, but no
-   `MatchStartedEvent` either, since `pushMatchStart` fires only on success. See
-   "Every path that can cancel a match" above for the full trace. This is the
-   highest-value follow-up: it covers flo create-game errors, join bugs,
-   disbanded teams, leavers and every per-state timeout, and it is exactly the
-   population relevant to match-creation abuse. It looks like a genuine
-   inconsistency rather than a design decision.
-2. **`LeaveDraw` is not treated as a first-class outcome** — see above. Would
-   remove the ~6h delay.
-3. **Tournament and custom matches never reach the stats hook** (the
-   `isLadderMatch` gate at `matches.manager.ts:318`). Tournament code also uses
-   `CANCELED` as an outcome marker while still assigning a winner
-   (`tournament.manager.ts:306-365`), so including them needs semantics
-   untangled first.
-4. **Displaying `MatchLogs`** alongside each cancelled match — see the
-   `MatchLogs` section above for why this is deferred and what it would take.
+1. **The missing `pushMatchCanceled`/`pushMatchStart` on the creation-failure
+   path.** This design no longer depends on it, since it reads the `Match`
+   collection instead. It remains a real inconsistency worth fixing on its own
+   merit, so that other read models and future event consumers see these matches.
+2. **`LeaveDraw` is not treated as a first-class outcome** — would remove the ~6h
+   delay before a drawn match is marked cancelled.
+3. **Recording the cancellation reason** on the `Match` entity — see above; the
+   reason already exists at failure time and is sent to clients.
+4. **Displaying `MatchLogs`** alongside each cancelled match.
 
-## Backend design
+## Design
 
-### 1. New `CanceledMatch` read model
+### Data source: proxy matchmaking-service
 
-Nothing queryable exists today. The only trace of a cancellation is the raw
-`MatchCanceledEvent` document, inserted directly by matchmaking's stats hook
-(`stats-hook.ts:106-111`, `insertOne` with no top-level `_id`, so no dedup). The
-backend never inserts into, indexes, or deletes that collection; its sole read is
-`MatchEventRepository.Load<T>(lastObjectId, pageSize)`, a forward-only
-ascending-`_id` cursor with no filters, no descending sort and no count. Only two
-handlers consume the event, and neither records anything reusable:
-`OngoingRemovalMatchCanceledHandler` deletes the ongoing-match row, and
-`LagReportMatchCanceledHandler` enriches an already-existing lag report.
-`Matchup` has no state field and its only factory is `Create(MatchFinishedEvent)`.
+Rather than building a `CanceledMatch` read model fed by the event stream, the
+statistic service proxies a new matchmaking-service admin endpoint. This is the
+established pattern for admin data that matchmaking owns — banned players, player
+warnings, warning definitions, queue snapshots, maps and MOTD all work this way
+via `MatchmakingServiceClient`.
 
-Add `CanceledMatchReadModelHandler : IMatchCanceledReadModelHandler`, registered
-in `Program.cs` via the existing `AddMatchCanceledReadModelService`.
+Why this over a read model:
 
-**Backfill is free.** A new handler gets its own `HandlerVersions` row, and
-`VersionRepository.GetLastVersion` defaults to `LastVersion = ObjectId.Empty`,
-`Season = 0`. `UpdateSeasonIfNeeded` raises the stored season monotonically as
-the handler walks `_id` order, so a fresh handler replays the entire historical
-`MatchCanceledEvent` backlog on first deploy.
+- **Complete.** Includes creation-failure cancellations, which no event carries.
+- **No backfill, full history immediately.** Matchmaking has no TTL on `Match`
+  (its only TTL is `ip-intel-cache`), so every historical cancellation is already
+  there.
+- **No `HandlerVersions`, no replay-from-`ObjectId.Empty`, no `START_HANDLERS`
+  dependency**, and no duplicate-suppression logic.
+- **Self-healing.** `healMatches` can retroactively flip a cancelled ladder match
+  to `FINISHED` up to 2 days later (`matches.manager.ts:326-357`). With a live
+  query the row simply stops matching `state = CANCELED` and disappears. A read
+  model would have needed a removal handler to avoid phantom rows.
+- Matchmaking keeps ownership of its own data.
 
-> **Verify before relying on full history.** No TTL index and no delete path
-> exists for that collection anywhere in either repo (the only TTLs are
-> `LagReport` at 90 days and `PlayerMatchTelemetry`; the only event delete is
-> `DeleteStartedEvent`). That is a claim about *code* — a manually-created TTL
-> index or an ops-side prune job would not be visible in the repos. Check the
-> live cluster before promising complete history.
+The cost is a runtime dependency on matchmaking being reachable, which the admin
+area already has for several other pages.
 
-#### Entity
+### 1. `matchmaking-service` changes
 
-| Field | Source | Notes |
-| --- | --- | --- |
-| `Id` | source event `ObjectId` | |
-| `MatchId` | `match._id` | 10-char nanoid; unique key |
-| `FloGameId` | `match.floGameId` | `int?` — genuinely absent for pre-flo cancels |
-| `GameMode`, `GameName` | `match` | |
-| `Map`, `MapId`, `MapName` | `match` | |
-| `Gateway`, `Season`, `ServerProvider`, `FloNode` | `match` | |
-| `StartTime` | `match.startTime` | unix ms; the sort key |
-| `CanceledAt` | none available | **nullable, left null** — see below |
-| `Players` | `match.players` | dedicated DTO, see below; includes `SlotIndex` if the upstream change lands |
-
-**`CanceledAt` is nullable and stays null.** `endTime` is never set upstream on a
-cancellation and the C# `Match` DTO coerces the null to `0`
-(`MatchEventDtos.cs:124-136`), so it cannot be used. An earlier draft proposed
-deriving the timestamp from the event `ObjectId`; that is rejected — ObjectIds
-should not be inspected for their embedded timestamp, and the value would in any
-case be "when the sweeper ran", not when the match actually ended. Since the
-sweeper only runs every 5 minutes and fires on a 6-hour threshold, that number
-would be misleading by up to hours.
-
-An honest null beats an inferred value. Recovering a real cancellation time would
-require parsing replays or `MatchLogs`, both explicitly out of scope.
-
-**Sort by `StartTime` descending instead.** `startTime` is set at match creation
-and is always present, so it is a reliable ordering key. It is also the more
-useful one for a moderator: "which matches started most recently".
-
-**Player DTO: extract a shared base rather than a standalone type.** The
-direction of a dedicated type is right — `PlayerOverviewMatches.Won` is a
-non-nullable `bool` and `Team.Won` is a computed getter, so reusing it as-is would
-put `won: false` on the wire and `PlayerMatchInfo.vue:135-143` would paint every
-player as a loser. But it should not be built from scratch: the event DTOs already
-demonstrate this pattern (`PlayerMMrChange : UnfinishedMatchPlayer :
-IMatchPlayerServerInfo`, `MatchEventDtos.cs:24,44`), while the read-model
-`PlayerOverviewMatches` is a flat standalone class.
-
-Introduce a base holding the identity and pre-match fields, and derive both:
-
-- **Base** (`MatchPlayerBase` or similar): `Race`, `RndRace`, `OldMmr`,
-  `OldMmrQuantile`, `OldRankDeviation`, `BattleTag`, `InviteName`, `Name`,
-  `Location`, `CountryCode`, `Country`, `Twitch`, `Ranking`.
-- **`PlayerOverviewMatches : base`** adds the result fields: `CurrentMmr`,
-  `MmrGain`, `Won`, `MatchRanking`, `Heroes`.
-- **`CanceledMatchPlayer : base`** adds only `Team`, plus `SlotIndex` if the
-  upstream change below lands.
-
-Confirm the exact split against `Matchup.CreatePlayerArray` during
-implementation — anything sourced from the Blizzard result (`Heroes` in
-particular) belongs on the derived result type, not the base. This is a
-refactor of a serialized public DTO, so it changes JSON property *order* but not
-names or semantics; verify no consumer depends on ordering.
-
-#### Indexes and dedup
-
-Upsert by `MatchId` with a unique index — upstream uses `insertOne` with no
-dedup, and the producer's 300-entry queue can re-send on failure, so the same
-match can legitimately arrive twice.
-
-- unique `MatchId`
-- `{ GameMode: 1, StartTime: -1 }` — the by-mode listing
-- `{ StartTime: -1 }` — the all-modes listing
-- `{ "Players.BattleTag": 1 }` — battletag filter
-
-Follow the existing `IRequiresIndexes` pattern (see `MatchRepository.EnsureIndexesAsync`).
-
-### 2. Remove healed matches
-
-`healMatches` runs every 12 hours and retroactively converts a `CANCELED` ladder
-match from the last 2 days into `FINISHED` when a matching winner-bearing result
-log turns up (`matches.manager.ts:326-357`). So a match can emit
-`MatchCanceledEvent` first and `MatchFinishedEvent` later.
-
-Add `CanceledMatchRemovalOnFinishHandler : IMatchFinishedReadModelHandler` that
-deletes the `CanceledMatch` row by `MatchId`. This mirrors the existing
-`OngoingRemovalMatchCanceledHandler` pattern exactly. Without it, healed matches
-linger as phantom rows on the admin page.
-
-(True draws are never healed — a heal still requires a winner — so this only
-affects the genuine cancel-then-finish race.)
-
-### 3. New endpoint
-
-New `AdminMatchesController` with route prefix **`api/admin/matches`**. Every
-action carries `[BearerHasPermissionFilter(Permission = EPermission.Moderation)]`
-— the attribute is `AttributeTargets.Method`, so it cannot be applied at
-controller level and must be repeated per action.
+**New admin endpoint**, following the `/warnings` shape exactly
+(`admin.api.ts:55-73`):
 
 ```
-GET api/admin/matches/canceled?gameMode=&battleTag=&offset=&pageSize=
-    -> { matches, count }
+GET /admin/canceled-matches?page=&itemsPerPage=&gameMode=&battleTag=
+    -> { total, matches }
 ```
 
-The extra layer is deliberate and has precedent: `api/admin` already sub-layers
-into `api/admin/permissions`, `api/admin/logs`, `api/admin/storage` and
-`api/admin/api-tokens` (only `AdminController` itself sits at the bare
-`api/admin`). Grouping under `api/admin/matches` leaves room for further
-match-related admin endpoints without another controller prefix.
+- Guarded with `requireAdmin`, like every other admin route.
+- `page` is 1-based, default 1; `itemsPerPage` default 25, clamped to a sane
+  maximum. Offset is `page * itemsPerPage - itemsPerPage`
+  (`admin.api.ts:493`).
+- Filter `state: EMatchState.CANCELED`, optional `gameMode`, optional
+  `players.battleTag`.
+- Sort `_updated_at` descending (see below).
+- Add it to `MatchesRepo` as a properly paged query. The existing
+  `getCancelledMatchesSince(date)` (`matches.repo.ts:34-41`) is unpaged and capped
+  at 100k documents, so it is not reusable as-is; it can stay for its current
+  caller.
+- **Query Mongo, not the in-memory cache.** `MatchesRepo.initialize` loads only
+  `getNotCanceledMatches()` into `this.matches`, and `cancelMatch` removes the
+  match from it, so cancelled matches are never in the cache by construction.
 
-- Envelope `{ matches, count }` matches the match-domain convention the frontend
-  already consumes (`MatchesController` uses it for `/api/matches` and
-  `/api/matches/search`); the newer `{ items, total }` shape used by lag reports
-  is the other option, but consistency with the match endpoints wins here.
-- `gameMode` accepts `GameMode.Undefined` (0) to mean **all modes**. This needs
-  an explicit bypass branch — the existing `MatchRepository.GetLoadFilter` does a
-  bare `builder.Eq(m => m.GameMode, gameMode)` with no Undefined handling.
-- `battleTag` is an optional filter; moderation workflows usually start from a
-  player.
-- Clamp `pageSize` to 100, consistent with `MatchesController`.
-- Sort `StartTime` descending.
+**New index.** The collection currently has only `{_created_at: -1}` and
+`{players.battleTag: 1}` (`matches.repo.ts:19-21`). Add a compound index
+supporting the primary listing, e.g. `{state: 1, gameMode: 1, _updated_at: -1}`,
+via the same `createIndex` calls in `initialize()`.
 
-**This endpoint must not call the replay service.** Listing is a pure Mongo read.
-See the note under FFA de-anonymization — replay-service calls cost money and must
-stay out of the list path.
+**Populate `IMatchPlayer.slotIndex` for matchmaking paths.** The field already
+exists and is already documented as the canonical FLO slot index
+(`match.ts:31-41`): *"Lobby slotId. For custom games this is the canonical FLO
+slot index (0-based, matches `CreateGameSlot[]` index) … Optional for back-compat
+with non-custom (matchmaking) paths where the slot is assigned later by
+`setPlayersToSlots` via `getNextAvailableSlot`."*
+
+So nothing new needs designing — only the write. In `setPlayersToSlots`
+(`player-slots.helper.ts:14-29`), which already resolves each player's slot and
+assigns `slot.player_id = x.playerInstance.floPlayer.id`, also set
+`x.matchPlayer.slotIndex = slots.indexOf(slot)`.
+
+It is **0-based**, matching the `CreateGameSlot[]` index. Flo's mask is
+`format!("Player {}", i + 1)` and replay-service's `PlayerInfo.id` is likewise
+`idx + 1`, so the UI must display `slotIndex + 1`.
+
+This only applies to matches that reached flo game creation. `INIT` timeout
+cancels never called `createGame`, so they have no slots — but they also have no
+replay and no chat log, so there is nothing to reconcile against.
+
+### 2. `website-backend` changes
+
+**`MatchmakingServiceClient`**: add a request/response pair mirroring the existing
+`PlayerWarningsGetRequest` / `PlayerWarningsResponse` convention
+(`MatchmakingServiceClient.cs:759-770`):
+
+```csharp
+public class CanceledMatchesGetRequest
+{
+    public int Page { get; set; } = 1;
+    public int ItemsPerPage { get; set; } = 25;
+    public GameMode GameMode { get; set; }
+    public string BattleTag { get; set; }
+}
+
+public class CanceledMatchesResponse
+{
+    public int total { get; set; }
+    public List<Match> matches { get; set; }
+}
+```
+
+**Reuse the existing `Match` DTO — do not write a new one.** The endpoint returns
+matchmaking `Match` documents, which `W3C.Domain/MatchmakingService/MatchEventDtos.cs`
+already models: `Match` (`:100-151`) with `id` (mapped from `_id`), `state`,
+`gamename`, `map`/`mapId`/`mapName`, `gameMode`, `gateway`, `season`, `host`,
+`startTime`, `endTime`, `floGameId`, `floNode`, `serverProvider`, `type`, and
+`players` as `List<PlayerMMrChange>`, which already inherits from
+`UnfinishedMatchPlayer` (`:24,44`). This is the "don't reinvent the wheel"
+resolution: the inheritance chain exists and models exactly this document.
+
+Three additions to those DTOs:
+
+- `slotIndex` on `UnfinishedMatchPlayer`, matching the upstream field.
+- `_created_at` and `_updated_at` on `Match`, which are `BaseEntity` fields
+  (`base-entity.ts:11-13`) not currently mapped.
+
+**New `AdminMatchesController`**, route prefix `api/admin/matches`. Every action
+carries `[BearerHasPermissionFilter(Permission = EPermission.Moderation)]` — the
+attribute is `AttributeTargets.Method`, so it cannot be applied at controller
+level and must be repeated per action.
+
+```
+GET api/admin/matches/canceled?gameMode=&battleTag=&page=&itemsPerPage=
+    -> { total, matches }
+```
+
+The `api/admin` prefix already sub-layers into `api/admin/permissions`,
+`api/admin/logs`, `api/admin/storage` and `api/admin/api-tokens` (only
+`AdminController` itself sits at the bare `api/admin`), so grouping under
+`api/admin/matches` leaves room for further match-related admin endpoints.
+
+Pass paging through to matchmaking rather than re-paging locally, and surface
+`total` unchanged so the frontend can drive a pager.
 
 Do **not** apply `PlayersObfuscator`. It exists for ongoing FFA matches and for
 MMR/rank-deviation masking on public endpoints; this is a Moderation-gated admin
 surface that needs real values.
 
-### 4. Replay and chat log reachability
+**This endpoint must not call the replay service.** See the cost constraint under
+FFA de-anonymization.
+
+### Timestamps
+
+`endTime` is never set on a cancellation and the C# `Match` DTO coerces the null
+to `0` (`MatchEventDtos.cs:124-136`), so it is unusable.
+
+Use the entity timestamps instead, which are real maintained fields rather than
+inferred values:
+
+- **`_created_at`** — when the match was formed by the queue. Exact.
+- **`_updated_at`** — set by `EntityRepo.save` immediately before the
+  `replaceOne` (`entity-repo.ts:64-66`), and `cancelMatch` goes through `save`.
+  For a document still in state `CANCELED` this **is** the cancellation time,
+  since nothing writes the document afterwards except a heal, which changes the
+  state and removes it from this listing.
+
+Expose `_updated_at` as `canceledAt`, and document that caveat on the field.
+Sort by it descending.
+
+An earlier draft proposed deriving a timestamp from the event `ObjectId`. That is
+rejected: ObjectIds should not be inspected for their embedded timestamp, and the
+value would have been "when the sweeper ran" — misleading by up to hours given a
+6-hour threshold polled every 5 minutes.
+
+### 3. Replay and chat log reachability
 
 Both the replay download and the chat log bottom out in the **same single
 identifier — the flo game id (int)**. There is no second id to be missing:
 `ReplaysController` `{gameId}` and `{gameId}/chats` both call
 `MatchRepository.GetFloIdFromId` and pass the resulting int to
-`ReplayServiceClient`, whose two methods format that int into
-`/generate/{id}` and `/chats/{id}`.
+`ReplayServiceClient`, whose two methods format that int into `/generate/{id}`
+and `/chats/{id}`.
 
-`GetFloIdFromId` reads the **`Matchup` collection only** (`MatchRepository.cs:275-280`).
-A cancelled match has no `Matchup` row, so the `{gameId}` routes cannot ever
-serve one. Worse, `new ObjectId($"{gameId}")` at `:277` is unguarded, so passing
-the matchmaking nanoid yields a 500 rather than a clean 404.
+`GetFloIdFromId` reads the **`Matchup` collection only**
+(`MatchRepository.cs:275-280`). A cancelled match has no `Matchup` row, so the
+`{gameId}` routes can never serve one. Worse, `new ObjectId($"{gameId}")` at
+`:277` is unguarded, so passing the matchmaking nanoid yields a 500 rather than a
+clean 404.
 
-**Therefore: no new replay or chat endpoints. The list payload exposes
-`floGameId`, and the frontend uses the existing `by-flo-id` routes**, which do no
-DB lookup at all and only reject `0`.
+**Therefore: no new replay or chat endpoints.** The list payload exposes
+`floGameId`, and the frontend uses the existing `by-flo-id` routes, which do no DB
+lookup and only reject `0`.
 
-`FloGameId` is nullable and sometimes genuinely absent: it is assigned only after
-flo's `createGame` returns (`flo-game-creation.flow.ts:172-174`) and persisted
-only in `startMatch` (`match-maker.ts:149-152`). The 2-minute `INIT` sweep
-cancels matches that never got a flo game — `LagReportMatchCanceledHandler.cs:21-24`
-already early-returns on this. **For those matches no replay and no chat log can
-ever exist**; the UI must render the buttons as unavailable rather than failing.
+`floGameId` is nullable and sometimes genuinely absent: it is assigned only after
+flo's `createGame` returns (`flo-game-creation.flow.ts:172-174`). Matches cancelled
+before that — the 2-minute `INIT` sweep, and early creation failures — have none,
+and **can never have a replay or chat log**. The UI must render those buttons as
+unavailable rather than failing. Note that creation failures which got as far as
+flo *do* have a `floGameId`, because it is assigned to the match object as soon as
+`createGame` returns, specifically so the error path can cancel the flo game.
 
-Three supporting changes:
-
-#### 4a. Raise the hourly replay rate limit for authenticated moderators
+#### 3a. Raise the hourly replay rate limit for authenticated moderators
 
 Cancelled matches always land in the **strict** bucket, because
 `ReplayRateLimitAttribute.CheckMatchAge` resolves age via
 `LoadFinishedMatchDetailsBy*`, which returns null for a cancelled match →
-`isRecent == null` → strict (10/hour, 50/day). Ten downloads an hour is thin for
-a moderator working through a list.
+`isRecent == null` → strict (10/hour, 50/day). Ten downloads an hour is thin for a
+moderator working through a list.
 
 Change `ReplayRateLimitAttribute`:
 
 - Add `ModeratorHourlyLimit { get; set; } = 50`.
 - After `rateLimitService.DetermineRateLimitContext(...)` returns, if the request
   carries a valid bearer token whose permissions include `EPermission.Moderation`
-  **and** `!ctx.HasValidApiToken`, then set `ctx.HourlyLimit = ModeratorHourlyLimit`,
+  **and** `!ctx.HasValidApiToken`, set `ctx.HourlyLimit = ModeratorHourlyLimit`,
   `ctx.PolicyName = "replay-moderator"`, and
   `ctx.PartitionKey = $"moderator:{battleTag}:{Scope}"`.
-- **Leave `DailyLimit` untouched** — it stays at whatever strict/relaxed
-  resolved (50 strict, 100 relaxed).
+- **Leave `DailyLimit` untouched** — it stays at whatever strict/relaxed resolved
+  (50 strict, 100 relaxed).
 
 Resolve the auth service from DI: `IW3CAuthenticationService` is registered at
 `Program.cs:178` as an intercepted transient, so use
@@ -399,14 +398,13 @@ Partitioning by battleTag rather than IP is deliberate: it keeps one moderator
 from consuming another's budget behind a shared IP, and matches the existing key
 conventions (`ip:{ip}:{scope}`, `token:{id}:{scope}`).
 
-Note that with hourly at 50 and strict daily at 50, the daily cap becomes the
-binding constraint — a moderator can spend the whole day's allowance in one hour.
-That is the intended trade-off: bursty review sessions are the actual usage
-pattern, and the daily ceiling still holds.
+With hourly at 50 and strict daily at 50, the daily cap becomes the binding
+constraint — a moderator can spend the whole day's allowance in one hour. That is
+the intended trade-off: bursty review sessions are the actual usage pattern, and
+the daily ceiling still holds. Unauthenticated and non-moderator behaviour is
+unchanged.
 
-Unauthenticated and non-moderator behaviour is unchanged.
-
-#### 4b. Handle unavailable replays and chat logs properly
+#### 3b. Handle unavailable replays and chat logs properly
 
 Both directions are currently wrong, and both must be fixed — a replay being
 unavailable is a normal, expected outcome, not an error. It may never have been
@@ -418,30 +416,27 @@ recorded, or it may have aged into DeepArchive.
   a clean 404.
 - **`GenerateReplay`** (`:18-25`) has the opposite problem: `GetStreamAsync`
   applies `EnsureSuccessStatusCode` internally, so an upstream 404 becomes an
-  unhandled exception → HTTP 500. Must map upstream 404 (and the
-  archived/unavailable case) to a 404 the client can render as "replay
-  unavailable" rather than a generic failure.
+  unhandled exception → HTTP 500. Must map upstream 404 and the
+  archived/unavailable case to a 404 the client can render as "replay
+  unavailable".
 
 The frontend already distinguishes 404 from other failures
 (`DownloadReplayIcon.vue` has separate `notFound` and `unavailable` strings), so
 correct status codes are immediately usable.
 
-#### 4c. Never return `playerScores: []`
+#### 3c. Never return `playerScores: []`
 
 If any payload feeding `MatchDetail.vue` carries `playerScores: []` instead of
 `null`, the page silently flips into "complete game" mode: `isCompleteGame`
 (`MatchDetail.vue:303`) is typed `PlayerScore[]`, not boolean, and an empty array
 is truthy. That suppresses the `incompletedata` message, renders an all-zeros
 score screen, and unlocks the unguarded FFA dereferences at `:335` and `:487-499`.
-`null` is the correct value and is what the existing code already produces.
+`null` is correct and is what the existing code already produces.
 
 ## FFA de-anonymization
 
-The requirement is to reconcile who is who in modes that hide names in-game.
-**No new mapping table is needed.** Real battletags are already available for the
-list, and the chat log already resolves `Player N` → real name. One small upstream
-change is recommended so the list can show slot numbers without paying for a
-replay-service call per row.
+The requirement is to reconcile who is who in modes that hide names in-game. No
+new mapping table is needed.
 
 ### Where "Player N" comes from
 
@@ -454,98 +449,57 @@ Not this backend. Flo masks names as exactly `format!("Player {}", i + 1)` where
 `GM_SC_FFA_4`, `GM_SC_OZ` and `GM_FOOTMEN_FRENZY`.
 
 The backend's own FFA obfuscation is a separate mechanism that produces `"*"`,
-not `Player N`, applies at API-response time only, and only to **ongoing**
-matches (`PlayersObfuscator.cs:18-19`, called from `MatchesController.cs:190,206`).
+not `Player N`, applies at API-response time only, and only to **ongoing** matches
+(`PlayersObfuscator.cs:18-19`, called from `MatchesController.cs:190,206`).
 
 ### Both identity sources are already unmasked
 
-1. **`MatchCanceledEvent.match.players[].battleTag` is real.** Matchmaking pushes
-   the live `Match` object verbatim into the stats DB; it anonymizes nothing in
-   its event payloads. So the new read model captures real battletags directly,
-   and the list shows real names with no extra work.
+1. **`Match.players[].battleTag` is real.** Matchmaking stores the live match
+   object; it anonymizes nothing in its own collection. The proxied list therefore
+   carries real battletags with no extra work.
 
 2. **The chat log already resolves slot → real name.** replay-service's chats
    handler calls flo's gRPC `get_game`, and `Game::pack()`
    (`controller/src/game/types.rs:45-68`) packs `slots` verbatim **without
    masking** — masking lives only in the observer-edge, client and player-sender
    paths. The handler then builds `PlayerInfo { id: idx + 1, name: player.name }`
-   over the same slot enumeration (`w3c-replay/binaries/replay-service/src/handlers/chats.rs:139-151`).
+   over the same slot enumeration
+   (`w3c-replay/binaries/replay-service/src/handlers/chats.rs:139-151`).
 
-   Because both use `slots.iter().enumerate()`, **`chatLog.players[].id` is
-   exactly the N in "Player N"**, and `.name` is the real name. "Player 3 was
-   toxic" resolves by looking up `players[].id == 3`.
+   Because both use `slots.iter().enumerate()`, **`chatLog.players[].id` is exactly
+   the N in "Player N"**, and `.name` is the real name.
 
    The frontend already implements this join:
    `AdminReplayChatLogMessages.vue:157-167` does
    `log.value.players.find(x => x.id == playerId)?.name` on `message.fromPlayer`.
 
-So the chat log, once reachable by flo game id, resolves `Player N` → battletag.
-
 ### Requirement: show both the battletag and the slot number
 
 Moderators need to map a report ("Player 3 was toxic") onto a battletag, so the UI
-must present **both identifiers together**, not just real names. Where the slot
-number is known, render it beside the battletag (e.g. `Player 3 — <battletag>`) in
-both the list row and the chat log view.
+must present **both identifiers together**. With `slotIndex` now persisted, render
+`Player {slotIndex + 1} — {battleTag}` in the list row and in the chat log view.
 
 ### Constraint: never call the replay service in the list path
 
 Replay-service calls incur real cost, so they must be strictly on-demand:
 
-- The list endpoint does a Mongo read only. No replay or chat call, ever — not to
-  enrich names, not to check replay availability, not to resolve slots.
+- The list endpoint proxies matchmaking only. No replay or chat call, ever — not
+  to enrich names, not to check replay availability, not to resolve slots.
 - Chat logs are fetched only when a moderator explicitly opens one for a single
   match. No prefetching, no fetch-on-hover, no batch resolution across the page.
-- Availability is inferred from `FloGameId` being non-null, which is free. Do not
+- Availability is inferred from `floGameId` being non-null, which is free. Do not
   probe the replay service to find out whether a replay exists.
 
-This constraint is what makes the upstream change below worth doing: without a
-persisted slot map, the *only* source of slot numbers is the chat log — which
-would mean a paid call per row to populate the list.
-
-### Recommended upstream change: persist the slot index
-
-Verified as a genuinely small change. `setPlayersToSlots`
-(`player-slots.helper.ts:14-29`) already computes exactly the needed mapping — it
-walks `allPlayers`, obtains each player's slot via
-`getNextAvailableSlot(slots, team, map)`, and assigns
-`slot.player_id = x.playerInstance.floPlayer.id`. At that moment the slot array
-index, the flo player id and `x.matchPlayer` (the persisted player object) are all
-in hand. The same flow already builds a `playerBattleTagsByFloPlayerId` map for
-custom-game colours (`flo-game-creation.flow.ts:137-144`), so the concept exists.
-
-The change is to write the slot index onto the match player so it rides along on
-every event:
-
-1. In `setPlayersToSlots`, set `x.matchPlayer.slotIndex = slots.indexOf(slot)`.
-2. Add `slotIndex?: number` to `IMatchPlayer` (`match.ts`).
-3. Add the matching property to the C# `UnfinishedMatchPlayer` DTO
-   (`MatchEventDtos.cs:44`), which `PlayerMMrChange` already inherits from.
-
-`CanceledMatch` then carries `SlotIndex` per player, and the list can render
-`Player N` alongside the battletag with **no replay-service call at all**.
-
-Caveat: this only helps matches that reached flo game creation. For `INIT` timeout
-cancels, `createGame` never ran, so there are no slots — but those matches also
-have no replay and no chat log, so there is nothing to reconcile against.
-
-Note the numbering: flo's mask is `slot_index + 1` and replay-service's
-`PlayerInfo.id` is likewise `idx + 1`, so if `slotIndex` is stored 0-based it must
-be displayed as `slotIndex + 1` to match what players saw in-game. Pick one
-convention and document it on the field.
-
-Without this change, v1 still works — the participant set with real battletags is
-always available from the list, and the slot mapping appears when a moderator opens
-the chat log — but the list itself cannot show slot numbers.
+Persisting `slotIndex` upstream is what makes this satisfiable: without it, the
+only source of slot numbers would be the chat log, meaning a paid call per row.
 
 ### PII
 
 Per decision, the Moderation permission gate is the only control — no audit
 logging in v1. Worth stating plainly in the PR: this page shows real battletags
-for game modes that deliberately hide names in-game, so the Moderation gate is
-the sole thing standing between an admin without Moderation and that data.
-Enforce it server-side on every action; a client-side flag would be
-insufficient.
+for game modes that deliberately hide names in-game, so the Moderation gate is the
+sole thing standing between an admin without Moderation and that data. Enforce it
+server-side on every action; a client-side flag would be insufficient.
 
 ## Frontend design
 
@@ -555,8 +509,8 @@ standalone row component), and its pagination is hard-bound to
 `playerStore`/`matchStore` through an `isPlayerProfile` boolean, so a third
 consumer cannot drive it without surgery. Its `unfinished` flag is also
 overloaded — it hides the replay column, disables detail navigation, replaces the
-duration with "onGoing" and zeroes the duration bar. Keeping the new page
-separate leaves the player profile and public Matches page untouched.
+duration with "onGoing" and zeroes the duration bar. Keeping the new page separate
+leaves the player profile and public Matches page untouched.
 
 ### Files to create
 
@@ -567,13 +521,13 @@ separate leaves the player profile and public Matches page untouched.
 | `src/types/admin/CancelledMatch.ts` | DTOs mirroring the backend |
 | `src/services/admin/CancelledMatchService.test.ts` | vitest + `node:assert`, fake `fetch` injected via constructor |
 
-Follow the Jobs page as the template (`AdminJobs.vue`, `AdminJobService.ts`):
-lazy module-level service singleton (`_service ??= new Service({ endpoint: API_URL })`,
-because `@/config/env` reads `window` at module load), token from
-`useOauthStore()` passed per call, `HttpError` status mapped to UI meaning at the
-boundary, component-local refs rather than a Pinia store, and hardcoded English
-strings — recent admin pages use no `$t` at all, and `src/locales/data.ts` is
-autogenerated and overwritten by the build, so adding locale keys is awkward.
+Follow the Jobs page as the template (`AdminJobs.vue`, `AdminJobService.ts`): lazy
+module-level service singleton (`_service ??= new Service({ endpoint: API_URL })`,
+because `@/config/env` reads `window` at module load), token from `useOauthStore()`
+passed per call, `HttpError` status mapped to UI meaning at the boundary,
+component-local refs rather than a Pinia store, and hardcoded English strings —
+recent admin pages use no `$t` at all, and `src/locales/data.ts` is autogenerated
+and overwritten by the build.
 
 ### Files to touch
 
@@ -591,13 +545,13 @@ autogenerated and overwritten by the build, so adding locale keys is awkward.
 The by-flo-id chat fetch belongs on the **new `CancelledMatchService`** using
 `AuthorizedClient`, not beside `AdminService.getChatLog` (`:283`) — that method
 uses the deprecated `authorizedFetch`, and extending it would perpetuate the
-pattern the `AuthorizedClient` docstring explicitly steers new code away from.
-The store action can call the new service directly.
+pattern the `AuthorizedClient` docstring explicitly steers new code away from. The
+store action can call the new service directly.
 
 The nav child's `component` value **must equal the route's `path` segment** — the
 `/admin` landing redirect pushes `admin/${firstItem.component}`
-(`AdminNavigation.vue:129-138`). Add it as a child of the existing Moderation
-group rather than a new top-level group; a childless top-level entry breaks that
+(`AdminNavigation.vue:129-138`). Add it as a child of the existing Moderation group
+rather than a new top-level group; a childless top-level entry breaks that
 redirect.
 
 ### `noWinner` prop
@@ -612,28 +566,31 @@ spoiler logic, which is not wanted here.
 
 Everything else degrades safely already, verified by reading the components:
 
-- **MMR** — `PlayerMatchInfo.vue:150` guards `oldMmr != null`; `:157-163`
-  requires both `oldMmr` and `currentMmr`; the template gates on
-  `displayRating !== null` and `displayMmrChange !== 0`.
+- **MMR** — `PlayerMatchInfo.vue:150` guards `oldMmr != null`; `:157-163` requires
+  both `oldMmr` and `currentMmr`; the template gates on `displayRating !== null`
+  and `displayMmrChange !== 0`.
 - **League/rank** — `:154-155`, `:203` optional-chain `ranking?.leagueOrder`,
   falling back to `views_rankings.unranked`.
 - **Placement** — `TeamMatchInfo.vue:3,8` use `!isNil(...)` on `matchRanking`.
-- **Heroes** — `HeroIconRow` accepts `Hero[] | null` and `v-for` over null
-  renders nothing.
+- **Heroes** — `HeroIconRow` accepts `Hero[] | null` and `v-for` over null renders
+  nothing.
 - `mmrGain` from the backend is dead on the frontend — the delta is always
-  recomputed client-side. Another reason to omit it from the DTO.
+  recomputed client-side.
+
+Note that the proxied payload uses matchmaking's player shape
+(`PlayerMMrChange`/`UnfinishedMatchPlayer`), not the read-model
+`PlayerOverviewMatches` the grid components expect, so the page maps it to the
+props those components take. Since `won` is simply absent from the source, there is
+no falsy value to suppress.
 
 ### Slot number display
 
 For anonymizing modes, render the slot number next to the battletag so a report
-naming "Player 3" can be matched to an account — `Player 3 — <battletag>`. Source
-it from the per-player `SlotIndex` on the list payload (remember the `+ 1`
-convention). When `SlotIndex` is absent — either because the upstream change has
-not landed or because the match never reached flo game creation — show the
-battletag alone and let the chat log supply the mapping on demand.
+naming "Player 3" can be matched to an account — `Player 3 — <battletag>`, from
+`slotIndex + 1`. When `slotIndex` is absent — a match that never reached flo game
+creation — show the battletag alone; those matches have no chat log either.
 
-Do **not** fetch chat logs to populate slot numbers in the list. See the
-replay-service cost constraint under FFA de-anonymization.
+Do **not** fetch chat logs to populate slot numbers in the list.
 
 ### Replay and chat buttons
 
@@ -643,69 +600,73 @@ present, targets the `by-flo-id` route instead. It already handles 429 and 404
 distinctly, which is exactly what is needed here.
 
 Render both buttons as disabled with an explanatory tooltip when `floGameId` is
-null — those matches were cancelled before flo created the game and can never
-have a replay or chat log.
+null.
 
 ### Notes panel
 
-Per decision, the page carries a visible note explaining:
+The page carries a visible note explaining:
 
-- Drawn and stalled matches appear only after the 6-hour cleanup sweep.
-- Matches cancelled during game creation (flo errors, join bugs, leavers) are
-  **not** listed, because they emit no event today.
-- Tournament and custom matches are not listed.
+- Drawn and stalled matches are only marked cancelled after the 6-hour cleanup
+  sweep, so a just-drawn match will not appear immediately.
 - Replay and chat log are unavailable for matches cancelled before the flo game
   was created.
+- No cancellation reason is recorded, so the list cannot say *why* a match was
+  cancelled.
 
 ### In-page permission check
 
 There is **no router guard and no route `meta` anywhere** in this frontend — the
 whole `/admin` view is gated on `oauthStore.isAdmin` only, and any admin can
-deep-link to `/admin/<any-page>`. Client gating today is purely the sidebar
-filter. Add an in-page check following `AdminSmurfs.vue:220-221`:
+deep-link to `/admin/<any-page>`. Client gating today is purely the sidebar filter.
+Add an in-page check following `AdminSmurfs.vue:220-221`:
 
 ```ts
 const canModerate = computed(() =>
   oauthStore.permissions.includes(EPermission[EPermission.Moderation]));
 ```
 
-and render a refusal state instead of the table. The backend 403 is still the
-real enforcement; this stops the page rendering a broken shell.
+and render a refusal state instead of the table. The backend 403 is still the real
+enforcement; this stops the page rendering a broken shell.
 
 ## Testing
 
-**Backend.** The established pattern for match code is NUnit repository fixtures
-against a live Mongo via `IntegrationTestBase`, built with AutoFixture through
-`TestDtoHelper` (see `WC3ChampionsStatisticService.UnitTests/Matchups/`). There
-are **no** controller-level tests for `MatchesController` to copy; controller test
-patterns exist elsewhere (`AdminWarningsControllerTests.cs`) using hand-built
-controllers plus Moq.
+**matchmaking-service.** Cover the new repository query and route: `state`
+filtering, `gameMode` filter, `battleTag` filter, paging maths
+(`page * itemsPerPage - itemsPerPage`), `_updated_at` descending ordering, and
+`requireAdmin` rejection. Add a case asserting `slotIndex` is populated on every
+player after `setPlayersToSlots`, and that it equals the `CreateGameSlot[]` index.
+
+**website-backend.** The established pattern for match code is NUnit repository
+fixtures against a live Mongo via `IntegrationTestBase`, built with AutoFixture
+through `TestDtoHelper`. There are **no** controller-level tests for
+`MatchesController` to copy; controller test patterns exist elsewhere
+(`AdminWarningsControllerTests.cs`) using hand-built controllers plus Moq — that is
+the closer analogue here, since this controller is a proxy with no repository of
+its own.
 
 > **Caution:** `IntegrationTestBase` drops and recreates the real shared
 > `W3Champions-Statistic-Service` database on a remote Mongo host in `[SetUp]`.
 
 Cover:
 
-- Handler writes a `CanceledMatch` from a `MatchCanceledEvent`
-  (`TestDtoHelper` already has cancelled-event helpers).
-- Handler is idempotent — same match twice yields one row.
-- `FloGameId == null` is persisted without error.
-- Repository: gameMode filter, `Undefined` = all modes, battleTag filter, paging,
-  `StartTime` descending.
-- `CanceledMatchRemovalOnFinishHandler` deletes the row on a matching finish.
+- Controller returns 401 without Moderation, 200 with it.
+- Query parameters are forwarded to `MatchmakingServiceClient` unmodified and
+  `total` is surfaced unchanged.
+- Deserialization of the matchmaking response into the existing `Match` DTO,
+  including `slotIndex`, `_created_at`/`_updated_at`, and a null `floGameId`.
+- The endpoint issues **no** replay-service call — assert against a mock
+  `ReplayServiceClient` that it is never invoked.
 - `ReplayRateLimitAttribute`: moderator token → hourly 50, daily unchanged,
   battleTag partition key; non-moderator and API-token paths unchanged.
 - `GetChatLogs` maps an upstream non-success status to 404; `GenerateReplay` maps
   an upstream 404 to 404 rather than throwing.
-- `GameModesHelper.IsFfaGameMode(GameMode.GM_FOOTMEN_FRENZY)` is true, and the
-  existing FFA modes still are. `GM_LTW_FFA` is still false.
-- The list endpoint issues **no** replay-service call — assert against a mock
-  `ReplayServiceClient` that it is never invoked.
+- `GameModesHelper.IsFfaGameMode(GameMode.GM_FOOTMEN_FRENZY)` is true, the existing
+  FFA modes still are, and `GM_LTW_FFA` is still false.
 
 **Frontend.** vitest runs in `environment: "node"` with no vue plugin
-(`vitest.config.ts:13-19`), so **`.vue` files cannot be unit tested** without
-adding jsdom and `@vitejs/plugin-vue` first. Test the service layer only:
-assert URL, method, query params and status mapping with an injected fake fetch.
+(`vitest.config.ts:13-19`), so **`.vue` files cannot be unit tested** without adding
+jsdom and `@vitejs/plugin-vue` first. Test the service layer only: assert URL,
+method, query params and status mapping with an injected fake fetch.
 
 Quality gates: `npm run lint` (`--max-warnings=0`), `npm run dprint`,
 `npm run type-check`, `npm test`. Backend: `dotnet build`, `dotnet test`,
@@ -713,10 +674,10 @@ Quality gates: `npm run lint` (`--max-warnings=0`), `npm run dprint`,
 
 ## Deployment note
 
-Read-model handlers are gated on `START_HANDLERS` and the comparison is
-**case-sensitive exact equality** with `"true"` (`Program.cs:267`) — `"True"`,
-`"TRUE"` and `"1"` all silently disable every handler. The new handler will not
-backfill until that is set correctly in the target environment.
+This design adds no read-model handler, so it does not depend on `START_HANDLERS`
+and needs no backfill window. It does require the matchmaking-service change to be
+deployed before the website-backend endpoint returns anything, and the new Mongo
+index should be created before the endpoint is exercised at scale.
 
 Per `CLAUDE.md`: read model handling is off by default locally, and connecting to
 the wrong database can overwrite prod/test data.

--- a/docs/superpowers/specs/2026-08-05-cancelled-matches-admin-page-design.md
+++ b/docs/superpowers/specs/2026-08-05-cancelled-matches-admin-page-design.md
@@ -493,13 +493,19 @@ Replay-service calls incur real cost, so they must be strictly on-demand:
 Persisting `slotIndex` upstream is what makes this satisfiable: without it, the
 only source of slot numbers would be the chat log, meaning a paid call per row.
 
-### PII
+### Disclosure
+
+Battletags are public information, not PII, so exposing them carries no special
+handling burden — they can be logged and traced like any other field.
+
+What this page does that warrants a gate is *linking* flo's anonymised
+`Player N` back to an account, in modes that deliberately hide names in-game.
+The sensitivity is the linkage, not the identifier.
 
 Per decision, the Moderation permission gate is the only control — no audit
-logging in v1. Worth stating plainly in the PR: this page shows real battletags
-for game modes that deliberately hide names in-game, so the Moderation gate is the
-sole thing standing between an admin without Moderation and that data. Enforce it
-server-side on every action; a client-side flag would be insufficient.
+logging in v1. Enforce it server-side on every action; a client-side flag would
+be insufficient, since on the masked paths the real value must never be sent to
+an unauthorised client in the first place.
 
 ## Frontend design
 

--- a/dotnet-docker.sh
+++ b/dotnet-docker.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Runs the .NET 8 SDK in a container against this worktree.
+#
+# There is no dotnet on this host, so `dotnet build` / `dotnet test` are run
+# inside mcr.microsoft.com/dotnet/sdk:8.0 (the same image the Dockerfile uses).
+# NuGet packages and build output are cached on the host so repeat runs are fast.
+#
+# Usage:
+#   ./dotnet-docker.sh build
+#   ./dotnet-docker.sh test
+#   ./dotnet-docker.sh test --filter "FullyQualifiedName~GameModes"
+#   ./dotnet-docker.sh format --verify-no-changes
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NUGET_CACHE="${REPO_DIR}/.nuget-docker"
+mkdir -p "${NUGET_CACHE}"
+
+exec docker run --rm \
+  -v "${REPO_DIR}":/src \
+  -v "${NUGET_CACHE}":/nuget \
+  -w /src \
+  -e DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+  -e DOTNET_NOLOGO=1 \
+  -e NUGET_PACKAGES=/nuget \
+  -e HOME=/tmp \
+  -e DOTNET_CLI_HOME=/tmp \
+  -u "$(id -u):$(id -g)" \
+  mcr.microsoft.com/dotnet/sdk:8.0 \
+  dotnet "$@"


### PR DESCRIPTION
Backend half of the **Cancelled Matches** moderation page — matches that ended with no result, so no winner, no score, no MMR change.

The upstream endpoint and FLO slot index it consumes landed in w3champions/matchmaking-service#866, which is now **merged** — so this is no longer blocked. (It returns 502 if the matchmaking service is older than that.)

## Why a proxy and not a read model

The obvious design — a `CanceledMatch` read model fed by `MatchCanceledEvent` — is wrong here, because that stream is lossy. `pushMatchCanceled` has exactly one call site (the timeout sweeper); the game-creation-failure path calls `cancelMatch` and pushes nothing, and doesn't emit a `MatchStartedEvent` either. Those matches would simply be missing.

Matchmaking's `Match` collection records every cancellation, so this proxies it. That also drops the backfill, the `HandlerVersions` cursor, the `START_HANDLERS` dependency, and a heal-removal handler — a healed match changes state and leaves the result set on its own.

## What's here

- **`GET api/admin/matches/canceled`** (`AdminMatchesController`), gated on `EPermission.Moderation`, proxying matchmaking via `MatchmakingServiceClient`.
- **Reuses the existing `Match` / `PlayerMMrChange` / `UnfinishedMatchPlayer` DTOs** rather than adding parallel ones. They already model this document; they only needed JSON mapping, since they were BSON-annotated and `MatchmakingServiceClient` deserialises with Newtonsoft — **without `[JsonProperty("_id")]` the match id silently came back null.** Verified safe: those DTOs are not returned by any controller (`MatchesController`'s `Ok(match)` returns `MatchupDetail`, which holds a `Matchup`).
- **Replay and chat logs now 404 properly when unavailable.** Previously `GetChatLogs` swallowed the status and returned 200-with-null, while `GenerateReplay` threw and became a 500. Both now return `null` for 404/410 only — any other upstream status logs and fails loudly, so a replay-service **outage stays distinguishable from a replay that was never recorded or has aged into DeepArchive**.
- **Moderators get 50 replay downloads/hour instead of 10**, partitioned per battletag rather than per IP. Cancelled matches always resolve to the strict bucket, because `CheckMatchAge` returns null for them. The daily number is unchanged, and `Math.Max` means the override can only ever raise a limit.
- **`GM_FOOTMEN_FRENZY` is now treated as an FFA mode.** ⚠️ This is a live behaviour change beyond the feature: its matchmaking definition sets `isAnonymous = true`, so flo masks names in game, but the backend was not treating it as FFA — ongoing Footmen Frenzy matches were exposing real battletags through `/api/matches/ongoing` and were lookupable by player. Anon-FFA Footmen Frenzy is returning, so this needs to be right. It reaches three pre-existing call sites (`MatchesController.cs:201`, `PlayersObfuscator.cs:12`, `Matchup.cs:160`), all anonymisation behaviours.

## Two bugs worth calling out, both caught in review

**The search parameter cannot be named `battleTag`.** `BearerHasPermissionFilter.cs:33` does `context.ActionArguments["battleTag"] = res.BattleTag;` unconditionally, so on any action it guards, a parameter with that name is silently replaced by the *acting moderator's* tag — the endpoint would have quietly returned only the moderator's own matches. It is `playerBattleTag`, with a regression test that fails if the name comes back. Unit tests could not have caught this: they invoke the controller directly and bypass the filter pipeline.

**The moderator rate limit was initially unreachable** from the page it exists for — the download button sent no `Authorization` header, so every request landed in the anonymous IP partition. Fixed in the companion frontend PR; noted here because the two halves have to agree.

## Testing

`dotnet build` clean, 45/45 passing across every test class this touches.

There is no dotnet SDK on this dev host, so `dotnet-docker.sh` is included — it runs the same SDK image the Dockerfile uses. It carries a warning worth repeating: **never run an unfiltered `dotnet test`**, because `IntegrationTestBase` drops and recreates the real shared `W3Champions-Statistic-Service` database on a remote host in `[SetUp]`.

Consequently the Mongo-backed handler tests could not run here. BSON back-compatibility of the DTO changes was verified with a targeted `BsonSerializer.Deserialize<Match>` test (fields present as dates, and absent) rather than the integration suite — worth confirming in CI.

The design spec and implementation plan are included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

