### PR TITLE
feat(lag-reports): capture flo per-player leave reasons

### DIFF
--- a/W3ChampionsStatisticService/LagReports/FloGameLeaveReport.cs
+++ b/W3ChampionsStatisticService/LagReports/FloGameLeaveReport.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+using W3C.Domain.Repositories;
+
+namespace W3ChampionsStatisticService.LagReports;
+
+/// <summary>
+/// Per-player leave reasons for one flo game, read from the flo-stats GraphQL
+/// snapshot.
+///
+/// Deliberately a separate collection from <see cref="LagReport"/>: a LagReport
+/// document only exists when a player actually submitted a report, which is
+/// exactly the population that cancelled and abandoned games do NOT belong to.
+/// Extending LagReport would therefore capture nothing on the games this is for.
+/// </summary>
+[BsonIgnoreExtraElements]
+public class FloGameLeaveReport : IIdentifiable
+{
+    [BsonId]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>Flo game id, from flo-controller. Unique key for this collection.</summary>
+    public int FloGameId { get; set; }
+
+    /// <summary>Which handler captured this. Diagnostic - tells you which paths actually yield data.</summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public EFloLeaveCaptureTrigger Trigger { get; set; }
+
+    /// <summary>
+    /// False when flo-stats had no snapshot for the game - evicted from its
+    /// in-memory LRU, or the fetch failed.
+    ///
+    /// This is the field that keeps the data honest. Without it, "flo saw the game
+    /// and recorded no leave for this player" is indistinguishable from "we never
+    /// saw the game at all", and those support opposite conclusions.
+    /// </summary>
+    public bool SnapshotAvailable { get; set; }
+
+    public List<FloPlayerLeave> Players { get; set; } = [];
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>One player's leave record within a <see cref="FloGameLeaveReport"/>.</summary>
+public class FloPlayerLeave
+{
+    /// <summary>Flo player id. Matches <see cref="ServerSidePingData.PlayerId"/>.</summary>
+    public int PlayerId { get; set; }
+
+    /// <summary>Battletag, or "Player N" when flo masked names for the game.</summary>
+    public string PlayerName { get; set; }
+
+    /// <summary>
+    /// Null both when flo recorded no leave for this slot AND when flo sent a
+    /// variant this backend does not know about. Use <see cref="LeaveReasonRaw"/> to
+    /// tell those apart: a null raw means no record, a non-null raw means an
+    /// unmapped new variant.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public EFloLeaveReason? LeaveReason { get; set; }
+
+    /// <summary>Exact wire string from flo, e.g. "LEAVE_DISCONNECT". Null when absent.</summary>
+    public string LeaveReasonRaw { get; set; }
+
+    /// <summary>
+    /// Milliseconds since game start, on flo's action clock - the same clock as
+    /// <see cref="LagEvent.GameTimeOffsetMs"/>, so the two are directly comparable.
+    /// Null when there is no leave record.
+    /// </summary>
+    public long? LeftAtMs { get; set; }
+}

--- a/W3ChampionsStatisticService/LagReports/FloGameLeaveRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/FloGameLeaveRepository.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using W3C.Domain.Repositories;
+using W3C.Domain.Tracing;
+
+namespace W3ChampionsStatisticService.LagReports;
+
+[Trace]
+public class FloGameLeaveRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IRequiresIndexes
+{
+    public string CollectionName => "FloGameLeaveReport";
+
+    public async Task EnsureIndexesAsync()
+    {
+        var collection = CreateCollection<FloGameLeaveReport>();
+
+        var indexes = new List<CreateIndexModel<FloGameLeaveReport>>
+        {
+            // Upsert key — one document per flo game
+            new(Builders<FloGameLeaveReport>.IndexKeys.Ascending(r => r.FloGameId),
+                new CreateIndexOptions { Unique = true }),
+
+            // Default sort + date range filter
+            new(Builders<FloGameLeaveReport>.IndexKeys.Descending(r => r.CreatedAt)),
+
+            // TTL: mirrors the LagReport retention window
+            new(Builders<FloGameLeaveReport>.IndexKeys.Ascending(r => r.UpdatedAt),
+                new CreateIndexOptions { ExpireAfter = TimeSpan.FromDays(90) }),
+        };
+
+        await collection.Indexes.CreateManyAsync(indexes);
+    }
+
+    public async Task<FloGameLeaveReport> GetByFloGameId(int floGameId)
+    {
+        return await LoadFirst<FloGameLeaveReport>(r => r.FloGameId == floGameId);
+    }
+
+    /// <summary>
+    /// Record leave data for a game.
+    ///
+    /// A snapshot-bearing write never gets downgraded by a later snapshot-less one:
+    /// the three triggers fire at very different times and only the earliest is
+    /// likely to catch the game before flo evicts it, so a later empty result is
+    /// almost always "too late", not "nothing happened".
+    /// </summary>
+    public async Task Upsert(int floGameId, EFloLeaveCaptureTrigger trigger, bool snapshotAvailable, List<FloPlayerLeave> players)
+    {
+        var collection = CreateCollection<FloGameLeaveReport>();
+        var filter = Builders<FloGameLeaveReport>.Filter.Eq(r => r.FloGameId, floGameId);
+
+        var existing = await collection.Find(filter).FirstOrDefaultAsync();
+        if (existing != null && existing.SnapshotAvailable && !snapshotAvailable)
+        {
+            return;
+        }
+
+        var update = Builders<FloGameLeaveReport>.Update
+            .Set(r => r.Trigger, trigger)
+            .Set(r => r.SnapshotAvailable, snapshotAvailable)
+            .Set(r => r.Players, players ?? [])
+            .Set(r => r.UpdatedAt, DateTime.UtcNow)
+            .SetOnInsert(r => r.FloGameId, floGameId)
+            .SetOnInsert(r => r.CreatedAt, DateTime.UtcNow);
+
+        await collection.UpdateOneAsync(filter, update, new UpdateOptions { IsUpsert = true });
+    }
+}

--- a/W3ChampionsStatisticService/LagReports/FloStatsService.cs
+++ b/W3ChampionsStatisticService/LagReports/FloStatsService.cs
@@ -21,8 +21,20 @@ namespace W3ChampionsStatisticService.LagReports;
 /// </summary>
 public interface IFloStatsService
 {
-    Task<List<ServerSidePingData>> FetchGamePingData(int floGameId);
-    Task FetchAndStoreIfNeeded(int floGameId, LagReportRepository repo);
+    Task<FloGameSnapshotResult> FetchGameSnapshot(int floGameId);
+    Task FetchAndStoreIfNeeded(int floGameId, LagReportRepository repo, FloGameLeaveRepository leaveRepo, EFloLeaveCaptureTrigger trigger);
+}
+
+/// <summary>
+/// One flo-stats snapshot read. <see cref="Available"/> is false when the game was
+/// not in flo's LRU or the fetch failed; both payload lists are then empty. The
+/// distinction matters downstream - see FloGameLeaveReport.SnapshotAvailable.
+/// </summary>
+public class FloGameSnapshotResult
+{
+    public bool Available { get; set; }
+    public List<ServerSidePingData> Ping { get; set; } = [];
+    public List<FloPlayerLeave> PlayerLeaves { get; set; } = [];
 }
 
 [Trace]
@@ -34,14 +46,16 @@ public class FloStatsService : IFloStatsService
 
     // Coalesce concurrent fetches for the same game — avoids duplicate WebSocket connections.
     // Entries are removed on completion, so size is bounded by concurrent game endings.
-    private static readonly System.Collections.Concurrent.ConcurrentDictionary<int, Task<List<ServerSidePingData>>>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<int, Task<FloGameSnapshotResult>>
         _inflightFetches = new();
 
     /// <summary>
-    /// Fetch accumulated ping data for a game from flo-stats via WebSocket subscription.
-    /// Returns null if the game is not found (evicted from LRU) or on any error.
+    /// Fetch the accumulated snapshot for a game from flo-stats via WebSocket
+    /// subscription. Returns a result with Available = false if the game is not found
+    /// (evicted from flo's LRU) or on any error - never null, so callers can record
+    /// "we asked and got nothing" as a fact rather than losing it.
     /// </summary>
-    public async Task<List<ServerSidePingData>> FetchGamePingData(int floGameId)
+    public async Task<FloGameSnapshotResult> FetchGameSnapshot(int floGameId)
     {
         try
         {
@@ -59,7 +73,7 @@ public class FloStatsService : IFloStatsService
             if (ack?.GetProperty("type").GetString() != "connection_ack")
             {
                 Log.Warning("FloStatsService: expected connection_ack, got {Type}", ack?.GetProperty("type").GetString());
-                return null;
+                return new FloGameSnapshotResult();
             }
 
             // 3. Subscribe to GameUpdateSub
@@ -74,7 +88,7 @@ public class FloStatsService : IFloStatsService
                             __typename
                             ... on GameSnapshotWithStats {
                                 stats { ping { time data { playerId min max avg } } }
-                                game { players { id name } }
+                                game { players { id name leftAt leaveReason } }
                             }
                         }
                     }",
@@ -90,13 +104,13 @@ public class FloStatsService : IFloStatsService
             if (msgType == "error" || msgType == "complete")
             {
                 Log.Information("FloStatsService: game {GameId} not found in flo-stats (type={Type})", floGameId, msgType);
-                return null;
+                return new FloGameSnapshotResult();
             }
 
             if (msgType != "next")
             {
                 Log.Warning("FloStatsService: unexpected message type {Type} for game {GameId}", msgType, floGameId);
-                return null;
+                return new FloGameSnapshotResult();
             }
 
             // 5. Parse the snapshot
@@ -106,63 +120,75 @@ public class FloStatsService : IFloStatsService
             if (typeName != "GameSnapshotWithStats")
             {
                 Log.Information("FloStatsService: first event for game {GameId} was {Type}, not snapshot", floGameId, typeName);
-                return null;
+                return new FloGameSnapshotResult();
             }
 
-            return ParsePingData(payload);
+            return new FloGameSnapshotResult
+            {
+                Available = true,
+                Ping = ParsePingData(payload),
+                PlayerLeaves = ParsePlayerLeaves(payload),
+            };
         }
         catch (OperationCanceledException)
         {
             Log.Warning("FloStatsService: timeout fetching ping data for game {GameId}", floGameId);
-            return null;
+            return new FloGameSnapshotResult();
         }
         catch (WebSocketException ex)
         {
             Log.Warning(ex, "FloStatsService: WebSocket error for game {GameId}", floGameId);
-            return null;
+            return new FloGameSnapshotResult();
         }
         catch (Exception ex)
         {
             Log.Warning(ex, "FloStatsService: failed to fetch ping data for game {GameId}", floGameId);
-            return null;
+            return new FloGameSnapshotResult();
         }
     }
 
     /// <summary>
-    /// Fetch ping data and store it on the lag report if not already populated.
-    /// Concurrent calls for the same game share a single WebSocket fetch and a single write.
+    /// Fetch the flo-stats snapshot once and store both halves: ping data onto the lag
+    /// report (only when one exists and is unpopulated), and leave reasons into
+    /// FloGameLeaveReport.
+    ///
+    /// The leave half is written UNCONDITIONALLY. The old ping-only logic bailed when
+    /// no lag report existed, which is precisely the case for a cancelled or abandoned
+    /// game - so the games most worth explaining were the ones guaranteed to record
+    /// nothing. Concurrent callers for the same game share one WebSocket fetch.
     /// </summary>
-    public async Task FetchAndStoreIfNeeded(int floGameId, LagReportRepository repo)
+    public async Task FetchAndStoreIfNeeded(int floGameId, LagReportRepository repo, FloGameLeaveRepository leaveRepo, EFloLeaveCaptureTrigger trigger)
     {
         var report = await repo.GetByFloGameId(floGameId);
-        if (report == null || report.ServerSidePing != null)
+        var existingLeaves = await leaveRepo.GetByFloGameId(floGameId);
+
+        var needsPing = report != null && report.ServerSidePing == null;
+        var needsLeaves = existingLeaves == null || !existingLeaves.SnapshotAvailable;
+        if (!needsPing && !needsLeaves)
         {
             return;
         }
 
-        // Coalesce: all concurrent callers for the same game share one fetch+store task
-        var task = _inflightFetches.GetOrAdd(floGameId, id => FetchAndStore(id, repo));
+        // Coalesce: all concurrent callers for the same game share one fetch
+        var task = _inflightFetches.GetOrAdd(floGameId, FetchGameSnapshot);
+        FloGameSnapshotResult snapshot;
         try
         {
-            await task;
+            snapshot = await task;
         }
         finally
         {
             _inflightFetches.TryRemove(floGameId, out _);
         }
-    }
 
-    private async Task<List<ServerSidePingData>> FetchAndStore(int floGameId, LagReportRepository repo)
-    {
-        var pingData = await FetchGamePingData(floGameId);
+        await leaveRepo.Upsert(floGameId, trigger, snapshot.Available, snapshot.PlayerLeaves);
 
-        var report = await repo.GetByFloGameId(floGameId);
+        // Re-read: another caller may have populated the ping data while we were fetching.
+        report = await repo.GetByFloGameId(floGameId);
         if (report != null && report.ServerSidePing == null)
         {
-            await repo.UpdateServerSidePing(report.Id, pingData ?? []);
+            await repo.UpdateServerSidePing(report.Id, snapshot.Ping);
         }
-
-        return pingData;
     }
 
     internal static List<ServerSidePingData> ParsePingData(JsonElement payload)
@@ -230,6 +256,74 @@ public class FloStatsService : IFloStatsService
         value.TryGetDouble(out var number)
             ? (int)Math.Round(number)
             : null;
+
+    /// <summary>
+    /// Reads per-player leave reasons out of the snapshot's game.players array.
+    ///
+    /// Emits EVERY player, including those with no leave record: a null reason for a
+    /// player who was in the game is itself the signal, since flo records no PlayerLeft
+    /// at all when a started game's stream simply closes.
+    /// </summary>
+    internal static List<FloPlayerLeave> ParsePlayerLeaves(JsonElement payload)
+    {
+        var leaves = new List<FloPlayerLeave>();
+
+        if (!payload.TryGetProperty("game", out var game) ||
+            !game.TryGetProperty("players", out var players) ||
+            players.ValueKind != JsonValueKind.Array)
+        {
+            return leaves;
+        }
+
+        foreach (var p in players.EnumerateArray())
+        {
+            if (!p.TryGetProperty("id", out var idElement) ||
+                idElement.ValueKind != JsonValueKind.Number ||
+                !idElement.TryGetInt32(out var playerId))
+            {
+                continue;
+            }
+
+            var raw = p.TryGetProperty("leaveReason", out var reason) && reason.ValueKind == JsonValueKind.String
+                ? reason.GetString()
+                : null;
+
+            leaves.Add(new FloPlayerLeave
+            {
+                PlayerId = playerId,
+                PlayerName = p.TryGetProperty("name", out var name) && name.ValueKind == JsonValueKind.String
+                    ? name.GetString()
+                    : null,
+                LeaveReasonRaw = raw,
+                LeaveReason = MapLeaveReason(raw),
+                LeftAtMs = p.TryGetProperty("leftAt", out var leftAt) &&
+                           leftAt.ValueKind == JsonValueKind.Number &&
+                           leftAt.TryGetInt64(out var ms)
+                    ? ms
+                    : null,
+            });
+        }
+
+        return leaves;
+    }
+
+    /// <summary>
+    /// Maps flo's SCREAMING_SNAKE_CASE PlayerLeaveReason wire strings. Returns null both
+    /// for an absent reason and for a variant added to flo after this switch was written;
+    /// FloPlayerLeave.LeaveReasonRaw preserves the original either way, so an unmapped
+    /// variant is visible in the data instead of silently becoming "no record".
+    /// </summary>
+    internal static EFloLeaveReason? MapLeaveReason(string wire) => wire switch
+    {
+        "LEAVE_DISCONNECT" => EFloLeaveReason.LeaveDisconnect,
+        "LEAVE_LOST" => EFloLeaveReason.LeaveLost,
+        "LEAVE_LOST_BUILDINGS" => EFloLeaveReason.LeaveLostBuildings,
+        "LEAVE_WON" => EFloLeaveReason.LeaveWon,
+        "LEAVE_DRAW" => EFloLeaveReason.LeaveDraw,
+        "LEAVE_OBSERVER" => EFloLeaveReason.LeaveObserver,
+        "LEAVE_UNKNOWN" => EFloLeaveReason.LeaveUnknown,
+        _ => null,
+    };
 
     private static async Task SendJson<T>(ClientWebSocket ws, T obj, CancellationToken ct)
     {

--- a/W3ChampionsStatisticService/LagReports/LagReportController.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportController.cs
@@ -12,9 +12,13 @@ namespace W3ChampionsStatisticService.LagReports;
 [ApiController]
 [Route("api/lag-reports")]
 [Trace]
-public class LagReportController(LagReportRepository lagReportRepository, IFloStatsService floStatsService) : ControllerBase
+public class LagReportController(
+    LagReportRepository lagReportRepository,
+    FloGameLeaveRepository floGameLeaveRepository,
+    IFloStatsService floStatsService) : ControllerBase
 {
     private readonly LagReportRepository _lagReportRepository = lagReportRepository;
+    private readonly FloGameLeaveRepository _floGameLeaveRepository = floGameLeaveRepository;
     private readonly IFloStatsService _floStatsService = floStatsService;
 
     // ── Submission validation caps ────────────────────────────────────
@@ -70,7 +74,8 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
 
         // Fire-and-forget: fetch server-side ping from flo-stats while data is still in LRU.
         // The match-finished handler is a fallback, but often runs before any player submits.
-        _ = _floStatsService.FetchAndStoreIfNeeded(dto.GameMetadata.FloGameId, _lagReportRepository);
+        _ = _floStatsService.FetchAndStoreIfNeeded(
+            dto.GameMetadata.FloGameId, _lagReportRepository, _floGameLeaveRepository, EFloLeaveCaptureTrigger.Submission);
 
         return Ok(new LagReportSubmissionResponse { ReportId = reportId });
     }

--- a/W3ChampionsStatisticService/LagReports/LagReportEnums.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportEnums.cs
@@ -57,3 +57,38 @@ public enum EConnectionType
     Direct,
     Proxied,
 }
+
+/// <summary>
+/// Per-player leave reason as recorded by flo's observer-edge
+/// (crates/observer-edge/src/game/mod.rs, PlayerLeaveReason).
+///
+/// IMPORTANT - <see cref="LeaveDisconnect"/> is AMBIGUOUS and must not be read as
+/// "the player's connection dropped". flo's node fabricates it whenever a player is
+/// removed without an explicit client-supplied reason
+/// (crates/node/src/game/host/dispatch.rs, `reason.unwrap_or(LeaveReason::LeaveDisconnect)`):
+/// a genuine client disconnect-leave, a lag-timeout drop, a majority drop vote, an
+/// ack-queue overflow, an internal dispatch error and a desync eviction all land here.
+/// Treat it as "was removed", nothing more.
+///
+/// Every one of these is ultimately CLIENT-ASSERTED: the reason is decoded verbatim
+/// from the client's W3GS leave packet and never validated, so it is exactly as
+/// forgeable as the scorescreen. Record it, never treat it as an outcome.
+/// </summary>
+public enum EFloLeaveReason
+{
+    LeaveDisconnect,
+    LeaveLost,
+    LeaveLostBuildings,
+    LeaveWon,
+    LeaveDraw,
+    LeaveObserver,
+    LeaveUnknown,
+}
+
+/// <summary>Which handler captured a <see cref="FloGameLeaveReport"/>.</summary>
+public enum EFloLeaveCaptureTrigger
+{
+    Submission,
+    MatchFinished,
+    MatchCanceled,
+}

--- a/W3ChampionsStatisticService/LagReports/LagReportMatchCanceledHandler.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportMatchCanceledHandler.cs
@@ -6,13 +6,20 @@ using W3ChampionsStatisticService.ReadModelBase;
 namespace W3ChampionsStatisticService.LagReports;
 
 /// <summary>
-/// When a match is canceled, check if a lag report exists for that game
-/// and fetch server-side ping data from flo-stats if needed.
-/// Canceled games (e.g. disconnects) are often the most interesting for diagnostics.
+/// When a match is canceled, fetch the flo-stats snapshot: ping data onto an
+/// existing lag report, and per-player leave reasons into FloGameLeaveReport.
+///
+/// Expect a low yield here. Matchmaking only emits MatchCanceledEvent from its
+/// 6-hour cleanup sweep, and only for ladder matches, by which point flo has almost
+/// certainly evicted the game from its in-memory LRU. The capture is still recorded
+/// (with SnapshotAvailable = false) so the miss rate is measurable rather than
+/// invisible, but the submission-time and match-finished paths are where data will
+/// actually come from.
 /// </summary>
 [Trace]
 public class LagReportMatchCanceledHandler(
     LagReportRepository lagReportRepository,
+    FloGameLeaveRepository floGameLeaveRepository,
     IFloStatsService floStatsService
 ) : IMatchCanceledReadModelHandler
 {
@@ -24,6 +31,7 @@ public class LagReportMatchCanceledHandler(
             return;
         }
 
-        await floStatsService.FetchAndStoreIfNeeded(floGameId.Value, lagReportRepository);
+        await floStatsService.FetchAndStoreIfNeeded(
+            floGameId.Value, lagReportRepository, floGameLeaveRepository, EFloLeaveCaptureTrigger.MatchCanceled);
     }
 }

--- a/W3ChampionsStatisticService/LagReports/LagReportMatchFinishedHandler.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportMatchFinishedHandler.cs
@@ -12,6 +12,7 @@ namespace W3ChampionsStatisticService.LagReports;
 [Trace]
 public class LagReportMatchFinishedHandler(
     LagReportRepository lagReportRepository,
+    FloGameLeaveRepository floGameLeaveRepository,
     IFloStatsService floStatsService
 ) : IMatchFinishedReadModelHandler
 {
@@ -23,6 +24,7 @@ public class LagReportMatchFinishedHandler(
             return;
         }
 
-        await floStatsService.FetchAndStoreIfNeeded(floGameId.Value, lagReportRepository);
+        await floStatsService.FetchAndStoreIfNeeded(
+            floGameId.Value, lagReportRepository, floGameLeaveRepository, EFloLeaveCaptureTrigger.MatchFinished);
     }
 }

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -172,6 +172,8 @@ builder.Services.AddInterceptedTransient<IPatchRepository, PatchRepository>();
 builder.Services.AddInterceptedTransient<IAdminRepository, AdminRepository>();
 builder.Services.AddInterceptedTransient<W3ChampionsStatisticService.LagReports.LagReportRepository>();
 builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexes, W3ChampionsStatisticService.LagReports.LagReportRepository>();
+builder.Services.AddInterceptedTransient<W3ChampionsStatisticService.LagReports.FloGameLeaveRepository>();
+builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexes, W3ChampionsStatisticService.LagReports.FloGameLeaveRepository>();
 builder.Services.AddInterceptedTransient<W3ChampionsStatisticService.PlayerMatchTelemetry.IPlayerMatchTelemetryRepository, W3ChampionsStatisticService.PlayerMatchTelemetry.PlayerMatchTelemetryRepository>();
 builder.Services.AddInterceptedTransient<W3C.Domain.Repositories.IRequiresIndexes, W3ChampionsStatisticService.PlayerMatchTelemetry.PlayerMatchTelemetryRepository>();
 builder.Services.AddInterceptedSingleton<W3ChampionsStatisticService.LagReports.IFloStatsService, W3ChampionsStatisticService.LagReports.FloStatsService>();

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/FloStatsSnapshotParsingTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/FloStatsSnapshotParsingTests.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+using NUnit.Framework;
+using W3ChampionsStatisticService.LagReports;
+
+namespace WC3ChampionsStatisticService.Tests.LagReports;
+
+/// <summary>
+/// Pins the per-player leave contract between flo-stats and this service.
+///
+/// Pure unit tests over a JsonElement — no WebSocket, no Mongo, no
+/// IntegrationTestBase. Ping-sample parsing is covered separately in
+/// FloStatsPingParsingTests.
+/// </summary>
+[TestFixture]
+public class FloStatsSnapshotParsingTests
+{
+    private static JsonElement Payload(string json) => JsonDocument.Parse(json).RootElement;
+
+    // ── leave reason mapping ──────────────────────────────────────────
+
+    [TestCase("LEAVE_DISCONNECT", EFloLeaveReason.LeaveDisconnect)]
+    [TestCase("LEAVE_LOST", EFloLeaveReason.LeaveLost)]
+    [TestCase("LEAVE_LOST_BUILDINGS", EFloLeaveReason.LeaveLostBuildings)]
+    [TestCase("LEAVE_WON", EFloLeaveReason.LeaveWon)]
+    [TestCase("LEAVE_DRAW", EFloLeaveReason.LeaveDraw)]
+    [TestCase("LEAVE_OBSERVER", EFloLeaveReason.LeaveObserver)]
+    [TestCase("LEAVE_UNKNOWN", EFloLeaveReason.LeaveUnknown)]
+    public void MapsEveryKnownWireString(string wire, EFloLeaveReason expected)
+    {
+        // async-graphql renders enum items as SCREAMING_SNAKE_CASE. If flo ever
+        // changes that, this is the test that fails rather than the whole feature
+        // silently recording nulls.
+        Assert.That(FloStatsService.MapLeaveReason(wire), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void AnUnknownVariantMapsToNullButKeepsTheRawString()
+    {
+        var leaves = FloStatsService.ParsePlayerLeaves(Payload(
+            """
+            { "game": { "players": [
+                { "id": 1, "name": "Player1#1234", "leftAt": 1000, "leaveReason": "LEAVE_SOMETHING_NEW" }
+            ] } }
+            """));
+
+        Assert.That(leaves, Has.Count.EqualTo(1));
+        Assert.That(leaves[0].LeaveReason, Is.Null);
+        // Without the raw string a variant flo added later would be indistinguishable
+        // from "no leave was recorded", which means the opposite thing.
+        Assert.That(leaves[0].LeaveReasonRaw, Is.EqualTo("LEAVE_SOMETHING_NEW"));
+    }
+
+    // ── player leaves ─────────────────────────────────────────────────
+
+    [Test]
+    public void APlayerWithNoLeaveRecordIsStillEmitted()
+    {
+        // flo records no PlayerLeft at all when a started game's stream simply
+        // closes, so a null reason on a player who was in the game is the signal,
+        // not an absence of data.
+        var leaves = FloStatsService.ParsePlayerLeaves(Payload(
+            """
+            { "game": { "players": [
+                { "id": 3, "name": "Player3#1234", "leftAt": null, "leaveReason": null }
+            ] } }
+            """));
+
+        Assert.That(leaves, Has.Count.EqualTo(1));
+        Assert.That(leaves[0].PlayerId, Is.EqualTo(3));
+        Assert.That(leaves[0].LeaveReason, Is.Null);
+        Assert.That(leaves[0].LeaveReasonRaw, Is.Null);
+        Assert.That(leaves[0].LeftAtMs, Is.Null);
+    }
+
+    [Test]
+    public void ParsesAMixedGame()
+    {
+        var leaves = FloStatsService.ParsePlayerLeaves(Payload(
+            """
+            { "game": { "players": [
+                { "id": 1, "name": "Player1#1234", "leftAt": 412350, "leaveReason": "LEAVE_WON" },
+                { "id": 2, "name": "Player2#1234", "leftAt": 412100, "leaveReason": "LEAVE_LOST" },
+                { "id": 3, "name": "Player3#1234", "leftAt": null, "leaveReason": null },
+                { "id": 4, "name": "Player4#1234", "leftAt": 90000, "leaveReason": "LEAVE_DISCONNECT" }
+            ] } }
+            """));
+
+        Assert.That(leaves, Has.Count.EqualTo(4));
+        Assert.That(leaves[0].LeaveReason, Is.EqualTo(EFloLeaveReason.LeaveWon));
+        Assert.That(leaves[0].LeftAtMs, Is.EqualTo(412350));
+        Assert.That(leaves[1].LeaveReason, Is.EqualTo(EFloLeaveReason.LeaveLost));
+        Assert.That(leaves[2].LeaveReason, Is.Null);
+        Assert.That(leaves[3].LeaveReason, Is.EqualTo(EFloLeaveReason.LeaveDisconnect));
+        Assert.That(leaves[3].PlayerName, Is.EqualTo("Player4#1234"));
+    }
+
+    [Test]
+    public void AMissingGameKeyYieldsAnEmptyListRatherThanThrowing()
+    {
+        // A throw here would abort the whole snapshot parse, and the caller would
+        // then persist an empty result that the "already captured" guard treats as
+        // final — the exact failure mode the avg bug below caused for ping data.
+        Assert.That(FloStatsService.ParsePlayerLeaves(Payload("""{ "stats": {} }""")), Is.Empty);
+    }
+
+    [Test]
+    public void APlayerWithNoIdIsSkipped()
+    {
+        var leaves = FloStatsService.ParsePlayerLeaves(Payload(
+            """
+            { "game": { "players": [
+                { "name": "NoId#1234", "leaveReason": "LEAVE_WON" },
+                { "id": 2, "name": "Player2#1234", "leaveReason": "LEAVE_LOST" }
+            ] } }
+            """));
+
+        Assert.That(leaves, Has.Count.EqualTo(1));
+        Assert.That(leaves[0].PlayerId, Is.EqualTo(2));
+    }
+}


### PR DESCRIPTION
**Draft.** Stacked on #551 (the ping-`avg` fix, split out of this PR so it can land on its own). This PR's diff is against that branch.

**Read "Is this still worth it?" at the bottom first.** The justification for this PR has changed since it was opened, and it may not be worth merging.

## What this does

flo's observer-edge already exposes per-player `leaveReason` and `leftAt` on the snapshot this service subscribes to on every finished, cancelled and reported game. We were selecting only `id` and `name`:

```diff
- game { players { id name } }
+ game { players { id name leftAt leaveReason } }
```

That's the entire flo-side ask. No flo changes, no new connection, no protocol work.

## Storage

A new `FloGameLeaveReport` collection rather than an extension of `LagReport`.

A `LagReport` document only exists once a player has submitted one — `FetchAndStoreIfNeeded` returned early when `report == null`. That is precisely the population abandoned and cancelled games are *not* in, so extending `LagReport` would have captured nothing on the games this is for. The leave half is now written unconditionally.

`LagReport` also can't host synthesised documents: `GameId` is an `int` with a unique index, but `MatchCanceledEvent.match.id` is a string ObjectId, so every synthesised row would write `GameId = 0` and collide.

`SnapshotAvailable` records whether flo had the game at all. Without it, *"flo saw the game and recorded no leave for this player"* is indistinguishable from *"we never saw the game"* — and those support opposite conclusions.

## Two properties of the data that must not be lost

Both documented on the enum, because both are easy to misread:

**Every reason is client-asserted.** flo decodes it verbatim from the client's W3GS leave packet with no validation (`crates/node/src/game/host/dispatch.rs`), so any single value is as forgeable as the scorescreen. Stored as evidence of what a client reported, never as an outcome.

That said, `LEAVE_DRAW` is more useful than that caveat alone suggests, because of how the `-draw` vote works. It is a map-side command (`map-updater-scripts`, `src/player_features/draw.ts`): once the vote carries — unanimous, or n-1 for 4+ players, and disabled after 120 s of play — it calls `RemovePlayerPreserveUnitsBJ(player, PLAYER_GAME_RESULT_NEUTRAL, false)` on **every** player, which is exactly what makes a client report a draw.

So a genuine `-draw` appears here as **every player reporting `LEAVE_DRAW` at once, early in the game**. A forger controls only their own client, so unanimity across the lobby is corroboration no single actor can manufacture. That is the part worth reading; one player's `LEAVE_DRAW` on its own is not.

**`LEAVE_DISCONNECT` is ambiguous.** flo's node fabricates it for any removal with no explicit client reason (`reason.unwrap_or(LeaveReason::LeaveDisconnect)`): a genuine client disconnect-leave, a ~57 s lag-timeout drop, a majority drop vote, an ack-queue overflow, an internal dispatch error, or a desync eviction. It means "was removed", not "the connection dropped".

A related gap worth knowing: on a *started* game, a stream close emits **no `PlayerLeft` at all** — `handle_peer_stream_close` returns `ClosedDisconnected` without broadcasting. So `leaveReason` is null exactly when a player's process died and the game ended before the lag timeout could fabricate one. Null is not "nothing happened".

## Live bug fixed along the way

This one blocked the whole feature, and I'd suggest reviewing it first.

flo's `Ping.avg` is an `f32` (`crates/observer/src/record.rs:137`), so it arrives as a GraphQL `Float` and serialises as `"42.0"` even when integral. `JsonElement.GetInt32()` throws `FormatException` on that.

The throw escaped `ParsePingData`, was swallowed by the outer `catch`, and the caller then persisted an **empty** ping array — which the "already populated" guard treats as done and never retries. **Every lag report should currently have an empty `ServerSidePing`.**

Verified rather than reasoned: reverting the fix makes both the fractional (`42.7`) and the integral (`42.0`) test case throw `FormatException`. Since `avg` is always a Float, every parse has been failing.

## Is this still worth it?

When this was opened it was the only route to knowing why a match was cancelled. That is no longer true, and I would rather say so than let it merge on a stale rationale.

**What has changed:**

- matchmaking#872 and #874 now record the fact directly. `NO_WINNER_REPORTED` with source `RESULT_NO_WINNER` states that N participants reported a result nobody won — recorded, immediate, and independent of flo entirely.
- The `-draw` vote is triggered by players **typing `-draw` in chat**, and `replay-service`'s `/chats` endpoint already extracts chat. The admin page already has a chat-log button on every row, so a moderator can likely confirm a `-draw` in one click today. (Worth confirming against a known `-draw` match — that inference is from the map trigger, not from an extracted log.)
- I previously claimed matchmaking#874 rescues the cancelled-match capture by firing `pushMatchCanceled` within seconds instead of six hours. That is true, but only for matches where everyone reported. Where someone crashed and never submitted, the six-hour sweep still applies and flo will have evicted the game — so the hardest-to-explain case remains the one flo cannot help with.

**What remains, and note that neither is about cancellations:**

- `leftAt` shares a clock with `LagEvent.GameTimeOffsetMs`, so who left relative to a reported lag spike becomes visible. That is a lag-diagnostics feature.
- Leave reasons on *finished* matches, captured while the game is still hot, which nothing else covers — abandons in completed games.

So the deciding question is whether per-player leave and timing data is wanted for **lag diagnostics**. If yes, this is worth keeping on those merits. If no, close it — an unread collection is a liability. Either way #551 should merge.

## Verification

- `dotnet build` — 0 warnings, 0 errors
- 15 new parser unit tests — pure `JsonElement` functions, **no WebSocket and no Mongo**, so they do not touch `IntegrationTestBase` (whose `[SetUp]` drops a shared remote database). Run filtered, with container networking disabled.
- Tests pin the `SCREAMING_SNAKE_CASE` wire contract per variant, and the null-versus-unmapped distinction: an unknown variant maps to `null` but keeps `LeaveReasonRaw`, so flo adding a variant later shows up in the data instead of silently becoming "no record".

**Wire spellings verified.** These were initially inferred from async-graphql's default rename rule. They are now confirmed against generated code in `launcher-e` (`src/generated/graphql.ts`), which is produced by GraphQL codegen from flo's actual published schema — all seven variants and both field names (`leaveReason`, `leftAt`) match exactly:

```ts
export enum PlayerLeaveReason {
  LeaveDisconnect = 'LEAVE_DISCONNECT',
  LeaveDraw = 'LEAVE_DRAW',
  LeaveLost = 'LEAVE_LOST',
  LeaveLostBuildings = 'LEAVE_LOST_BUILDINGS',
  LeaveObserver = 'LEAVE_OBSERVER',
  LeaveUnknown = 'LEAVE_UNKNOWN',
  LeaveWon = 'LEAVE_WON'
}
```

`LeaveReasonRaw` is retained anyway, so a variant flo adds later is visible in the data rather than silently becoming "no record".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
