### PR TITLE
feat(chat): notify chat-service when a player's flair changes

### DIFF
--- a/W3C.Domain/ChatService/FlairChangeNotifier.cs
+++ b/W3C.Domain/ChatService/FlairChangeNotifier.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Serilog;
+
+namespace W3C.Domain.ChatService;
+
+/// <summary>
+/// Clone of <see cref="RelationshipChangeNotifier"/>'s dispatch discipline — same HMAC scheme, same
+/// fire-and-forget <see cref="Task.Run"/>, same 2 attempts at 3 s each, same self-disable and the same
+/// never-log-the-secret rule — carrying a battleTag list instead of a relationship triple.
+/// </summary>
+public class FlairChangeNotifier(IHttpClientFactory httpClientFactory, ChatPingSettings settings) : IFlairChangeNotifier
+{
+    private const int TimeoutSecondsPerAttempt = 3;
+    private const int MaxAttempts = 2; // initial + one retry, matching RelationshipChangeNotifier
+
+    // Chat-service rejects any batch above ChatLimits.InternalMaxMembersPerCall outright, with no
+    // partial processing. A clan delete can affect more members than that, so an unchunked send would
+    // lose the ENTIRE notification for exactly the largest clans.
+    private const int MaxBattleTagsPerRequest = 64;
+
+    private readonly ChatPingSettings _settings = settings;
+    private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
+
+    /// <summary>Test seam: the background dispatch started by the most recent call.</summary>
+    public Task LastDispatch { get; private set; } = Task.CompletedTask;
+
+    public void NotifyChanged(IReadOnlyCollection<string> battleTags)
+    {
+        if (!_settings.Enabled) return; // silent no-op; startup already logged once (Program.cs)
+
+        if (battleTags == null) return;
+
+        var usable = battleTags
+            .Where(tag => !string.IsNullOrWhiteSpace(tag))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (usable.Count == 0) return;
+
+        LastDispatch = Task.Run(() => SendAllAsync(usable));
+    }
+
+    private async Task SendAllAsync(List<string> battleTags)
+    {
+        foreach (var chunk in battleTags.Chunk(MaxBattleTagsPerRequest))
+        {
+            await SendWithRetryAsync(chunk);
+        }
+    }
+
+    private async Task SendWithRetryAsync(IReadOnlyCollection<string> battleTags)
+    {
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            try
+            {
+                // Serialize ONCE and reuse the same string for both the signature and the content —
+                // signing a re-serialization would produce a valid-looking but rejected request.
+                var body = JsonConvert.SerializeObject(new { battleTags });
+                var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+                var request = new HttpRequestMessage(HttpMethod.Post,
+                    $"{_settings.ChatApiUrl}/internal/profile-changes")
+                {
+                    Content = new StringContent(body, Encoding.UTF8, "application/json")
+                };
+                request.Headers.Add(ChatInternalApiSigner.TimestampHeaderName, timestamp);
+                request.Headers.Add(ChatInternalApiSigner.SignatureHeaderName,
+                    ChatInternalApiSigner.CreateSignatureHeaderValue(_settings.Secret, timestamp, body));
+
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(TimeoutSecondsPerAttempt));
+                var response = await _httpClientFactory.CreateClient().SendAsync(request, cts.Token);
+                if (response.IsSuccessStatusCode) return;
+                // Non-2xx: fall out of the loop body (no throw, no return) and let the for-loop
+                // either retry or -- on the last attempt -- fall through to the post-loop log.
+            }
+            catch (Exception) when (attempt < MaxAttempts)
+            {
+                // Retry once, immediately — the retry may still succeed, so nothing is logged here.
+            }
+            catch (Exception e)
+            {
+                Log.Warning(e, "Flair change-ping failed after {Attempts} attempts for {Count} battleTag(s)",
+                    MaxAttempts, battleTags.Count); // never logs the secret, the signature, or the tags
+                return;
+            }
+        }
+
+        Log.Warning("Flair change-ping rejected by chat-service after {Attempts} attempts for {Count} battleTag(s)",
+            MaxAttempts, battleTags.Count);
+    }
+}

--- a/W3C.Domain/ChatService/FlairChangeNotifier.cs
+++ b/W3C.Domain/ChatService/FlairChangeNotifier.cs
@@ -76,7 +76,7 @@ public class FlairChangeNotifier(IHttpClientFactory httpClientFactory, ChatPingS
                     ChatInternalApiSigner.CreateSignatureHeaderValue(_settings.Secret, timestamp, body));
 
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(TimeoutSecondsPerAttempt));
-                var response = await _httpClientFactory.CreateClient().SendAsync(request, cts.Token);
+                using var response = await _httpClientFactory.CreateClient().SendAsync(request, cts.Token);
                 if (response.IsSuccessStatusCode) return;
                 // Non-2xx: fall out of the loop body (no throw, no return) and let the for-loop
                 // either retry or -- on the last attempt -- fall through to the post-loop log.

--- a/W3C.Domain/ChatService/IFlairChangeNotifier.cs
+++ b/W3C.Domain/ChatService/IFlairChangeNotifier.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace W3C.Domain.ChatService;
+
+/// <summary>
+/// Tells chat-service that one or more players' flair (portrait, chat colour, chat icons, clan) may
+/// have changed, so it can re-resolve and push the update to anyone currently viewing them.
+/// <para>
+/// Fire-and-forget by contract: implementations must never throw and never block the caller. A lost
+/// notification degrades to the reconnect backstop — chat-service re-enriches from this service on
+/// every connect regardless.
+/// </para>
+/// </summary>
+public interface IFlairChangeNotifier
+{
+    void NotifyChanged(IReadOnlyCollection<string> battleTags);
+}

--- a/W3ChampionsStatisticService/Clans/FlairNotifyingClanRepository.cs
+++ b/W3ChampionsStatisticService/Clans/FlairNotifyingClanRepository.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Serilog;
+using W3C.Domain.ChatService;
+using W3ChampionsStatisticService.Ports;
+
+namespace W3ChampionsStatisticService.Clans;
+
+/// <summary>
+/// Fires a flair change-ping after a successful clan-membership write. Clan tag is part of a player's
+/// chat flair, so joining, leaving, being kicked, or having the clan deleted under them all need to
+/// reach chat-service.
+/// <para>
+/// Only the two MEMBERSHIP-persisting methods notify. <c>UpsertClan</c> and <c>DeleteClan</c> carry no
+/// battleTags, and every path that calls them also persists the affected memberships through
+/// <see cref="UpsertMemberShip"/> or <see cref="SaveMemberShips"/> — including the bulk teardown in
+/// <c>ClanCommandHandler.DeleteClan</c>, which calls <see cref="SaveMemberShips"/> twice (former
+/// members, then revoked invitees). So the bulk path is covered with no special-casing.
+/// </para>
+/// </summary>
+public class FlairNotifyingClanRepository(
+    IClanRepository inner,
+    IFlairChangeNotifier notifier) : IClanRepository
+{
+    public Task TryInsertClan(Clan clan) => inner.TryInsertClan(clan);
+    public Task<Clan> LoadClan(string clanId) => inner.LoadClan(clanId);
+    public Task UpsertClan(Clan clan) => inner.UpsertClan(clan);
+    public Task<ClanMembership> LoadMemberShip(string battleTag) => inner.LoadMemberShip(battleTag);
+    public Task DeleteClan(string clanId) => inner.DeleteClan(clanId);
+    public Task<List<ClanMembership>> LoadMemberShips(List<string> clanMembers) => inner.LoadMemberShips(clanMembers);
+    public Task<List<ClanMembership>> LoadMemberShipsSince(DateTimeOffset from) => inner.LoadMemberShipsSince(from);
+
+    public async Task UpsertMemberShip(ClanMembership clanMemberShip)
+    {
+        await inner.UpsertMemberShip(clanMemberShip);
+        Notify(new[] { clanMemberShip?.BattleTag });
+    }
+
+    public async Task SaveMemberShips(List<ClanMembership> clanMembers)
+    {
+        await inner.SaveMemberShips(clanMembers);
+        Notify(clanMembers?.Select(m => m?.BattleTag).ToList());
+    }
+
+    private void Notify(IReadOnlyCollection<string> battleTags)
+    {
+        if (battleTags == null || battleTags.Count == 0) return;
+
+        try
+        {
+            notifier.NotifyChanged(battleTags);
+        }
+        catch (Exception e)
+        {
+            Log.Warning(e, "Flair change-ping dispatch failed after a clan-membership write");
+        }
+    }
+}

--- a/W3ChampionsStatisticService/Extensions/ServiceCollectionExtensions.cs
+++ b/W3ChampionsStatisticService/Extensions/ServiceCollectionExtensions.cs
@@ -117,6 +117,63 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Wraps the LAST existing registration of <typeparamref name="TInterface"/> in
+    /// <typeparamref name="TDecorator"/>, in place — same position in the collection, same lifetime.
+    /// <para>
+    /// This exists because <see cref="AddInterceptedTransient{TInterface,TImplementation}"/> registers
+    /// the interface as a Castle DynamicProxy over the concrete type. A decorator cannot be layered by
+    /// re-registering the interface: that helper resolves constructor arguments straight from the
+    /// container by type, so a decorator taking <typeparamref name="TInterface"/> would resolve to
+    /// ITSELF and recurse. Building the inner instance from the CAPTURED descriptor is what keeps the
+    /// tracing proxy alive underneath the decorator.
+    /// </para>
+    /// <para>
+    /// Must be called AFTER the registration it wraps. Decorating twice nests in call order:
+    /// the second decorator wraps the first.
+    /// </para>
+    /// </summary>
+    public static IServiceCollection Decorate<TInterface, TDecorator>(this IServiceCollection services)
+        where TInterface : class
+        where TDecorator : class, TInterface
+    {
+        var index = -1;
+        for (var i = services.Count - 1; i >= 0; i--)
+        {
+            if (services[i].ServiceType == typeof(TInterface))
+            {
+                index = i;
+                break;
+            }
+        }
+
+        if (index < 0)
+        {
+            throw new InvalidOperationException(
+                $"Cannot decorate {typeof(TInterface).Name} with {typeof(TDecorator).Name}: it has no existing "
+                + "registration. Decorate must be called AFTER the registration it wraps.");
+        }
+
+        var inner = services[index];
+
+        services[index] = new ServiceDescriptor(
+            typeof(TInterface),
+            serviceProvider => ActivatorUtilities.CreateInstance<TDecorator>(
+                serviceProvider,
+                CreateInner(serviceProvider, inner)),
+            inner.Lifetime);
+
+        return services;
+    }
+
+    // Rebuilds the captured registration by whichever of the three ServiceDescriptor forms it used.
+    private static object CreateInner(IServiceProvider serviceProvider, ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationInstance != null) return descriptor.ImplementationInstance;
+        if (descriptor.ImplementationFactory != null) return descriptor.ImplementationFactory(serviceProvider);
+        return ActivatorUtilities.CreateInstance(serviceProvider, descriptor.ImplementationType);
+    }
+
     // AddInterceptedSingleton for a concrete type (TImplementation is the service type)
     public static IServiceCollection AddInterceptedSingleton<TImplementation>(
         this IServiceCollection services)

--- a/W3ChampionsStatisticService/PersonalSettings/FlairNotifyingPersonalSettingsRepository.cs
+++ b/W3ChampionsStatisticService/PersonalSettings/FlairNotifyingPersonalSettingsRepository.cs
@@ -30,7 +30,30 @@ public class FlairNotifyingPersonalSettingsRepository(
     IFlairChangeNotifier notifier) : IPersonalSettingsRepository
 {
     public Task<PersonalSetting> Load(string battletag) => inner.Load(battletag);
-    public Task<PersonalSetting> LoadOrCreate(string battletag) => inner.LoadOrCreate(battletag);
+
+    // PersonalSettingsRepository.LoadOrCreate persists the new document itself (via the protected
+    // Upsert it inherits from MongoDbRepositoryBase), bypassing this decorator's Save/SaveMany, so the
+    // create-path write is otherwise invisible here. We only want to notify when a document is
+    // actually created — not on the far more common load-of-an-existing-document path — and without
+    // paying for a second read on that hot path.
+    //
+    // inner.LoadOrCreate's existing-document branch is just LoadFirst + a RaceWins merge from
+    // PlayerOverallStats, which is exactly what inner.Load does. So loading first costs the same as
+    // today's LoadOrCreate when the document already exists, and only falls through to
+    // inner.LoadOrCreate (one extra read, once per battleTag ever) when it must create.
+    public async Task<PersonalSetting> LoadOrCreate(string battletag)
+    {
+        var existing = await inner.Load(battletag);
+        if (existing != null)
+        {
+            return existing;
+        }
+
+        var created = await inner.LoadOrCreate(battletag);
+        Notify(new[] { created?.Id });
+        return created;
+    }
+
     public Task<PersonalSetting> Find(string battletag) => inner.Find(battletag);
     public Task<List<PersonalSetting>> LoadSince(DateTimeOffset from) => inner.LoadSince(from);
     public Task<List<PersonalSetting>> LoadMany(string[] battletags) => inner.LoadMany(battletags);

--- a/W3ChampionsStatisticService/PersonalSettings/FlairNotifyingPersonalSettingsRepository.cs
+++ b/W3ChampionsStatisticService/PersonalSettings/FlairNotifyingPersonalSettingsRepository.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Serilog;
+using W3C.Domain.ChatService;
+using W3ChampionsStatisticService.Ports;
+
+namespace W3ChampionsStatisticService.PersonalSettings;
+
+/// <summary>
+/// Fires a flair change-ping after a successful settings write, so chat-service can push the new
+/// portrait / chat colour / chat icons to anyone currently viewing that player.
+/// <para>
+/// This hangs off the PERSISTENCE boundary rather than the command handlers deliberately. There are
+/// five separate flair-write paths — the portrait handler, the settings controller, both reward
+/// modules (which bypass the controller entirely) and the clan handler — and hooking them
+/// individually means a sixth added later is silently missed. Every one of them crosses this
+/// interface, so covering it here cannot be forgotten.
+/// </para>
+/// <para>
+/// Deliberately over-notifies: it fires on ANY settings save, not only flair-relevant ones.
+/// Fingerprinting the flair fields to suppress no-op pings was considered and rejected — it saves a
+/// call that only happens for players currently online in chat, at the cost of real machinery and a
+/// new way to be subtly wrong. Chat-side coalescing absorbs the volume.
+/// </para>
+/// </summary>
+public class FlairNotifyingPersonalSettingsRepository(
+    IPersonalSettingsRepository inner,
+    IFlairChangeNotifier notifier) : IPersonalSettingsRepository
+{
+    public Task<PersonalSetting> Load(string battletag) => inner.Load(battletag);
+    public Task<PersonalSetting> LoadOrCreate(string battletag) => inner.LoadOrCreate(battletag);
+    public Task<PersonalSetting> Find(string battletag) => inner.Find(battletag);
+    public Task<List<PersonalSetting>> LoadSince(DateTimeOffset from) => inner.LoadSince(from);
+    public Task<List<PersonalSetting>> LoadMany(string[] battletags) => inner.LoadMany(battletags);
+    public Task<List<PersonalSetting>> LoadAll() => inner.LoadAll();
+
+    public async Task Save(PersonalSetting setting)
+    {
+        await inner.Save(setting);
+        Notify(new[] { setting?.Id });
+    }
+
+    public async Task SaveMany(List<PersonalSetting> settings)
+    {
+        await inner.SaveMany(settings);
+        Notify(settings?.Select(s => s?.Id).ToList());
+    }
+
+    // Notification is strictly after a successful write and can never fail it: if the inner call
+    // throws we never get here, and if the notifier throws we swallow it. A player must not lose a
+    // settings save because chat-service is unreachable.
+    private void Notify(IReadOnlyCollection<string> battleTags)
+    {
+        if (battleTags == null || battleTags.Count == 0) return;
+
+        try
+        {
+            notifier.NotifyChanged(battleTags);
+        }
+        catch (Exception e)
+        {
+            Log.Warning(e, "Flair change-ping dispatch failed after a personal-settings write");
+        }
+    }
+}

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -190,6 +190,14 @@ builder.Services.AddInterceptedTransient<IPortraitRepository, PortraitRepository
 builder.Services.AddInterceptedTransient<IInformationMessagesRepository, InformationMessagesRepository>();
 builder.Services.AddInterceptedTransient<ClanCommandHandler>();
 
+// Flair change-pings hang off the persistence boundary rather than the five separate command paths
+// that write flair — see FlairNotifyingPersonalSettingsRepository's class doc. Decorate MUST run
+// after the AddInterceptedTransient registrations above: it wraps whatever is registered at the time
+// it is called, and building the inner instance from that captured registration is what keeps the
+// Castle tracing proxy alive underneath the decorator.
+builder.Services.Decorate<IPersonalSettingsRepository, FlairNotifyingPersonalSettingsRepository>();
+builder.Services.Decorate<IClanRepository, FlairNotifyingClanRepository>();
+
 // Actionfilters
 builder.Services.AddInterceptedTransient<BearerCheckIfBattleTagBelongsToAuthFilter>();
 builder.Services.AddInterceptedTransient<CheckIfBattleTagIsAdminFilter>();
@@ -246,6 +254,7 @@ Log.Information(chatPingSettings.Enabled
     chatPingSettings.ChatApiUrl); // the single startup line (AC5); never logs the secret
 builder.Services.AddSingleton(chatPingSettings);
 builder.Services.AddSingleton<IRelationshipChangeNotifier, RelationshipChangeNotifier>();
+builder.Services.AddSingleton<IFlairChangeNotifier, FlairChangeNotifier>();
 
 // Inbound fail-closed auth guard for the friends/blocked-lists endpoint chat-service calls
 ChatRelationshipsAuthSettings chatRelationshipsAuthSettings = ChatRelationshipsAuthSettings.FromEnvironment();

--- a/WC3ChampionsStatisticService.UnitTests/Extensions/ServiceCollectionDecorateTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Extensions/ServiceCollectionDecorateTests.cs
@@ -1,0 +1,92 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using W3ChampionsStatisticService.Extensions;
+
+namespace WC3ChampionsStatisticService.Tests.Extensions;
+
+[TestFixture]
+public class ServiceCollectionDecorateTests
+{
+    private interface IGreeter
+    {
+        string Greet();
+    }
+
+    private class Inner : IGreeter
+    {
+        public string Greet() => "inner";
+    }
+
+    private class Outer(IGreeter inner) : IGreeter
+    {
+        public string Greet() => $"outer({inner.Greet()})";
+    }
+
+    private class Second(IGreeter inner) : IGreeter
+    {
+        public string Greet() => $"second({inner.Greet()})";
+    }
+
+    [Test]
+    public void Decorate_WrapsTheExistingRegistration()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<IGreeter, Inner>();
+
+        services.Decorate<IGreeter, Outer>();
+
+        var resolved = services.BuildServiceProvider().GetRequiredService<IGreeter>();
+        Assert.That(resolved.Greet(), Is.EqualTo("outer(inner)"));
+    }
+
+    [Test]
+    public void Decorate_PreservesAFactoryRegistration()
+    {
+        // AddInterceptedTransient registers the interface via an ImplementationFactory that builds a
+        // Castle proxy. If Decorate ignored the factory and reflected over ImplementationType (null
+        // here), the tracing proxy would be silently dropped.
+        var services = new ServiceCollection();
+        services.AddTransient<IGreeter>(_ => new Inner());
+
+        services.Decorate<IGreeter, Outer>();
+
+        var resolved = services.BuildServiceProvider().GetRequiredService<IGreeter>();
+        Assert.That(resolved.Greet(), Is.EqualTo("outer(inner)"));
+    }
+
+    [Test]
+    public void Decorate_PreservesLifetime()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IGreeter, Inner>();
+
+        services.Decorate<IGreeter, Outer>();
+
+        var provider = services.BuildServiceProvider();
+        Assert.That(provider.GetRequiredService<IGreeter>(), Is.SameAs(provider.GetRequiredService<IGreeter>()));
+    }
+
+    [Test]
+    public void Decorate_Twice_NestsInRegistrationOrder()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<IGreeter, Inner>();
+
+        services.Decorate<IGreeter, Outer>();
+        services.Decorate<IGreeter, Second>();
+
+        var resolved = services.BuildServiceProvider().GetRequiredService<IGreeter>();
+        Assert.That(resolved.Greet(), Is.EqualTo("second(outer(inner))"));
+    }
+
+    [Test]
+    public void Decorate_WithNoExistingRegistration_ThrowsWithAnActionableMessage()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => services.Decorate<IGreeter, Outer>());
+        Assert.That(ex.Message, Does.Contain("IGreeter"));
+        Assert.That(ex.Message, Does.Contain("AFTER"));
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/Friend/FlairChangeNotifierTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Friend/FlairChangeNotifierTests.cs
@@ -207,7 +207,7 @@ public class FlairChangeNotifierTests
     }
 
     [Test]
-    public void NotifyChanged_HandlerThrows_NeverPropagates()
+    public async Task NotifyChanged_HandlerThrows_NeverPropagates()
     {
         // Enabled settings (real url AND real secret) so NotifyChanged actually reaches Task.Run ->
         // SendAllAsync -> SendWithRetryAsync, and every SendAsync call throws -- this is what
@@ -219,7 +219,7 @@ public class FlairChangeNotifierTests
 
         notifier.NotifyChanged(new[] { "Foo#1234" });
 
-        Assert.DoesNotThrowAsync(async () => await notifier.LastDispatch);
+        await notifier.LastDispatch;
 
         // MaxAttempts == 2: proves both the retry AND the give-up branch actually ran, not a
         // short-circuit on Enabled.

--- a/WC3ChampionsStatisticService.UnitTests/Friend/FlairChangeNotifierTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Friend/FlairChangeNotifierTests.cs
@@ -42,6 +42,25 @@ public class FlairChangeNotifierTests
 
     private static ChatPingSettings Enabled() => new("https://chat.test", "test-secret");
 
+    /// <summary>Every SendAsync call throws, unconditionally -- used to exercise the
+    /// <c>catch (Exception) when (attempt &lt; MaxAttempts)</c> / <c>catch (Exception e)</c> branches
+    /// in <see cref="FlairChangeNotifier"/> with an ENABLED notifier, mirroring
+    /// RelationshipChangeNotifierTests.CreateAlwaysThrowingFactory.</summary>
+    private static (Mock<IHttpClientFactory> Factory, List<HttpRequestMessage> Requests) CreateAlwaysThrowingFactory()
+    {
+        var requests = new List<HttpRequestMessage>();
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((request, _) => requests.Add(request))
+            .Returns<HttpRequestMessage, CancellationToken>((_, _) => throw new HttpRequestException("always fails"));
+
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(() => new HttpClient(handler.Object));
+
+        return (factory, requests);
+    }
+
     [Test]
     public async Task NotifyChanged_PostsTheBattleTagsToProfileChanges()
     {
@@ -95,6 +114,35 @@ public class FlairChangeNotifierTests
     }
 
     [Test]
+    public async Task NotifyChanged_ExactlySixtyFourTags_ProducesExactlyOneRequest()
+    {
+        // The receiver rejects any batch over 64 outright, so the boundary itself -- not just an
+        // over-sized case -- is what matters: 64 must stay a single request, not get chunked early.
+        var notifier = CreateNotifier(Enabled());
+        var tags = Enumerable.Range(0, 64).Select(i => $"Player{i}#1").ToArray();
+
+        notifier.NotifyChanged(tags);
+        await notifier.LastDispatch;
+
+        Assert.That(_captured, Has.Count.EqualTo(1));
+        Assert.That(JObject.Parse(_capturedBodies[0])["battleTags"].Count(), Is.EqualTo(64));
+    }
+
+    [Test]
+    public async Task NotifyChanged_SixtyFiveTags_SplitsIntoSixtyFourPlusOne()
+    {
+        var notifier = CreateNotifier(Enabled());
+        var tags = Enumerable.Range(0, 65).Select(i => $"Player{i}#1").ToArray();
+
+        notifier.NotifyChanged(tags);
+        await notifier.LastDispatch;
+
+        Assert.That(_captured, Has.Count.EqualTo(2));
+        Assert.That(JObject.Parse(_capturedBodies[0])["battleTags"].Count(), Is.EqualTo(64));
+        Assert.That(JObject.Parse(_capturedBodies[1])["battleTags"].Count(), Is.EqualTo(1));
+    }
+
+    [Test]
     public async Task NotifyChanged_DedupesAndDropsBlanks()
     {
         var notifier = CreateNotifier(Enabled());
@@ -140,8 +188,14 @@ public class FlairChangeNotifierTests
     }
 
     [Test]
-    public void NotifyChanged_NeverThrowsToTheCaller()
+    public void NotifyChanged_WhenDisabled_ConstructorAndNotifyNeverTouchTheHttpClientFactory()
     {
+        // NOT coverage of the retry/exception branches in SendWithRetryAsync -- see
+        // NotifyChanged_HandlerThrows_NeverPropagates for that. With a null secret,
+        // ChatPingSettings.Enabled is false, so NotifyChanged returns at its very first line before
+        // Task.Run/SendAllAsync/factory.CreateClient() are ever reached. This test only proves that
+        // the disabled path never eagerly builds an HttpClient: factory.CreateClient() is rigged to
+        // throw specifically so that reaching it would fail the test.
         var factory = new Mock<IHttpClientFactory>();
         factory.Setup(f => f.CreateClient(It.IsAny<string>())).Throws(new InvalidOperationException("boom"));
 
@@ -150,5 +204,25 @@ public class FlairChangeNotifierTests
             var notifier = new FlairChangeNotifier(factory.Object, new ChatPingSettings("https://chat.test", null));
             notifier.NotifyChanged(new[] { "Foo#1234" });
         });
+    }
+
+    [Test]
+    public void NotifyChanged_HandlerThrows_NeverPropagates()
+    {
+        // Enabled settings (real url AND real secret) so NotifyChanged actually reaches Task.Run ->
+        // SendAllAsync -> SendWithRetryAsync, and every SendAsync call throws -- this is what
+        // genuinely exercises the `catch (Exception) when (attempt < MaxAttempts)` retry branch and
+        // the final unconditional `catch (Exception e)` give-up branch, unlike the disabled-path test
+        // above. Modeled on RelationshipChangeNotifierTests.SendWithRetryAsync_HandlerThrows_NeverPropagates.
+        var (factory, requests) = CreateAlwaysThrowingFactory();
+        var notifier = new FlairChangeNotifier(factory.Object, Enabled());
+
+        notifier.NotifyChanged(new[] { "Foo#1234" });
+
+        Assert.DoesNotThrowAsync(async () => await notifier.LastDispatch);
+
+        // MaxAttempts == 2: proves both the retry AND the give-up branch actually ran, not a
+        // short-circuit on Enabled.
+        Assert.That(requests, Has.Count.EqualTo(2));
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/Friend/FlairChangeNotifierTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Friend/FlairChangeNotifierTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using W3C.Domain.ChatService;
+
+namespace WC3ChampionsStatisticService.Tests.Friend;
+
+[TestFixture]
+public class FlairChangeNotifierTests
+{
+    private List<HttpRequestMessage> _captured;
+    private List<string> _capturedBodies;
+
+    private FlairChangeNotifier CreateNotifier(ChatPingSettings settings, HttpStatusCode status = HttpStatusCode.OK)
+    {
+        _captured = new List<HttpRequestMessage>();
+        _capturedBodies = new List<string>();
+
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Returns(async (HttpRequestMessage request, CancellationToken _) =>
+            {
+                _captured.Add(request);
+                _capturedBodies.Add(request.Content == null ? null : await request.Content.ReadAsStringAsync());
+                return new HttpResponseMessage(status);
+            });
+
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(new HttpClient(handler.Object));
+
+        return new FlairChangeNotifier(factory.Object, settings);
+    }
+
+    private static ChatPingSettings Enabled() => new("https://chat.test", "test-secret");
+
+    [Test]
+    public async Task NotifyChanged_PostsTheBattleTagsToProfileChanges()
+    {
+        var notifier = CreateNotifier(Enabled());
+
+        notifier.NotifyChanged(new[] { "Foo#1234", "Bar#5678" });
+        await notifier.LastDispatch;
+
+        Assert.That(_captured, Has.Count.EqualTo(1));
+        Assert.That(_captured[0].Method, Is.EqualTo(HttpMethod.Post));
+        Assert.That(_captured[0].RequestUri.ToString(), Is.EqualTo("https://chat.test/internal/profile-changes"));
+
+        var body = JObject.Parse(_capturedBodies[0]);
+        Assert.That(body["battleTags"].Select(t => t.ToString()), Is.EqualTo(new[] { "Foo#1234", "Bar#5678" }));
+    }
+
+    [Test]
+    public async Task NotifyChanged_SignsWithTheSharedHmacScheme()
+    {
+        var notifier = CreateNotifier(Enabled());
+
+        notifier.NotifyChanged(new[] { "Foo#1234" });
+        await notifier.LastDispatch;
+
+        var timestamp = _captured[0].Headers.GetValues(ChatInternalApiSigner.TimestampHeaderName).Single();
+        var signature = _captured[0].Headers.GetValues(ChatInternalApiSigner.SignatureHeaderName).Single();
+
+        // The signature must be over the EXACT body bytes that were sent — a mismatch here is the
+        // classic "serialized twice" bug and chat-service would reject every ping.
+        Assert.That(signature, Is.EqualTo(
+            ChatInternalApiSigner.CreateSignatureHeaderValue("test-secret", timestamp, _capturedBodies[0])));
+    }
+
+    [Test]
+    public async Task NotifyChanged_ChunksAtSixtyFour()
+    {
+        // The receiver rejects any batch over ChatLimits.InternalMaxMembersPerCall (64) outright, and a
+        // clan delete can affect more members than that — so an unchunked notifier would silently lose
+        // the whole notification for exactly the largest clans.
+        var notifier = CreateNotifier(Enabled());
+        var tags = Enumerable.Range(0, 150).Select(i => $"Player{i}#1").ToArray();
+
+        notifier.NotifyChanged(tags);
+        await notifier.LastDispatch;
+
+        Assert.That(_captured, Has.Count.EqualTo(3));
+        var sent = _capturedBodies.SelectMany(b => JObject.Parse(b)["battleTags"].Select(t => t.ToString())).ToList();
+        Assert.That(sent, Is.EqualTo(tags));
+        Assert.That(JObject.Parse(_capturedBodies[0])["battleTags"].Count(), Is.EqualTo(64));
+        Assert.That(JObject.Parse(_capturedBodies[2])["battleTags"].Count(), Is.EqualTo(22));
+    }
+
+    [Test]
+    public async Task NotifyChanged_DedupesAndDropsBlanks()
+    {
+        var notifier = CreateNotifier(Enabled());
+
+        notifier.NotifyChanged(new[] { "Foo#1234", "foo#1234", "  ", null, "Bar#5678" });
+        await notifier.LastDispatch;
+
+        var sent = JObject.Parse(_capturedBodies[0])["battleTags"].Select(t => t.ToString()).ToList();
+        Assert.That(sent, Is.EqualTo(new[] { "Foo#1234", "Bar#5678" }));
+    }
+
+    [Test]
+    public void NotifyChanged_WhenDisabled_SendsNothing()
+    {
+        var notifier = CreateNotifier(new ChatPingSettings("https://chat.test", null));
+
+        notifier.NotifyChanged(new[] { "Foo#1234" });
+
+        Assert.That(notifier.LastDispatch.IsCompleted, Is.True);
+        Assert.That(_captured, Is.Empty);
+    }
+
+    [Test]
+    public void NotifyChanged_WithNoUsableTags_SendsNothing()
+    {
+        var notifier = CreateNotifier(Enabled());
+
+        notifier.NotifyChanged(new[] { "   ", null });
+
+        Assert.That(notifier.LastDispatch.IsCompleted, Is.True);
+        Assert.That(_captured, Is.Empty);
+    }
+
+    [Test]
+    public async Task NotifyChanged_OnNonSuccess_RetriesOnceThenGivesUp()
+    {
+        var notifier = CreateNotifier(Enabled(), HttpStatusCode.InternalServerError);
+
+        notifier.NotifyChanged(new[] { "Foo#1234" });
+        await notifier.LastDispatch;
+
+        Assert.That(_captured, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void NotifyChanged_NeverThrowsToTheCaller()
+    {
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Throws(new InvalidOperationException("boom"));
+
+        Assert.DoesNotThrow(() =>
+        {
+            var notifier = new FlairChangeNotifier(factory.Object, new ChatPingSettings("https://chat.test", null));
+            notifier.NotifyChanged(new[] { "Foo#1234" });
+        });
+    }
+}

--- a/WC3ChampionsStatisticService.UnitTests/PersonalSettings/FlairNotifyingRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PersonalSettings/FlairNotifyingRepositoryTests.cs
@@ -117,6 +117,7 @@ public class FlairNotifyingRepositoryTests
         {
             new() { BattleTag = "peter#123" },
         }));
+        _clanInner.Verify(r => r.SaveMemberShips(It.IsAny<List<ClanMembership>>()), Times.Once);
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/PersonalSettings/FlairNotifyingRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PersonalSettings/FlairNotifyingRepositoryTests.cs
@@ -133,6 +133,33 @@ public class FlairNotifyingRepositoryTests
     }
 
     [Test]
+    public async Task LoadOrCreate_WhenNoSettingsExist_CreatesAndNotifiesTheBattleTag()
+    {
+        _settingsInner.Setup(r => r.Load("peter#123")).ReturnsAsync((PersonalSetting)null);
+        _settingsInner.Setup(r => r.LoadOrCreate("peter#123")).ReturnsAsync(new PersonalSetting("peter#123"));
+
+        var created = await Settings().LoadOrCreate("peter#123");
+
+        Assert.That(created.Id, Is.EqualTo("peter#123"));
+        _settingsInner.Verify(r => r.Load("peter#123"), Times.Once);
+        _settingsInner.Verify(r => r.LoadOrCreate("peter#123"), Times.Once);
+        Assert.That(_notified, Is.EqualTo(new[] { "peter#123" }));
+    }
+
+    [Test]
+    public async Task LoadOrCreate_WhenSettingsAlreadyExist_LoadsWithoutCreatingOrNotifying()
+    {
+        _settingsInner.Setup(r => r.Load("peter#123")).ReturnsAsync(new PersonalSetting("peter#123"));
+
+        var loaded = await Settings().LoadOrCreate("peter#123");
+
+        Assert.That(loaded.Id, Is.EqualTo("peter#123"));
+        _settingsInner.Verify(r => r.Load("peter#123"), Times.Once);
+        _settingsInner.Verify(r => r.LoadOrCreate(It.IsAny<string>()), Times.Never);
+        Assert.That(_notified, Is.Empty);
+    }
+
+    [Test]
     public async Task DeleteClan_IsForwardedButDoesNotNotifyOnItsOwn()
     {
         // DeleteClan carries no battleTags. Its callers persist the affected memberships through

--- a/WC3ChampionsStatisticService.UnitTests/PersonalSettings/FlairNotifyingRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/PersonalSettings/FlairNotifyingRepositoryTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using W3C.Domain.ChatService;
+using W3ChampionsStatisticService.Clans;
+using W3ChampionsStatisticService.PersonalSettings;
+using W3ChampionsStatisticService.Ports;
+
+namespace WC3ChampionsStatisticService.Tests.PersonalSettings;
+
+[TestFixture]
+public class FlairNotifyingRepositoryTests
+{
+    private Mock<IPersonalSettingsRepository> _settingsInner;
+    private Mock<IClanRepository> _clanInner;
+    private Mock<IFlairChangeNotifier> _notifier;
+    private List<string> _notified;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _settingsInner = new Mock<IPersonalSettingsRepository>();
+        _clanInner = new Mock<IClanRepository>();
+        _notifier = new Mock<IFlairChangeNotifier>();
+        _notified = new List<string>();
+        _notifier.Setup(n => n.NotifyChanged(It.IsAny<IReadOnlyCollection<string>>()))
+            .Callback((IReadOnlyCollection<string> tags) => _notified.AddRange(tags));
+    }
+
+    private FlairNotifyingPersonalSettingsRepository Settings() =>
+        new(_settingsInner.Object, _notifier.Object);
+
+    private FlairNotifyingClanRepository Clans() =>
+        new(_clanInner.Object, _notifier.Object);
+
+    [Test]
+    public async Task Save_NotifiesTheSavedBattleTag()
+    {
+        await Settings().Save(new PersonalSetting("peter#123"));
+
+        Assert.That(_notified, Is.EqualTo(new[] { "peter#123" }));
+    }
+
+    [Test]
+    public async Task SaveMany_NotifiesEveryBattleTag()
+    {
+        await Settings().SaveMany(new List<PersonalSetting>
+        {
+            new("peter#123"),
+            new("alice#456"),
+        });
+
+        Assert.That(_notified, Is.EqualTo(new[] { "peter#123", "alice#456" }));
+    }
+
+    [Test]
+    public async Task UpsertMemberShip_NotifiesTheMember()
+    {
+        await Clans().UpsertMemberShip(new ClanMembership { BattleTag = "peter#123", ClanId = "W3C" });
+
+        Assert.That(_notified, Is.EqualTo(new[] { "peter#123" }));
+    }
+
+    [Test]
+    public async Task SaveMemberShips_NotifiesEveryMember()
+    {
+        // This is the bulk clan-delete path: ClanCommandHandler.DeleteClan persists every former member
+        // through SaveMemberShips, so covering this one method covers the whole clan teardown.
+        await Clans().SaveMemberShips(new List<ClanMembership>
+        {
+            new() { BattleTag = "peter#123" },
+            new() { BattleTag = "alice#456" },
+            new() { BattleTag = "bob#789" },
+        });
+
+        Assert.That(_notified, Is.EqualTo(new[] { "peter#123", "alice#456", "bob#789" }));
+    }
+
+    [Test]
+    public void Save_WhenTheInnerWriteThrows_DoesNotNotify()
+    {
+        _settingsInner.Setup(r => r.Save(It.IsAny<PersonalSetting>())).ThrowsAsync(new InvalidOperationException("db down"));
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => Settings().Save(new PersonalSetting("peter#123")));
+        Assert.That(_notified, Is.Empty);
+    }
+
+    [Test]
+    public void UpsertMemberShip_WhenTheInnerWriteThrows_DoesNotNotify()
+    {
+        _clanInner.Setup(r => r.UpsertMemberShip(It.IsAny<ClanMembership>())).ThrowsAsync(new InvalidOperationException("db down"));
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => Clans().UpsertMemberShip(new ClanMembership { BattleTag = "peter#123" }));
+        Assert.That(_notified, Is.Empty);
+    }
+
+    [Test]
+    public void Save_WhenTheNotifierThrows_TheWriteStillSucceeds()
+    {
+        // A broken notifier must never cost a player their settings save.
+        _notifier.Setup(n => n.NotifyChanged(It.IsAny<IReadOnlyCollection<string>>()))
+            .Throws(new InvalidOperationException("notifier exploded"));
+
+        Assert.DoesNotThrowAsync(() => Settings().Save(new PersonalSetting("peter#123")));
+        _settingsInner.Verify(r => r.Save(It.IsAny<PersonalSetting>()), Times.Once);
+    }
+
+    [Test]
+    public void SaveMemberShips_WhenTheNotifierThrows_TheWriteStillSucceeds()
+    {
+        _notifier.Setup(n => n.NotifyChanged(It.IsAny<IReadOnlyCollection<string>>()))
+            .Throws(new InvalidOperationException("notifier exploded"));
+
+        Assert.DoesNotThrowAsync(() => Clans().SaveMemberShips(new List<ClanMembership>
+        {
+            new() { BattleTag = "peter#123" },
+        }));
+    }
+
+    [Test]
+    public async Task ReadMethods_AreForwardedAndDoNotNotify()
+    {
+        _settingsInner.Setup(r => r.Load("peter#123")).ReturnsAsync(new PersonalSetting("peter#123"));
+
+        var loaded = await Settings().Load("peter#123");
+
+        Assert.That(loaded.Id, Is.EqualTo("peter#123"));
+        _settingsInner.Verify(r => r.Load("peter#123"), Times.Once);
+        Assert.That(_notified, Is.Empty);
+    }
+
+    [Test]
+    public async Task DeleteClan_IsForwardedButDoesNotNotifyOnItsOwn()
+    {
+        // DeleteClan carries no battleTags. Its callers persist the affected memberships through
+        // SaveMemberShips, which is where the notification comes from.
+        await Clans().DeleteClan("W3C");
+
+        _clanInner.Verify(r => r.DeleteClan("W3C"), Times.Once);
+        Assert.That(_notified, Is.Empty);
+    }
+}


### PR DESCRIPTION
> **PR set (3 repos).** Deploy order: **1.** chat-service https://github.com/w3champions/chat-service/pull/45 → **2.** website-backend https://github.com/w3champions/website-backend/pull/554 → **3.** launcher-e https://github.com/w3champions/launcher-e/pull/852 *(any time)*.
>
> This is **2 of 3 — website-backend**.

> [!IMPORTANT]
> **Do not deploy this before the chat-service PR.** See [Deploy order](#deploy-order). This PR is what turns the traffic on.

## What this does

A player changes their portrait, chat colour, chat icons or clan. Today every other viewer in chat keeps seeing the old flair until one of them reconnects. This PR is the notification half of fixing that: website-backend tells chat-service which battleTags changed, and chat-service pushes the new flair to whoever can currently see them.

## Approach: notify at the persistence boundary

The obvious implementation is to call a notifier from each command handler that changes flair. There are five such paths, and a sixth added later would silently not notify.

Instead, decorators wrap `IPersonalSettingsRepository` and `IClanRepository` and fire **after a successful write**:

| Interface | Methods that notify | battleTags |
|---|---|---|
| `IPersonalSettingsRepository` | `Save`, `SaveMany` | `setting.Id` |
| `IClanRepository` | `UpsertMemberShip`, `SaveMemberShips` | `clanMemberShip.BattleTag` |

Every other member of both interfaces forwards untouched.

Four methods cover all five paths — including `ClanCommandHandler.DeleteClan`, which carries no battleTags itself but persists every former member through two `SaveMemberShips` calls. No special-casing.

Verified rather than assumed: each interface has exactly one registration site, nothing in the codebase constructs `PersonalSettingsRepository` or `ClanRepository` directly, and only `PersonalSettingsRepository` touches the `PersonalSetting` collection. The notification is genuinely unbypassable.

### Why `Decorate` had to be written first

`IPersonalSettingsRepository` and `IClanRepository` are registered through this repo's hand-rolled `AddInterceptedTransient`, so what's in the container is a Castle DynamicProxy tracing proxy, not the concrete type. A decorator registered the naive way either **recurses** — resolving itself as its own inner — or **silently drops tracing** on the two busiest repositories in the service.

`ServiceCollectionExtensions.Decorate<TInterface, TDecorator>` finds the last existing descriptor, replaces it **in place** preserving lifetime and position, and builds the inner from the *captured* `ServiceDescriptor`. That last detail is the whole point: the proxy stays alive underneath. It throws if there's no prior registration, which is why the `Decorate` calls sit after the `AddInterceptedTransient` calls in `Program.cs` with the ordering documented at the call site.

## Never fail a caller's write

A settings save must not fail because chat is down.

- Notification fires **only after** the inner write returns. If the write throws, nothing is notified and the exception propagates unchanged.
- The notify call is wrapped in its own try/catch that only logs.
- `FlairChangeNotifier` is fire-and-forget (`Task.Run`), 2 attempts, 3 s per-attempt cap — a 1:1 clone of the existing `RelationshipChangeNotifier` triad, same `ChatInternalApiSigner` HMAC scheme, same headers, same `ChatPingSettings`.

Both properties have dedicated tests: inner-throws → nothing notified; notifier-throws → the write still succeeds *and* the inner write is verified to have actually happened.

## Chunked at 64

`ChatLimits.InternalMaxMembersPerCall` is 64 on the receiving side, and chat-service rejects an oversize batch **outright with no partial processing**. So the notifier chunks at 64 — an unchunked send would lose the entire notification for exactly the largest clans, which is the case that most needs it.

The body is serialized once and that same string is used for both the HMAC signature and the request content. Signing a different string than you send is the classic failure in this pattern; there's a test that recomputes the signature from the captured wire body.

## What review caught

The plan's own test for the load-bearing safety property was vacuous. `NotifyChanged_NeverThrowsToTheCaller` constructed settings with a null secret, which makes `Enabled` false — so `NotifyChanged` returned at its first line, before `Task.Run`, before the throwing factory it had carefully set up. It only re-proved what the disabled-path test already proved, and the actual `catch (Exception)` retry branches had **zero** coverage.

Fixed with a real enabled-plus-throwing-handler test; the old one was renamed to state what it genuinely covers. A follow-up review then caught that the replacement's `Assert.DoesNotThrowAsync` was unawaited over a `Task.Run` path — a race, and worse, a failure that would have been swallowed in an unobserved background task. Also added 64/65 chunk-boundary tests.

## Verification

`Failed: 0, Passed: 846, Skipped: 9` (skips pre-existing) after rebasing onto `master`. 26 tests added by this branch. `dotnet format --verify-no-changes` clean.

All new tests are pure Moq/NUnit with no Mongo dependency — deliberately not `IntegrationTestBase`, which drops a shared remote database in `[SetUp]`.

## Deploy order

**chat-service → website-backend (this PR) → launcher-e (any time).**

The plan claimed this was deployable dark. It isn't. `ChatPingSettings` is keyed on the same `CHAT_INTERNAL_API_SECRET` the already-shipped relationship pings use, and that secret is already set in production — so this notifier is live the moment this PR deploys. There is no configuration state in which it ships dormant. The plan document has been corrected.

If chat-service isn't live first, every settings save and clan write gets a 404 on `/internal/profile-changes`, retries once, and logs `Flair change-ping rejected by chat-service`. Users are unaffected — the write already committed and the notifier cannot fail it — but it's sustained log noise proportional to write volume, and reverting chat-service alone leaves this repo warning on every write until it follows.

## Still owed: manual verification

No automated test here runs against a real chat-service. The eight end-to-end checks are listed in the paired chat-service PR. Two are specifically about this side:

- Deleting a clan with **more than 64 members** — exercises the chunking, which is the only path where getting it wrong loses everything rather than degrading.
- Unsetting `CHAT_INTERNAL_API_SECRET` and restarting — everything behaves as today, one startup log line.

## Known and accepted

- `LastDispatch` is a public test seam on a production singleton. It would be better as `internal`, but `W3C.Domain` has no `InternalsVisibleTo` to the test assembly and adding one for a cosmetic change isn't worth it.
- `ProfilePicture.Default()` still picks a random `STARTER 1-4`. Unchanged, still the reason a *consistent* sheep in the client could be diagnosed as client-side in the first place.

## Design docs

Spec and plan live in the chat-service repo under `docs/superpowers/`.
