### PR TITLE
Push a discriminated FriendChangeEvent for live friend events

### DIFF
--- a/W3ChampionsStatisticService/Friends/FriendChange.cs
+++ b/W3ChampionsStatisticService/Friends/FriendChange.cs
@@ -1,0 +1,24 @@
+namespace W3ChampionsStatisticService.Friends;
+
+// Wire values for FriendChange.ChangeType. String constants rather than an
+// enum so the serialized value is stable and self-describing for every client.
+public static class FriendChangeType
+{
+    public const string RequestReceived = "RequestReceived";
+    public const string RequestRetracted = "RequestRetracted";
+    public const string RequestAccepted = "RequestAccepted";
+}
+
+/// <summary>
+/// A discriminated live friend event, pushed as <c>FriendChangeEvent</c> to the
+/// player it affects. <c>FriendResponseData</c> stays the state carrier; this
+/// message names WHAT changed and WHO did it — which the argument null-shape of
+/// <c>FriendResponseData</c> only implies, and a server refactor could silently
+/// change. <c>Actor</c> is the other player's battleTag: the one who sent,
+/// retracted, or accepted.
+/// </summary>
+public class FriendChange(string changeType, string actor)
+{
+    public string ChangeType { get; set; } = changeType;
+    public string Actor { get; set; } = actor;
+}

--- a/W3ChampionsStatisticService/Friends/FriendResponseType.cs
+++ b/W3ChampionsStatisticService/Friends/FriendResponseType.cs
@@ -21,6 +21,10 @@ public class FriendResponseType
     {
         get { return new FriendResponseType("FriendsWithPictures"); }
     }
+    public static FriendResponseType FriendChangeEvent
+    {
+        get { return new FriendResponseType("FriendChangeEvent"); }
+    }
 
     public override string ToString()
     {

--- a/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
+++ b/W3ChampionsStatisticService/Hubs/WebsiteBackendHub.cs
@@ -214,6 +214,7 @@ public class WebsiteBackendHub(
 
             var requestsReceivedByOtherPlayer = await _friendRequestCache.LoadReceivedFriendRequests(req.Receiver);
             await PushFriendResponseDataToPlayer(req.Receiver, null, null, requestsReceivedByOtherPlayer);
+            await PushFriendChangeToPlayer(req.Receiver, new FriendChange(FriendChangeType.RequestReceived, req.Sender));
         }
         catch (Exception ex)
         {
@@ -260,6 +261,7 @@ public class WebsiteBackendHub(
 
             var requestsReceivedByOtherPlayer = await _friendRequestCache.LoadReceivedFriendRequests(req.Receiver);
             await PushFriendResponseDataToPlayer(req.Receiver, null, null, requestsReceivedByOtherPlayer);
+            await PushFriendChangeToPlayer(req.Receiver, new FriendChange(FriendChangeType.RequestRetracted, req.Sender));
         }
         catch (Exception ex)
         {
@@ -321,6 +323,7 @@ public class WebsiteBackendHub(
             await PushFriendsWithPicturesToPlayer(req.Sender);
             var requestsSentByOtherPlayer = await _friendRequestCache.LoadSentFriendRequests(req.Sender);
             await PushFriendResponseDataToPlayer(req.Sender, senderFriendlist, requestsSentByOtherPlayer);
+            await PushFriendChangeToPlayer(req.Sender, new FriendChange(FriendChangeType.RequestAccepted, req.Receiver));
         }
         catch (Exception ex)
         {
@@ -365,6 +368,10 @@ public class WebsiteBackendHub(
                 $"Friend request from {req.Sender} denied!"
             );
 
+            // No FriendChangeEvent on purpose: deny and block must stay
+            // indistinguishable to the sender (block pushes this same shape),
+            // and "your request was denied" is not an event worth announcing —
+            // the request just disappears from the sender's sent list.
             var sentRequests = await _friendRequestCache.LoadSentFriendRequests(req.Sender);
             await PushFriendResponseDataToPlayer(req.Sender, null, sentRequests);
         }
@@ -600,6 +607,20 @@ public class WebsiteBackendHub(
         await Clients
             .Client(player.ConnectionId)
             .SendAsync(FriendResponseType.FriendResponseData.ToString(), friendList, sentRequests, receivedRequests, message);
+    }
+
+    // Additive discriminated push for live friend events. FriendResponseData
+    // stays the state carrier; this names WHAT changed and WHO did it, which
+    // the null-shape of the state push only implies. Clients that do not
+    // subscribe to FriendChangeEvent are unaffected.
+    private async Task PushFriendChangeToPlayer(string battleTag, FriendChange change)
+    {
+        var player = _connections.GetUsers().FirstOrDefault(x => x.BattleTag == battleTag);
+        if (player?.ConnectionId == null)
+            return;
+        await Clients
+            .Client(player.ConnectionId)
+            .SendAsync(FriendResponseType.FriendChangeEvent.ToString(), change);
     }
 
     private async Task PushFriendsWithPicturesToPlayer(string battleTag)

--- a/WC3ChampionsStatisticService.UnitTests/Hubs/WebsiteBackendHubTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/Hubs/WebsiteBackendHubTests.cs
@@ -305,6 +305,67 @@ public class WebsiteBackendHubTests
         );
     }
 
+    [Test]
+    public async Task MakeFriendRequest_PushesFriendChangeEventToConnectedReceiver()
+    {
+        personalSettingsRepo.Setup(r => r.Find(It.IsAny<string>())).ReturnsAsync(new PersonalSetting("Receiver#1"));
+        friendListCache.Upsert(new Friendlist("Sender#1"));
+        friendListCache.Upsert(new Friendlist("Receiver#1"));
+        IFriendCommandHandler friendCommandHandler = new TestFriendCommandHandler(friendRepository, friendListCache, friendRequestCache);
+
+        var hub = CreateHub(friendCommandHandler);
+        connections.Add("conn1", new WebSocketUser { BattleTag = "Sender#1", ConnectionId = "conn1" });
+        connections.Add("conn2", new WebSocketUser { BattleTag = "Receiver#1", ConnectionId = "conn2" });
+        var receiverProxy = new Mock<ISingleClientProxy>();
+        mockClients.Setup(c => c.Client("conn2")).Returns(receiverProxy.Object);
+        SetHubContext(hub, "conn1");
+
+        await hub.MakeFriendRequest(new FriendRequest("Sender#1", "Receiver#1"));
+
+        receiverProxy.Verify(
+            c => c.SendCoreAsync(
+                "FriendChangeEvent",
+                It.Is<object[]>(args => args.Length == 1
+                    && ((FriendChange)args[0]).ChangeType == FriendChangeType.RequestReceived
+                    && ((FriendChange)args[0]).Actor == "Sender#1"),
+                default
+            ),
+            Times.Once
+        );
+    }
+
+    [Test]
+    public async Task DenyIncomingFriendRequest_SendsNoFriendChangeEventToSender()
+    {
+        // Deliberate: deny and block push the same shape to the sender and must
+        // stay indistinguishable, so neither carries a change event.
+        friendRequestCache.AddRequest(new FriendRequest("Sender#1", "Receiver#1"));
+        friendListCache.Upsert(new Friendlist("Receiver#1"));
+        IFriendCommandHandler friendCommandHandler = new TestFriendCommandHandler(friendRepository, friendListCache, friendRequestCache);
+
+        var hub = CreateHub(friendCommandHandler);
+        connections.Add("conn1", new WebSocketUser { BattleTag = "Receiver#1", ConnectionId = "conn1" });
+        connections.Add("conn2", new WebSocketUser { BattleTag = "Sender#1", ConnectionId = "conn2" });
+        var senderProxy = new Mock<ISingleClientProxy>();
+        mockClients.Setup(c => c.Client("conn2")).Returns(senderProxy.Object);
+        SetHubContext(hub, "conn1");
+
+        await hub.DenyIncomingFriendRequest(new FriendRequest("Sender#1", "Receiver#1"));
+
+        senderProxy.Verify(
+            c => c.SendCoreAsync(
+                It.Is<string>(s => s.Contains("FriendResponseData")),
+                It.IsAny<object[]>(),
+                default
+            ),
+            Times.Once
+        );
+        senderProxy.Verify(
+            c => c.SendCoreAsync("FriendChangeEvent", It.IsAny<object[]>(), default),
+            Times.Never
+        );
+    }
+
     [TestCase("AcceptIncomingFriendRequest", "Receiver#1")]
     [TestCase("DenyIncomingFriendRequest", "Receiver#1")]
     [TestCase("DeleteOutgoingFriendRequest", "Sender#1")]


### PR DESCRIPTION
## What

A new additive SignalR message, `FriendChangeEvent`, pushed to the affected player next to the existing `FriendResponseData` state push:

| Hub method | Pushed to | ChangeType | Actor |
|---|---|---|---|
| `MakeFriendRequest` | Receiver | `RequestReceived` | sender |
| `DeleteOutgoingFriendRequest` | Receiver | `RequestRetracted` | sender |
| `AcceptIncomingFriendRequest` | Sender | `RequestAccepted` | accepter |

`DenyIncomingFriendRequest` and `BlockIncomingFriendRequest` deliberately send **no** change event: they push the same `FriendResponseData` shape to the sender today and must stay indistinguishable (and "your request was denied" is not an event worth announcing — the request just disappears from the sent list).

## Why

`FriendResponseData` carries several distinct events under one message name, separated only by which arguments each call site leaves null. A client that wants to react to a *live* event (the launcher's notification center wiring "X sent you a friend request") can only infer it from that null-shape — an observation, not a contract, that a server refactor can change without any client failing to compile. `FriendChangeEvent` makes the event explicit and names the subject.

## Compatibility

Strictly additive: `FriendResponseData` is byte-for-byte unchanged, and clients that do not subscribe to `FriendChangeEvent` never see it.

## Tests

- `MakeFriendRequest_PushesFriendChangeEventToConnectedReceiver` — receiver gets `{RequestReceived, Sender#1}`.
- `DenyIncomingFriendRequest_SendsNoFriendChangeEventToSender` — the deliberate omission is pinned by a test.

All 40 hub tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)