### PR TITLE
Add CreatedAt and SeenAt to friend requests

### DIFF
--- a/W3ChampionsStatisticService/Friends/FriendCommandHandler.cs
+++ b/W3ChampionsStatisticService/Friends/FriendCommandHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Driver;
@@ -9,6 +10,7 @@ public interface IFriendCommandHandler
 {
     Task<Friendlist> LoadFriendList(string battleTag);
     Task CreateFriendRequest(FriendRequest request);
+    Task MarkIncomingFriendRequestsSeen(string receiver);
     Task DeleteFriendRequest(FriendRequest request);
     Task<Friendlist> AddFriend(Friendlist friendlist, string battleTag);
     Task<Friendlist> RemoveFriend(Friendlist friendlist, string battleTag);
@@ -39,8 +41,19 @@ public class FriendCommandHandler(
 
     public virtual async Task CreateFriendRequest(FriendRequest request)
     {
+        // Server-authoritative: FriendRequest is also a SignalR argument type,
+        // so whatever a client put in these fields is overwritten here.
+        request.CreatedAt = DateTime.UtcNow;
+        request.SeenAt = null;
         await _friendRepository.CreateFriendRequest(request);
         _friendRequestCache.Insert(request);
+    }
+
+    public virtual async Task MarkIncomingFriendRequestsSeen(string receiver)
+    {
+        var seenAt = DateTime.UtcNow;
+        await _friendRepository.MarkReceivedFriendRequestsSeen(receiver, seenAt);
+        _friendRequestCache.MarkReceivedSeen(receiver, seenAt);
     }
 
     public virtual async Task DeleteFriendRequest(FriendRequest request)

--- a/W3ChampionsStatisticService/Friends/FriendRepository.cs
+++ b/W3ChampionsStatisticService/Friends/FriendRepository.cs
@@ -1,4 +1,5 @@
 ﻿using MongoDB.Driver;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using W3C.Domain.Repositories;
@@ -44,6 +45,16 @@ public class FriendRepository(MongoClient mongoClient) : MongoDbRepositoryBase(m
     public async Task DeleteFriendRequest(FriendRequest request)
     {
         await Delete<FriendRequest>(r => r.Sender == request.Sender && r.Receiver == request.Receiver);
+    }
+
+    public async Task MarkReceivedFriendRequestsSeen(string receiver, DateTime seenAt)
+    {
+        // Only unseen requests: SeenAt records the FIRST acknowledgement and
+        // never moves after that.
+        var collection = CreateCollection<FriendRequest>();
+        await collection.UpdateManyAsync(
+            r => r.Receiver == receiver && r.SeenAt == null,
+            Builders<FriendRequest>.Update.Set(r => r.SeenAt, seenAt));
     }
 
     public async Task<bool> FriendRequestExists(FriendRequest request)

--- a/W3ChampionsStatisticService/Friends/FriendRequest.cs
+++ b/W3ChampionsStatisticService/Friends/FriendRequest.cs
@@ -1,3 +1,4 @@
+using System;
 using MongoDB.Bson;
 
 namespace W3ChampionsStatisticService.Friends;
@@ -7,4 +8,11 @@ public class FriendRequest(string sender, string receiver)
     public ObjectId Id { get; set; }
     public string Sender { get; set; } = sender;
     public string Receiver { get; set; } = receiver;
+    // Both nullable so requests created before these fields existed deserialize
+    // as "unknown" instead of a fabricated value. CreatedAt is stamped
+    // server-side on creation (FriendCommandHandler) — a client-supplied value
+    // is overwritten. SeenAt is null until the receiver acknowledges having
+    // seen the request via MarkIncomingFriendRequestsSeen.
+    public DateTime? CreatedAt { get; set; }
+    public DateTime? SeenAt { get; set; }
 }

--- a/W3ChampionsStatisticService/Friends/FriendRequestCache.cs
+++ b/W3ChampionsStatisticService/Friends/FriendRequestCache.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -16,6 +17,7 @@ public interface IFriendRequestCache
     Task<bool> FriendRequestExists(FriendRequest req);
     void Insert(FriendRequest req);
     void Delete(FriendRequest req);
+    void MarkReceivedSeen(string receiver, DateTime seenAt);
 }
 
 [Trace]
@@ -68,6 +70,17 @@ public class FriendRequestCache(MongoClient mongoClient) : MongoDbRepositoryBase
         lock (_lock)
         {
             _requests.RemoveAll(r => r.Sender == request.Sender && r.Receiver == request.Receiver);
+        }
+    }
+
+    public virtual void MarkReceivedSeen(string receiver, DateTime seenAt)
+    {
+        lock (_lock)
+        {
+            foreach (var request in _requests.Where(r => r.Receiver == receiver && r.SeenAt == null))
+            {
+                request.SeenAt = seenAt;
+            }
         }
     }
 

--- a/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
+++ b/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
@@ -37,7 +37,7 @@ public class WebsiteBackendHub(
     {
         // Check if any of the public handlers have no arguments, as we need them to have at least one argument due to tracing requirements.
         var methods = typeof(WebsiteBackendHub).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-        var allowedZeroArgMethods = new HashSet<string> { "LoadFriendListAndRequests", "LoadFriendsWithPictures" };
+        var allowedZeroArgMethods = new HashSet<string> { "LoadFriendListAndRequests", "LoadFriendsWithPictures", "MarkIncomingFriendRequestsSeen" };
         foreach (var methodInfo in methods)
         {
             if (methodInfo.IsSpecialName) continue;
@@ -142,6 +142,26 @@ public class WebsiteBackendHub(
         List<FriendRequest> sentRequests = await _friendRequestCache.LoadSentFriendRequests(currentUser);
         List<FriendRequest> receivedRequests = await _friendRequestCache.LoadReceivedFriendRequests(currentUser);
         await Clients.Caller.SendAsync(FriendResponseType.FriendResponseData.ToString(), friendList, sentRequests, receivedRequests);
+    }
+
+    public async Task MarkIncomingFriendRequestsSeen()
+    {
+        await this.MarkIncomingFriendRequestsSeenTraced(new PreventZeroArgumentHandler());
+    }
+
+    // The receiver acknowledges having seen their incoming friend requests
+    // (e.g. opened the list). Stamps SeenAt on every not-yet-seen request, then
+    // returns the refreshed received list so the caller's state stays in sync.
+    public async Task MarkIncomingFriendRequestsSeenTraced(PreventZeroArgumentHandler _)
+    {
+        var currentUser = _connections.GetUser(Context.ConnectionId)?.BattleTag;
+        if (currentUser == null)
+        {
+            return;
+        }
+        await _friendCommandHandler.MarkIncomingFriendRequestsSeen(currentUser);
+        List<FriendRequest> receivedRequests = await _friendRequestCache.LoadReceivedFriendRequests(currentUser);
+        await Clients.Caller.SendAsync(FriendResponseType.FriendResponseData.ToString(), null, null, receivedRequests);
     }
 
     // Required for backwards compatibility

--- a/WC3ChampionsStatisticService.UnitTests/Hubs/WebsiteBackendHubTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Hubs/WebsiteBackendHubTests.cs
@@ -51,6 +51,11 @@ public class TestFriendCommandHandler(TestFriendRepository repo, TestFriendListC
     }
 
     public Task CreateFriendRequest(FriendRequest request) => Task.CompletedTask;
+    public Task MarkIncomingFriendRequestsSeen(string receiver)
+    {
+        _friendRequestCache.MarkReceivedSeen(receiver, DateTime.UtcNow);
+        return Task.CompletedTask;
+    }
     public Task DeleteFriendRequest(FriendRequest request)
     {
         _friendRequestCache.Delete(request);
@@ -92,6 +97,13 @@ public class FakeFriendRequestCache : IFriendRequestCache
     public Task<bool> FriendRequestExists(FriendRequest req) => Task.FromResult(_requests.Exists(r => r.Sender == req.Sender && r.Receiver == req.Receiver));
     public void Insert(FriendRequest req) { _requests.Add(req); }
     public void Delete(FriendRequest req) { _requests.RemoveAll(r => r.Sender == req.Sender && r.Receiver == req.Receiver); }
+    public void MarkReceivedSeen(string receiver, DateTime seenAt)
+    {
+        foreach (var request in _requests.FindAll(r => r.Receiver == receiver && r.SeenAt == null))
+        {
+            request.SeenAt = seenAt;
+        }
+    }
     public void AddRequest(FriendRequest req) => _requests.Add(req); // For test setup
 }
 
@@ -165,6 +177,37 @@ public class WebsiteBackendHubTests
     private void SetHubContext(Hub hub, string connectionId)
     {
         typeof(Hub).GetProperty("Context").SetValue(hub, new HubCallerContextMock(connectionId));
+    }
+
+    [Test]
+    public async Task MarkIncomingFriendRequestsSeen_StampsOnlyUnseenReceivedRequests()
+    {
+        var alreadySeen = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var unseenIncoming = new FriendRequest("Sender#1111", "User#1234");
+        var seenIncoming = new FriendRequest("Sender#2222", "User#1234") { SeenAt = alreadySeen };
+        var someoneElses = new FriendRequest("Sender#1111", "Other#9999");
+        friendRequestCache.AddRequest(unseenIncoming);
+        friendRequestCache.AddRequest(seenIncoming);
+        friendRequestCache.AddRequest(someoneElses);
+        IFriendCommandHandler friendCommandHandler = new TestFriendCommandHandler(friendRepository, friendListCache, friendRequestCache);
+
+        var hub = CreateHub(friendCommandHandler);
+        connections.Add("conn1", new WebSocketUser { BattleTag = "User#1234", ConnectionId = "conn1" });
+        SetHubContext(hub, "conn1");
+
+        await hub.MarkIncomingFriendRequestsSeen();
+
+        Assert.That(unseenIncoming.SeenAt, Is.Not.Null);
+        Assert.That(seenIncoming.SeenAt, Is.EqualTo(alreadySeen), "SeenAt records the first acknowledgement and never moves");
+        Assert.That(someoneElses.SeenAt, Is.Null, "another receiver's requests are untouched");
+        mockCaller.Verify(
+            c => c.SendCoreAsync(
+                It.Is<string>(s => s.Contains("FriendResponseData")),
+                It.IsAny<object[]>(),
+                default
+            ),
+            Times.Once
+        );
     }
 
     [Test]


### PR DESCRIPTION
## What

- `FriendRequest` gains nullable `CreatedAt` and `SeenAt`.
- `CreatedAt` is stamped server-side in `FriendCommandHandler.CreateFriendRequest` — `FriendRequest` is also a SignalR argument type, so a client-supplied value is overwritten.
- New hub method `MarkIncomingFriendRequestsSeen` (zero-arg, follows the existing `PreventZeroArgumentHandler` pattern): stamps `SeenAt` on every not-yet-seen request received by the caller, updates the in-memory cache coherently, and returns the refreshed received list to the caller. `SeenAt` records the *first* acknowledgement and never moves.

## Why

The launcher is growing a notification center, and friend requests are the one event where the client genuinely cannot infer what the player has already seen: a login with three pending requests looks identical whether they are new or week-old. With these fields the launcher can surface offline-received requests as unread and keep quiet about acknowledged ones.

## Compatibility

- Both fields nullable: existing Mongo documents deserialize with `null` ("predates the field"), no migration.
- Existing clients are unaffected — the new fields serialize alongside the existing ones and the new hub method is additive.
- Only unseen requests are touched by the mark-seen update (`SeenAt == null` filter), so repeated calls are idempotent.

## Tests

`MarkIncomingFriendRequestsSeen_StampsOnlyUnseenReceivedRequests` covers: unseen stamped, already-seen untouched, other receivers untouched, caller receives the refreshed list. All 39 hub tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)