### PR TITLE
fix(lag-reports): stop discarding every server-side ping sample

### DIFF
--- a/W3ChampionsStatisticService/LagReports/FloStatsService.cs
+++ b/W3ChampionsStatisticService/LagReports/FloStatsService.cs
@@ -165,7 +165,7 @@ public class FloStatsService : IFloStatsService
         return pingData;
     }
 
-    private static List<ServerSidePingData> ParsePingData(JsonElement payload)
+    internal static List<ServerSidePingData> ParsePingData(JsonElement payload)
     {
         var playerNames = new Dictionary<int, string>();
         if (payload.TryGetProperty("game", out var game) &&
@@ -199,9 +199,9 @@ public class FloStatsService : IFloStatsService
                     byPlayer[playerId].Add(new ServerPingSample
                     {
                         Time = time,
-                        Min = d.TryGetProperty("min", out var min) && min.ValueKind == JsonValueKind.Number ? min.GetInt32() : null,
-                        Max = d.TryGetProperty("max", out var max) && max.ValueKind == JsonValueKind.Number ? max.GetInt32() : null,
-                        Avg = d.TryGetProperty("avg", out var avg) && avg.ValueKind == JsonValueKind.Number ? avg.GetInt32() : null,
+                        Min = ReadRoundedInt(d, "min"),
+                        Max = ReadRoundedInt(d, "max"),
+                        Avg = ReadRoundedInt(d, "avg"),
                     });
                 }
             }
@@ -214,6 +214,22 @@ public class FloStatsService : IFloStatsService
             Samples = kv.Value,
         }).ToList();
     }
+
+    /// <summary>
+    /// Reads a numeric JSON property as an int, rounding a fractional value rather than
+    /// rejecting it. flo's Ping.avg is an f32 (crates/observer/src/record.rs) and so
+    /// arrives as a GraphQL Float, serialising as "12.0" even when integral -
+    /// JsonElement.GetInt32() throws FormatException on that. Because the throw escaped
+    /// ParsePingData, it aborted the whole snapshot parse and the caller then persisted
+    /// an empty ping array, which the "already populated" guard treated as done and
+    /// never retried.
+    /// </summary>
+    private static int? ReadRoundedInt(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) &&
+        value.ValueKind == JsonValueKind.Number &&
+        value.TryGetDouble(out var number)
+            ? (int)Math.Round(number)
+            : null;
 
     private static async Task SendJson<T>(ClientWebSocket ws, T obj, CancellationToken ct)
     {

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/FloStatsPingParsingTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/FloStatsPingParsingTests.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using NUnit.Framework;
+using W3ChampionsStatisticService.LagReports;
+
+namespace WC3ChampionsStatisticService.Tests.LagReports;
+
+/// <summary>
+/// Pins the numeric contract for flo-stats ping samples.
+///
+/// Pure unit tests over a JsonElement — no WebSocket, no Mongo, no
+/// IntegrationTestBase. ParsePingData is the only part of FloStatsService that can
+/// be exercised without a live socket, and it is where the type disagreement below
+/// surfaced.
+/// </summary>
+[TestFixture]
+public class FloStatsPingParsingTests
+{
+    private static JsonElement Payload(string json) => JsonDocument.Parse(json).RootElement;
+
+    private static string SnapshotWith(string sample) =>
+        $$"""
+        {
+          "game": { "players": [ { "id": 1, "name": "Player1#1234" } ] },
+          "stats": { "ping": [ { "time": 1000, "data": [ {{sample}} ] } ] }
+        }
+        """;
+
+    [Test]
+    public void AFractionalAverageIsRoundedRatherThanThrowing()
+    {
+        // Regression: flo's Ping.avg is an f32, so it arrives as a GraphQL Float and
+        // serialises as "42.7" — and JsonElement.GetInt32() throws FormatException on
+        // that. The throw escaped ParsePingData, was swallowed by the caller's catch,
+        // and an empty ping array was then persisted, which the "already populated"
+        // guard treated as done and never retried.
+        var ping = FloStatsService.ParsePingData(Payload(
+            SnapshotWith("""{ "playerId": 1, "min": 30, "max": 55, "avg": 42.7 }""")));
+
+        Assert.That(ping, Has.Count.EqualTo(1));
+        Assert.That(ping[0].Samples, Has.Count.EqualTo(1));
+        Assert.That(ping[0].Samples[0].Avg, Is.EqualTo(43));
+        Assert.That(ping[0].Samples[0].Min, Is.EqualTo(30));
+        Assert.That(ping[0].Samples[0].Max, Is.EqualTo(55));
+    }
+
+    [Test]
+    public void AnIntegralAverageStillParses()
+    {
+        // The one that shows the bug was total rather than occasional: serde renders an
+        // integral f32 as "42.0", which GetInt32() rejects just as hard as "42.7". Since
+        // avg is always a Float, every parse was failing.
+        var ping = FloStatsService.ParsePingData(Payload(
+            SnapshotWith("""{ "playerId": 1, "min": 30, "max": 55, "avg": 42.0 }""")));
+
+        Assert.That(ping[0].Samples[0].Avg, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void AMissingSampleFieldIsNullRatherThanZero()
+    {
+        // Null and zero are different claims about latency; a missing field must not
+        // read as a perfect ping.
+        var ping = FloStatsService.ParsePingData(Payload(
+            SnapshotWith("""{ "playerId": 1 }""")));
+
+        Assert.That(ping[0].Samples[0].Avg, Is.Null);
+        Assert.That(ping[0].Samples[0].Min, Is.Null);
+        Assert.That(ping[0].Samples[0].Max, Is.Null);
+    }
+
+    [Test]
+    public void PlayerNamesAreResolvedOntoTheSamples()
+    {
+        var ping = FloStatsService.ParsePingData(Payload(
+            SnapshotWith("""{ "playerId": 1, "min": 30, "max": 55, "avg": 42.5 }""")));
+
+        Assert.That(ping[0].PlayerId, Is.EqualTo(1));
+        Assert.That(ping[0].PlayerName, Is.EqualTo("Player1#1234"));
+    }
+}


### PR DESCRIPTION
## The bug

flo's `Ping.avg` is an `f32` (`crates/observer/src/record.rs`), so it arrives over GraphQL as a `Float` and serialises as `"42.0"` **even when integral**. `JsonElement.GetInt32()` throws `FormatException` on that.

The throw escaped `ParsePingData`, was swallowed by the outer `catch` in `FetchGamePingData`, and the caller then persisted an **empty** ping array:

```csharp
await repo.UpdateServerSidePing(report.Id, pingData ?? []);
```

which the "already populated" guard treats as done and never retries.

Since `avg` is always a `Float`, every parse has been failing. **Every lag report in production should currently have no server-side ping data at all.**

## The fix

`min`, `max` and `avg` now read through one helper that rounds a fractional value instead of rejecting it. `min` and `max` are `u16` and were never affected, but routing all three through the same helper stops them drifting apart again.

## Verification

Not reasoned — measured. Reverting the helper makes **both** the fractional (`42.7`) and the integral (`42.0`) case throw `FormatException`; the integral one is what shows the failure was total rather than occasional.

4 tests, pure functions over a `JsonElement` — no socket, no Mongo, and no `IntegrationTestBase` (whose `[SetUp]` drops a shared remote database). Run filtered, with container networking disabled.

`ParsePingData` becomes `internal` so the tests can reach it; `InternalsVisibleTo` for the test assembly is already declared in the csproj.

## Worth checking after merge

Whether `ServerSidePing` starts populating on new lag reports. Existing reports will stay empty — the guard means they are never retried, so a backfill would need to clear the field first.

Split out of #549 so it can land on its own; that PR now stacks on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
