### PR TITLE
test: allow overriding the integration-test database without editing source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,9 @@ dotnet test WC3ChampionsStatisticService.UnitTests
 
 # Run with verbosity
 dotnet test --logger "console;verbosity=detailed"
+
+# Run against a local MongoDB (see MongoDB Safety)
+TEST_MONGO_CONNECTION_STRING=mongodb://127.0.0.1:27017/ dotnet test
 ```
 
 ### Code Quality
@@ -118,6 +121,7 @@ docker run -e MONGO_CONNECTION_STRING="mongodb://localhost:27017" w3champions-ba
 - Default connection uses test database
 - **Never enable read model handlers locally** unless you know what you're doing
 - Can overwrite prod/test data if connected to wrong database
+- **`IntegrationTestBase` drops the whole database before every test.** Redirect it with `TEST_MONGO_CONNECTION_STRING`; don't edit the source, since a rebase or checkout silently restores the shared default
 
 ### Integration Points
 - WebsiteBackendHub provides SignalR connection for real-time updates

--- a/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
+++ b/WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs
@@ -15,8 +15,35 @@ namespace WC3ChampionsStatisticService.Tests;
 
 public class IntegrationTestBase
 {
-    //protected readonly MongoClient MongoClient = new MongoClient("mongodb://localhost:27017/");
-    protected readonly MongoClient MongoClient = new("mongodb://157.90.1.251:3512/");
+    /// <summary>
+    /// The shared CI instance. It resets itself between runs, which is the only reason
+    /// it is safe to point a suite that drops the database at it.
+    /// </summary>
+    private const string DefaultConnectionString = "mongodb://157.90.1.251:3512/";
+
+    /// <summary>
+    /// Where these tests connect. <see cref="Setup"/> drops the entire database before
+    /// EVERY test, so whatever this points at is destroyed repeatedly.
+    ///
+    /// <para>
+    /// To run against a local mongo, set the environment variable rather than editing
+    /// this file:
+    /// <code>TEST_MONGO_CONNECTION_STRING=mongodb://127.0.0.1:27017/ dotnet test</code>
+    /// Editing the line was the previous approach and it is a trap - anything that
+    /// restores the working tree mid-session (a rebase, a checkout, a stash pop) puts
+    /// the shared instance back silently, and the next run finds it.
+    /// </para>
+    ///
+    /// <para>
+    /// Deliberately a different variable from <c>MONGO_CONNECTION_STRING</c>, which the
+    /// service itself reads: pointing the service somewhere must not silently redirect
+    /// a database-dropping test suite there too.
+    /// </para>
+    /// </summary>
+    protected static string ConnectionString =>
+        Environment.GetEnvironmentVariable("TEST_MONGO_CONNECTION_STRING") ?? DefaultConnectionString;
+
+    protected readonly MongoClient MongoClient = new(ConnectionString);
 
     protected PersonalSettingsProvider personalSettingsProvider;
 


### PR DESCRIPTION
## The problem

`IntegrationTestBase` hardcodes the shared CI connection string:

```csharp
protected readonly MongoClient MongoClient = new("mongodb://157.90.1.251:3512/");
```

So running the suite against a local MongoDB means editing tracked source and remembering to put it back.

That's a trap rather than an inconvenience, because `[SetUp]` calls `DropDatabaseAsync` before **every** test. Anything that restores the working tree mid-session — a rebase, a checkout, a stash pop — silently reverts the edit, and the next `dotnet test` finds the shared instance and drops it repeatedly.

I know because it caught me out: a `git rebase --abort` restored the file between my edit and the test run, and I didn't re-check before running.

## The change

The connection string now comes from `TEST_MONGO_CONNECTION_STRING`, **defaulting to the same shared instance** — so CI and anyone who doesn't set it see no change at all.

```bash
TEST_MONGO_CONNECTION_STRING=mongodb://127.0.0.1:27017/ dotnet test
```

Deliberately a *different* variable from `MONGO_CONNECTION_STRING`, which the service itself reads. Pointing the service somewhere must not silently redirect a database-dropping test suite there too — that would just move the trap rather than remove it.

The commented-out `localhost` line above it goes away; it was the manual version of this.

## Verification

Ran `PlayerTests` (20 tests) against a local MongoDB with the file **unmodified** — the default still reads `157.90.1.251` in the committed source. Sub-second runtime confirms it connected locally rather than over the network.

I did not run the suite against the default, for obvious reasons.

## Docs

Second commit, three lines: the local-run command in the Testing block, and one bullet under MongoDB Safety noting that `IntegrationTestBase` drops the database and should be redirected with the variable rather than by editing source.

Kept deliberately terse to match the surrounding style. The fuller reasoning — why the variable is separate from `MONGO_CONNECTION_STRING`, why the shared default is safe at all — lives on the `ConnectionString` doc comment, which is where someone about to change that line will be looking.

Worth knowing for anyone doing this locally: `mongo:8.0` refuses to start on kernel 6.19+ (SERVER-121912). `mongo:8.0.19` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
