### PR TITLE
feat(lag-reports): working date filters, a wider filter surface, and grouped counts

### DIFF
--- a/W3ChampionsStatisticService/LagReports/LagReport.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReport.cs
@@ -43,6 +43,13 @@ public class LagReport : IIdentifiable
     public List<LagReportPlayer> Players { get; set; } = [];
 
     /// <summary>
+    /// Materialized Players.Count, kept in step by UpsertPlayerData (an $inc beside its
+    /// $push) and backfilled once onto older documents — Mongo cannot filter on an
+    /// array's length, so the min/maxPlayers filters need it as a real field.
+    /// </summary>
+    public int PlayerCount { get; set; }
+
+    /// <summary>
     /// Server-side ping data fetched from flo-stats-service after the game ends.
     /// Null until the match-finished handler populates it.
     /// </summary>

--- a/W3ChampionsStatisticService/LagReports/LagReportController.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportController.cs
@@ -35,6 +35,7 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
     private const int MaxAnnotationTextLength = 1000;
 
     private const int MaxPageSize = 100;
+    private const int MaxBattleTagBuckets = 500;
 
     /// <summary>
     /// Submit a lag report — called by the launcher for each player (explicit or auto).
@@ -136,6 +137,12 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
             return BadRequest($"groupBy must be one of: {string.Join(", ", LagReportAggregateDimensions.All)}");
         }
         req.GroupBy = groupBy;
+        // Ceiling for the one dimension that uses Limit (battleTag — the others return
+        // all their buckets and ignore it). Raise it if full-cap responses become routine:
+        // exactly 500 buckets back means the ranking truncated, and real submitters may be
+        // missing from badges and leaderboards (missing, never wrong — returned buckets
+        // stay exact). Lower it only if payload or latency ever becomes a concern.
+        req.Limit = Math.Clamp(req.Limit, 1, MaxBattleTagBuckets);
 
         var buckets = await _lagReportRepository.GetAggregate(req);
         return Ok(new { Buckets = buckets });

--- a/W3ChampionsStatisticService/LagReports/LagReportController.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportController.cs
@@ -118,6 +118,29 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
         return Ok(new { Items = listItems, Total = total });
     }
 
+    /// <summary>Admin: counts grouped by one dimension, honoring the list filters.</summary>
+    [HttpGet("aggregate")]
+    [BearerHasPermissionFilter(Permission = EPermission.Proxies)]
+    public async Task<IActionResult> GetAggregate([FromQuery] LagReportAggregateRequest req)
+    {
+        var validationError = LagReportQueryValidation.FirstError(req);
+        if (validationError != null)
+        {
+            return BadRequest(validationError);
+        }
+
+        var groupBy = LagReportAggregateDimensions.All.FirstOrDefault(d =>
+            string.Equals(d, req.GroupBy, StringComparison.OrdinalIgnoreCase));
+        if (groupBy == null)
+        {
+            return BadRequest($"groupBy must be one of: {string.Join(", ", LagReportAggregateDimensions.All)}");
+        }
+        req.GroupBy = groupBy;
+
+        var buckets = await _lagReportRepository.GetAggregate(req);
+        return Ok(new { Buckets = buckets });
+    }
+
     /// <summary>Admin: get a single lag report with full diagnostics data.</summary>
     [HttpGet("{id}")]
     [BearerHasPermissionFilter(Permission = EPermission.Proxies)]

--- a/W3ChampionsStatisticService/LagReports/LagReportController.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportController.cs
@@ -80,6 +80,12 @@ public class LagReportController(LagReportRepository lagReportRepository, IFloSt
     [BearerHasPermissionFilter(Permission = EPermission.Proxies)]
     public async Task<IActionResult> GetReports([FromQuery] LagReportQueryRequest req)
     {
+        var validationError = LagReportQueryValidation.FirstError(req);
+        if (validationError != null)
+        {
+            return BadRequest(validationError);
+        }
+
         req.PageSize = Math.Clamp(req.PageSize, 1, MaxPageSize);
         req.Page = Math.Max(req.Page, 0);
 

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -249,14 +249,23 @@ public class LagReportQueryRequest
 {
     public string BattleTag { get; set; }
     public string GameSearch { get; set; }
-    public string ServerName { get; set; }
+
+    /// <summary>Server-name prefixes, OR'd together — repeat the query param to send several.
+    /// A single value binds the same way, so existing callers are unaffected.</summary>
+    public List<string> ServerName { get; set; }
+
     public string ProxyName { get; set; }
     public string ProxyIp { get; set; }
     public string DateFrom { get; set; }
     public string DateTo { get; set; }
-    public string IssueCategory { get; set; }
+
+    /// <summary>Issue categories, OR'd together: a report matches when any player carries any
+    /// of them — players self-report one incident inconsistently, and OR sees it whole.</summary>
+    public List<string> IssueCategory { get; set; }
+
     [Microsoft.AspNetCore.Mvc.FromQuery(Name = "connection_issue_tag")]
-    public string ConnectionIssueTag { get; set; }
+    public List<string> ConnectionIssueTag { get; set; }
+
     public bool? ExplicitOnly { get; set; }
     public int Page { get; set; } = 0;
     public int PageSize { get; set; } = 20;

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -254,6 +254,9 @@ public class LagReportQueryRequest
     /// A single value binds the same way, so existing callers are unaffected.</summary>
     public List<string> ServerName { get; set; }
 
+    /// <summary>Exact node ids, OR'd together — repeat the query param to send several.</summary>
+    public List<int> ServerNodeId { get; set; }
+
     public string ProxyName { get; set; }
     public string ProxyIp { get; set; }
     public string DateFrom { get; set; }

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -276,8 +276,22 @@ public class LagReportQueryRequest
     public int? MinPlayers { get; set; }
     public int? MaxPlayers { get; set; }
 
+    /// <summary>Keep only reports tied to players with at least this many submissions
+    /// (or appearances, see RepeatMode) inside the filtered window. Below 2 = off.</summary>
+    public int? MinRepeat { get; set; }
+
+    /// <summary>"submitted" (default): the qualifying player personally submitted the report.
+    /// "involved": appearing in it is enough.</summary>
+    public string RepeatMode { get; set; }
+
     public int Page { get; set; } = 0;
     public int PageSize { get; set; } = 20;
+}
+
+public static class LagReportRepeatModes
+{
+    public const string Submitted = "submitted";
+    public const string Involved = "involved";
 }
 
 public static class LagReportQueryValidation
@@ -303,6 +317,13 @@ public static class LagReportQueryValidation
             {
                 return $"Unknown connection_issue_tag '{tag}'.";
             }
+        }
+
+        if (req.RepeatMode != null
+            && !string.Equals(req.RepeatMode, LagReportRepeatModes.Submitted, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(req.RepeatMode, LagReportRepeatModes.Involved, StringComparison.OrdinalIgnoreCase))
+        {
+            return $"repeatMode must be '{LagReportRepeatModes.Submitted}' or '{LagReportRepeatModes.Involved}'.";
         }
 
         return null;

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -274,6 +274,35 @@ public class LagReportQueryRequest
     public int PageSize { get; set; } = 20;
 }
 
+public static class LagReportQueryValidation
+{
+    /// <summary>
+    /// First problem with the request's filter values, or null. Unknown values turn into a
+    /// 400 rather than silently matching nothing (or dropping the condition and matching
+    /// everything) — a stale link or a typo should say so.
+    /// </summary>
+    public static string FirstError(LagReportQueryRequest req)
+    {
+        foreach (var category in req.IssueCategory ?? [])
+        {
+            if (!Enum.TryParse<EIssueCategory>(category, out _))
+            {
+                return $"Unknown issueCategory '{category}'.";
+            }
+        }
+
+        foreach (var tag in req.ConnectionIssueTag ?? [])
+        {
+            if (!Enum.TryParse<ELagReportTag>(tag, ignoreCase: true, out _))
+            {
+                return $"Unknown connection_issue_tag '{tag}'.";
+            }
+        }
+
+        return null;
+    }
+}
+
 // ── Admin list item ───────────────────────────────────────────────────
 
 public class LagReportListItem

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -309,6 +309,51 @@ public static class LagReportQueryValidation
     }
 }
 
+// ── Admin aggregate ───────────────────────────────────────────────────
+
+public static class LagReportAggregateDimensions
+{
+    public const string Day = "day";
+    public const string Category = "category";
+    public const string Server = "server";
+    public const string Proxy = "proxy";
+    public static readonly string[] All = [Day, Category, Server, Proxy];
+}
+
+/// <summary>
+/// Counts over the report corpus grouped by one dimension. Inherits the list
+/// endpoint's filter surface, so every filter narrows the aggregation exactly
+/// as it narrows the list; Page/PageSize are ignored.
+/// </summary>
+public class LagReportAggregateRequest : LagReportQueryRequest
+{
+    public string GroupBy { get; set; }
+}
+
+/// <summary>
+/// One aggregation bucket. Which key/extra fields are set depends on the
+/// dimension; unset ones are omitted from the JSON.
+/// </summary>
+public class LagReportAggregateBucket
+{
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Day { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ServerNodeId { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string ServerNodeName { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Category { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string ProxyName { get; set; }
+
+    public long Count { get; set; }
+}
+
 // ── Admin list item ───────────────────────────────────────────────────
 
 public class LagReportListItem

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -318,7 +318,8 @@ public static class LagReportAggregateDimensions
     public const string Category = "category";
     public const string Server = "server";
     public const string Proxy = "proxy";
-    public static readonly string[] All = [Day, NodeDay, Category, Server, Proxy];
+    public const string BattleTag = "battleTag";
+    public static readonly string[] All = [Day, NodeDay, Category, Server, Proxy, BattleTag];
 }
 
 /// <summary>
@@ -329,6 +330,9 @@ public static class LagReportAggregateDimensions
 public class LagReportAggregateRequest : LagReportQueryRequest
 {
     public string GroupBy { get; set; }
+
+    /// <summary>Bucket cap for the unbounded-cardinality dimension (battleTag).</summary>
+    public int Limit { get; set; } = 50;
 }
 
 /// <summary>
@@ -352,6 +356,9 @@ public class LagReportAggregateBucket
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string ProxyName { get; set; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string BattleTag { get; set; }
+
     public long Count { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -362,6 +369,14 @@ public class LagReportAggregateBucket
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<LagReportCategoryCount> TopCategories { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? DistinctNodes { get; set; }
+
+    /// <summary>battleTag dimension: reports this player submitted themselves
+    /// (their own IsExplicit entry), as opposed to Count = reports they appear in.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? SubmittedCount { get; set; }
 }
 
 public class LagReportCategoryCount

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -270,6 +270,12 @@ public class LagReportQueryRequest
     public List<string> ConnectionIssueTag { get; set; }
 
     public bool? ExplicitOnly { get; set; }
+
+    /// <summary>Bounds on the game's player count (the materialized PlayerCount field).
+    /// Null or non-positive means unbounded on that end.</summary>
+    public int? MinPlayers { get; set; }
+    public int? MaxPlayers { get; set; }
+
     public int Page { get; set; } = 0;
     public int PageSize { get; set; } = 20;
 }

--- a/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportDtos.cs
@@ -314,10 +314,11 @@ public static class LagReportQueryValidation
 public static class LagReportAggregateDimensions
 {
     public const string Day = "day";
+    public const string NodeDay = "node-day";
     public const string Category = "category";
     public const string Server = "server";
     public const string Proxy = "proxy";
-    public static readonly string[] All = [Day, Category, Server, Proxy];
+    public static readonly string[] All = [Day, NodeDay, Category, Server, Proxy];
 }
 
 /// <summary>
@@ -351,6 +352,21 @@ public class LagReportAggregateBucket
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string ProxyName { get; set; }
 
+    public long Count { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? ExplicitCount { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? DistinctPlayers { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<LagReportCategoryCount> TopCategories { get; set; }
+}
+
+public class LagReportCategoryCount
+{
+    public string Category { get; set; }
     public long Count { get; set; }
 }
 

--- a/W3ChampionsStatisticService/LagReports/LagReportPlayerCountBackfillService.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportPlayerCountBackfillService.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using W3ChampionsStatisticService.Ports;
+
+namespace W3ChampionsStatisticService.LagReports;
+
+/// <summary>
+/// One-shot startup backfill of LagReport.PlayerCount onto documents written before the field
+/// existed, so the min/maxPlayers filters cover historical reports. Same shape as
+/// <see cref="LagReportSearchBackfillService"/>: a marker in the HandlerVersions store gates it
+/// to one run, and the underlying UpdateMany is itself idempotent, so a crash before the marker
+/// is written just resumes next start.
+/// </summary>
+public class LagReportPlayerCountBackfillService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<LagReportPlayerCountBackfillService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            using var scope = scopeFactory.CreateScope();
+            var versions = scope.ServiceProvider.GetRequiredService<IVersionRepository>();
+
+            var marker = await versions.GetLastVersion<LagReportPlayerCountBackfillService>();
+            if (marker.Version != ObjectId.Empty.ToString())
+            {
+                return; // Already backfilled.
+            }
+
+            var repository = scope.ServiceProvider.GetRequiredService<LagReportRepository>();
+            var updated = await repository.BackfillPlayerCounts(stoppingToken);
+            await versions.SaveLastVersion<LagReportPlayerCountBackfillService>(ObjectId.GenerateNewId().ToString());
+
+            logger.LogInformation("LagReport player-count backfill complete: {Count} document(s) updated", updated);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "LagReport player-count backfill failed");
+        }
+    }
+}

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -217,12 +217,17 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
         return req.GroupBy switch
         {
             LagReportAggregateDimensions.Day => await AggregateByDay(collection, match),
+            LagReportAggregateDimensions.NodeDay => await AggregateByNodeDay(collection, match),
             LagReportAggregateDimensions.Category => await AggregateByCategory(collection, match),
             LagReportAggregateDimensions.Server => await AggregateByServer(collection, match),
             LagReportAggregateDimensions.Proxy => await AggregateByProxy(collection, match),
             _ => throw new ArgumentException($"Unsupported groupBy '{req.GroupBy}'", nameof(req)),
         };
     }
+
+    // How many category chips a node-day bucket carries; mirrors what the grouped
+    // view's headers display.
+    private const int NodeDayTopCategories = 4;
 
     /// <summary>$dateToString runs in UTC when no timezone is given — the same reading
     /// of "day" the date filters use for bare dates.</summary>
@@ -271,6 +276,107 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
         {
             Day = d["_id"].AsString,
             Count = d["count"].ToInt64(),
+        }).ToList();
+    }
+
+    private static async Task<List<LagReportAggregateBucket>> AggregateByNodeDay(
+        IMongoCollection<LagReport> collection, FilterDefinition<LagReport> match)
+    {
+        // Core buckets: count, submitted count, and distinct players per node × day.
+        // "$Players.BattleTag" expands to the array of tags per report; $push makes an
+        // array of those arrays, and the $reduce/$setUnion collapses it to a set.
+        // Grouped by (day, nodeId) only — a node rename mid-window must not split the
+        // bucket, and the categories join below is keyed the same way. The display name
+        // rides along as $first.
+        var coreTask = collection.Aggregate()
+            .Match(match)
+            .AppendStage<BsonDocument>(ThinProject("CreatedAt", "ServerNodeId", "ServerNodeName", "HasExplicitReport", "Players.BattleTag"))
+            .AppendStage<BsonDocument>(Stage("$group", new BsonDocument
+            {
+                {
+                    "_id",
+                    new BsonDocument
+                    {
+                        { "day", DayOfCreatedAt() },
+                        { "nodeId", "$ServerNodeId" },
+                    }
+                },
+                { "nodeName", new BsonDocument("$first", "$ServerNodeName") },
+                { "count", new BsonDocument("$sum", 1) },
+                { "explicitCount", new BsonDocument("$sum", new BsonDocument("$cond", new BsonArray { "$HasExplicitReport", 1, 0 })) },
+                { "playerSets", new BsonDocument("$push", "$Players.BattleTag") },
+            }))
+            .AppendStage<BsonDocument>(Stage("$project", new BsonDocument
+            {
+                { "nodeName", 1 },
+                { "count", 1 },
+                { "explicitCount", 1 },
+                {
+                    "distinctPlayers",
+                    new BsonDocument("$size", new BsonDocument("$reduce", new BsonDocument
+                    {
+                        { "input", "$playerSets" },
+                        { "initialValue", new BsonArray() },
+                        { "in", new BsonDocument("$setUnion", new BsonArray { "$$value", "$$this" }) },
+                    }))
+                },
+            }))
+            .AppendStage<BsonDocument>(Stage("$sort", new BsonDocument { { "_id.day", 1 }, { "count", -1 }, { "_id.nodeId", 1 } }))
+            .ToListAsync();
+
+        // Category occurrence counts per node × day, stitched onto the core buckets
+        // afterwards — a per-group top-N inside one pipeline needs operators newer
+        // than the deployment guarantees, and this second pass is just as cheap.
+        var categoriesTask = collection.Aggregate()
+            .Match(match)
+            .AppendStage<BsonDocument>(ThinProject("CreatedAt", "ServerNodeId", "Players.IssueCategories"))
+            .AppendStage<BsonDocument>(Stage("$unwind", "$Players"))
+            .AppendStage<BsonDocument>(Stage("$unwind", "$Players.IssueCategories"))
+            .AppendStage<BsonDocument>(Stage("$group", new BsonDocument
+            {
+                {
+                    "_id",
+                    new BsonDocument
+                    {
+                        { "day", DayOfCreatedAt() },
+                        { "nodeId", "$ServerNodeId" },
+                        { "category", "$Players.IssueCategories" },
+                    }
+                },
+                { "count", new BsonDocument("$sum", 1) },
+            }))
+            .ToListAsync();
+
+        await Task.WhenAll(coreTask, categoriesTask);
+
+        var topCategories = categoriesTask.Result
+            .GroupBy(d => (Day: d["_id"]["day"].AsString, NodeId: IntOrZero(d["_id"]["nodeId"])))
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderByDescending(d => d["count"].ToInt64())
+                    .ThenBy(d => d["_id"]["category"].ToInt32())
+                    .Take(NodeDayTopCategories)
+                    .Select(d => new LagReportCategoryCount
+                    {
+                        Category = CategoryName(d["_id"]["category"]),
+                        Count = d["count"].ToInt64(),
+                    })
+                    .ToList());
+
+        return coreTask.Result.Select(d =>
+        {
+            var day = d["_id"]["day"].AsString;
+            var nodeId = IntOrZero(d["_id"]["nodeId"]);
+            return new LagReportAggregateBucket
+            {
+                Day = day,
+                ServerNodeId = nodeId,
+                ServerNodeName = StringOrEmpty(d["nodeName"]),
+                Count = d["count"].ToInt64(),
+                ExplicitCount = d["explicitCount"].ToInt64(),
+                DistinctPlayers = d["distinctPlayers"].ToInt32(),
+                TopCategories = topCategories.GetValueOrDefault((day, nodeId)) ?? [],
+            };
         }).ToList();
     }
 

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -52,6 +52,9 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
             // Explicit filter — most reports are auto-submitted, admins typically filter to explicit only
             new(Builders<LagReport>.IndexKeys.Ascending(r => r.HasExplicitReport)),
 
+            // Player-count filter (materialized Players.Count)
+            new(Builders<LagReport>.IndexKeys.Ascending(r => r.PlayerCount)),
+
             // Default list sort + date range filter
             new(Builders<LagReport>.IndexKeys.Descending(r => r.CreatedAt)),
 
@@ -104,6 +107,9 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
         // $setOnInsert the template fields only when creating a new document.
         var update = Builders<LagReport>.Update
             .Push(r => r.Players, playerData)
+            // Materialized Players.Count, atomic with the push — Mongo cannot filter on
+            // an array's length, so the min/maxPlayers filters read this field instead.
+            .Inc(r => r.PlayerCount, 1)
             .Set(r => r.UpdatedAt, DateTime.UtcNow)
             .SetOnInsert(r => r.Id, template.Id)
             .SetOnInsert(r => r.GameId, template.GameId)
@@ -290,6 +296,16 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
         if (req.ExplicitOnly == true)
         {
             filters.Add(builder.Eq(r => r.HasExplicitReport, true));
+        }
+
+        if (req.MinPlayers is > 0)
+        {
+            filters.Add(builder.Gte(r => r.PlayerCount, req.MinPlayers.Value));
+        }
+
+        if (req.MaxPlayers is > 0)
+        {
+            filters.Add(builder.Lte(r => r.PlayerCount, req.MaxPlayers.Value));
         }
 
         return filters;

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -236,14 +236,18 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
             filters.Add(builder.Regex("Players.ProxyIpSearch", PrefixPattern(req.ProxyIp)));
         }
 
-        if (!string.IsNullOrEmpty(req.DateFrom) && TryParseFilterDate(req.DateFrom, out var dateFrom))
+        if (!string.IsNullOrEmpty(req.DateFrom) && TryParseFilterDate(req.DateFrom, out var dateFrom, out _))
         {
             filters.Add(builder.Gte(r => r.CreatedAt, dateFrom));
         }
 
-        if (!string.IsNullOrEmpty(req.DateTo) && TryParseFilterDate(req.DateTo, out var dateTo))
+        if (!string.IsNullOrEmpty(req.DateTo) && TryParseFilterDate(req.DateTo, out var dateTo, out var toIsBareDate))
         {
-            filters.Add(builder.Lte(r => r.CreatedAt, dateTo));
+            // A bare date names a whole day, so its upper bound is the start of the next one.
+            // Taken literally it is midnight, which excludes every report of the day asked for.
+            filters.Add(toIsBareDate
+                ? builder.Lt(r => r.CreatedAt, dateTo.AddDays(1))
+                : builder.Lte(r => r.CreatedAt, dateTo));
         }
 
         if (!string.IsNullOrEmpty(req.IssueCategory) && Enum.TryParse<EIssueCategory>(req.IssueCategory, out var category))
@@ -267,18 +271,21 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
     }
 
     /// <summary>
-    /// Parses a date filter to UTC. The result must be a DateTime because CreatedAt is one:
-    /// comparing it against a DateTimeOffset compiles via the implicit conversion, but
-    /// leaves the field expression a Convert node the driver cannot translate, so every
-    /// date-filtered query throws instead of running.
+    /// Parses a date filter to UTC, reporting whether it named a bare day (yyyy-MM-dd, what
+    /// an &lt;input type="date"&gt; sends) or an instant. The result must be a DateTime because
+    /// CreatedAt is one: comparing it against a DateTimeOffset compiles via the implicit
+    /// conversion, but leaves the field expression a Convert node the driver cannot translate,
+    /// so every date-filtered query throws instead of running.
     /// AssumeUniversal fixes a bare date to the same window whatever the server's timezone;
     /// a value carrying its own offset keeps it.
     /// </summary>
-    private static bool TryParseFilterDate(string value, out DateTime parsed)
+    private static bool TryParseFilterDate(string value, out DateTime parsed, out bool isBareDate)
     {
         const DateTimeStyles styles = DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal;
 
-        return DateTime.TryParse(value, CultureInfo.InvariantCulture, styles, out parsed);
+        isBareDate = DateTime.TryParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture, styles, out parsed);
+
+        return isBareDate || DateTime.TryParse(value, CultureInfo.InvariantCulture, styles, out parsed);
     }
 
     /// <summary>

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -232,6 +232,11 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
                 builder.Regex(r => r.ServerNodeNameSearch, PrefixPattern(n)))));
         }
 
+        if (req.ServerNodeId is { Count: > 0 })
+        {
+            filters.Add(builder.In(r => r.ServerNodeId, req.ServerNodeId));
+        }
+
         if (!string.IsNullOrEmpty(req.ProxyName))
         {
             filters.Add(builder.Regex("Players.ProxyNameSearch", PrefixPattern(req.ProxyName)));

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -201,6 +201,161 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
         return (itemsTask.Result, totalTask.Result);
     }
 
+    /// <summary>
+    /// Counts grouped by one dimension (see LagReportAggregateDimensions), honoring
+    /// the same filters as GetReports. Everything runs inside Mongo as a single
+    /// aggregation per dimension (node-day runs two, concurrently) — no per-bucket
+    /// queries. The corpus is TTL-bounded to 90 days, so even the unwind-heavy
+    /// dimensions stay small.
+    /// </summary>
+    public async Task<List<LagReportAggregateBucket>> GetAggregate(LagReportAggregateRequest req)
+    {
+        var collection = CreateCollection<LagReport>();
+        var filters = BuildFilters(req);
+        var match = filters.Count > 0 ? Builders<LagReport>.Filter.And(filters) : Builders<LagReport>.Filter.Empty;
+
+        return req.GroupBy switch
+        {
+            LagReportAggregateDimensions.Day => await AggregateByDay(collection, match),
+            LagReportAggregateDimensions.Category => await AggregateByCategory(collection, match),
+            LagReportAggregateDimensions.Server => await AggregateByServer(collection, match),
+            LagReportAggregateDimensions.Proxy => await AggregateByProxy(collection, match),
+            _ => throw new ArgumentException($"Unsupported groupBy '{req.GroupBy}'", nameof(req)),
+        };
+    }
+
+    /// <summary>$dateToString runs in UTC when no timezone is given — the same reading
+    /// of "day" the date filters use for bare dates.</summary>
+    private static BsonDocument DayOfCreatedAt() =>
+        new("$dateToString", new BsonDocument { { "format", "%Y-%m-%d" }, { "date", "$CreatedAt" } });
+
+    private static BsonDocument Stage(string name, BsonValue body) => new(name, body);
+
+    /// <summary>
+    /// Thin the documents down to the fields a pipeline actually groups on, immediately
+    /// after the $match. Storage still reads whole documents — a projection cannot change
+    /// that — but the unwind/group stages then carry ~1KB per report instead of the full
+    /// ~77KB diagnostics payload.
+    /// </summary>
+    private static BsonDocument ThinProject(params string[] fields)
+    {
+        var body = new BsonDocument();
+        foreach (var field in fields)
+        {
+            body[field] = 1;
+        }
+        return new BsonDocument("$project", body);
+    }
+
+    /// <summary>Legacy documents can miss ServerNodeId/ServerNodeName — read them null-safely
+    /// so one old document cannot 500 the whole aggregation.</summary>
+    private static int IntOrZero(BsonValue value) => value == null || value.IsBsonNull ? 0 : value.ToInt32();
+
+    private static string StringOrEmpty(BsonValue value) => value == null || value.IsBsonNull ? "" : value.AsString;
+
+    private static async Task<List<LagReportAggregateBucket>> AggregateByDay(
+        IMongoCollection<LagReport> collection, FilterDefinition<LagReport> match)
+    {
+        var docs = await collection.Aggregate()
+            .Match(match)
+            .AppendStage<BsonDocument>(ThinProject("CreatedAt"))
+            .AppendStage<BsonDocument>(Stage("$group", new BsonDocument
+            {
+                { "_id", DayOfCreatedAt() },
+                { "count", new BsonDocument("$sum", 1) },
+            }))
+            .AppendStage<BsonDocument>(Stage("$sort", new BsonDocument("_id", 1)))
+            .ToListAsync();
+
+        return docs.Select(d => new LagReportAggregateBucket
+        {
+            Day = d["_id"].AsString,
+            Count = d["count"].ToInt64(),
+        }).ToList();
+    }
+
+    /// <summary>Counts category occurrences per player per report — the same semantics
+    /// as the admin UI's facet counts, where two players reporting Desync in one game
+    /// count twice.</summary>
+    private static async Task<List<LagReportAggregateBucket>> AggregateByCategory(
+        IMongoCollection<LagReport> collection, FilterDefinition<LagReport> match)
+    {
+        var docs = await collection.Aggregate()
+            .Match(match)
+            .AppendStage<BsonDocument>(ThinProject("Players.IssueCategories"))
+            .AppendStage<BsonDocument>(Stage("$unwind", "$Players"))
+            .AppendStage<BsonDocument>(Stage("$unwind", "$Players.IssueCategories"))
+            .AppendStage<BsonDocument>(Stage("$group", new BsonDocument
+            {
+                { "_id", "$Players.IssueCategories" },
+                { "count", new BsonDocument("$sum", 1) },
+            }))
+            .AppendStage<BsonDocument>(Stage("$sort", new BsonDocument { { "count", -1 }, { "_id", 1 } }))
+            .ToListAsync();
+
+        return docs.Select(d => new LagReportAggregateBucket
+        {
+            Category = CategoryName(d["_id"]),
+            Count = d["count"].ToInt64(),
+        }).ToList();
+    }
+
+    private static async Task<List<LagReportAggregateBucket>> AggregateByServer(
+        IMongoCollection<LagReport> collection, FilterDefinition<LagReport> match)
+    {
+        var docs = await collection.Aggregate()
+            .Match(match)
+            .AppendStage<BsonDocument>(ThinProject("ServerNodeId", "ServerNodeName"))
+            .AppendStage<BsonDocument>(Stage("$group", new BsonDocument
+            {
+                { "_id", new BsonDocument { { "nodeId", "$ServerNodeId" }, { "nodeName", "$ServerNodeName" } } },
+                { "count", new BsonDocument("$sum", 1) },
+            }))
+            .AppendStage<BsonDocument>(Stage("$sort", new BsonDocument { { "count", -1 }, { "_id.nodeId", 1 } }))
+            .ToListAsync();
+
+        return docs.Select(d => new LagReportAggregateBucket
+        {
+            ServerNodeId = IntOrZero(d["_id"]["nodeId"]),
+            ServerNodeName = StringOrEmpty(d["_id"]["nodeName"]),
+            Count = d["count"].ToInt64(),
+        }).ToList();
+    }
+
+    private static async Task<List<LagReportAggregateBucket>> AggregateByProxy(
+        IMongoCollection<LagReport> collection, FilterDefinition<LagReport> match)
+    {
+        var docs = await collection.Aggregate()
+            .Match(match)
+            .AppendStage<BsonDocument>(ThinProject("Players.ProxyName"))
+            .AppendStage<BsonDocument>(Stage("$unwind", "$Players"))
+            .AppendStage<BsonDocument>(Stage("$match", new BsonDocument("Players.ProxyName", new BsonDocument("$ne", BsonNull.Value))))
+            .AppendStage<BsonDocument>(Stage("$group", new BsonDocument
+            {
+                { "_id", "$Players.ProxyName" },
+                { "count", new BsonDocument("$sum", 1) },
+            }))
+            .AppendStage<BsonDocument>(Stage("$sort", new BsonDocument { { "count", -1 }, { "_id", 1 } }))
+            .ToListAsync();
+
+        return docs.Select(d => new LagReportAggregateBucket
+        {
+            ProxyName = d["_id"].AsString,
+            Count = d["count"].ToInt64(),
+        }).ToList();
+    }
+
+    /// <summary>Enums live in BSON as ints (no BsonRepresentation on the model); map
+    /// them to names here so the wire format matches the list endpoint's strings.</summary>
+    private static string CategoryName(BsonValue value)
+    {
+        if (value.IsString) return value.AsString;
+        var i = value.ToInt32();
+        return Enum.IsDefined(typeof(EIssueCategory), i)
+            ? ((EIssueCategory)i).ToString()
+            : i.ToString(CultureInfo.InvariantCulture);
+    }
+
     private static List<FilterDefinition<LagReport>> BuildFilters(LagReportQueryRequest req)
     {
         var builder = Builders<LagReport>.Filter;

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -165,6 +165,10 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
     {
         var collection = CreateCollection<LagReport>();
         var filters = BuildFilters(req);
+        if (req.MinRepeat is >= 2)
+        {
+            filters.Add(await ResolveRepeatFilter(collection, req));
+        }
         var hasFilter = filters.Count > 0;
         var filter = hasFilter ? Builders<LagReport>.Filter.And(filters) : Builders<LagReport>.Filter.Empty;
 
@@ -212,6 +216,10 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
     {
         var collection = CreateCollection<LagReport>();
         var filters = BuildFilters(req);
+        if (req.MinRepeat is >= 2)
+        {
+            filters.Add(await ResolveRepeatFilter(collection, req));
+        }
         var match = filters.Count > 0 ? Builders<LagReport>.Filter.And(filters) : Builders<LagReport>.Filter.Empty;
 
         return req.GroupBy switch
@@ -498,6 +506,58 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
         return Enum.IsDefined(typeof(EIssueCategory), i)
             ? ((EIssueCategory)i).ToString()
             : i.ToString(CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// The repeat filter needs a round-trip of its own: qualifying players are found by the
+    /// battleTag aggregation over the same filtered window (BuildFilters never consults
+    /// MinRepeat, so reusing it here cannot recurse), then pinned onto the main query as an
+    /// indexed condition on the lowercased BattleTagSearch shadow field. Zero qualifiers
+    /// yields a match-nothing filter — the honest result is an empty page, not an
+    /// unfiltered one.
+    /// </summary>
+    private static async Task<FilterDefinition<LagReport>> ResolveRepeatFilter(
+        IMongoCollection<LagReport> collection, LagReportQueryRequest req)
+    {
+        var baseFilters = BuildFilters(req);
+        var match = baseFilters.Count > 0 ? Builders<LagReport>.Filter.And(baseFilters) : Builders<LagReport>.Filter.Empty;
+
+        var submittedOnly = !string.Equals(req.RepeatMode, LagReportRepeatModes.Involved, StringComparison.OrdinalIgnoreCase);
+
+        var docs = await collection.Aggregate()
+            .Match(match)
+            .AppendStage<BsonDocument>(ThinProject("Players.BattleTag", "Players.IsExplicit"))
+            .AppendStage<BsonDocument>(Stage("$unwind", "$Players"))
+            .AppendStage<BsonDocument>(Stage("$group", new BsonDocument
+            {
+                { "_id", "$Players.BattleTag" },
+                { "count", new BsonDocument("$sum", 1) },
+                { "submittedCount", new BsonDocument("$sum", new BsonDocument("$cond", new BsonArray { "$Players.IsExplicit", 1, 0 })) },
+            }))
+            .AppendStage<BsonDocument>(Stage("$match",
+                new BsonDocument(submittedOnly ? "submittedCount" : "count", new BsonDocument("$gte", req.MinRepeat.Value))))
+            .ToListAsync();
+
+        var qualifying = docs
+            .Where(d => !d["_id"].IsBsonNull)
+            .Select(d => d["_id"].AsString.ToLowerInvariant())
+            .ToList();
+
+        var builder = Builders<LagReport>.Filter;
+        if (qualifying.Count == 0)
+        {
+            return builder.In(r => r.Id, Array.Empty<string>());
+        }
+
+        // submitted: the qualifying player personally submitted THIS report too;
+        // involved: appearing in it is enough. Plain $in on the dotted path is the
+        // multikey form — AnyIn would demand the terminal field itself be an array,
+        // and BattleTagSearch is a scalar inside one.
+        return submittedOnly
+            ? builder.ElemMatch(r => r.Players, Builders<LagReportPlayer>.Filter.And(
+                Builders<LagReportPlayer>.Filter.In(p => p.BattleTagSearch, qualifying),
+                Builders<LagReportPlayer>.Filter.Eq(p => p.IsExplicit, true)))
+            : builder.In("Players.BattleTagSearch", qualifying);
     }
 
     private static List<FilterDefinition<LagReport>> BuildFilters(LagReportQueryRequest req)

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -235,12 +236,12 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
             filters.Add(builder.Regex("Players.ProxyIpSearch", PrefixPattern(req.ProxyIp)));
         }
 
-        if (!string.IsNullOrEmpty(req.DateFrom) && DateTimeOffset.TryParse(req.DateFrom, out var dateFrom))
+        if (!string.IsNullOrEmpty(req.DateFrom) && TryParseFilterDate(req.DateFrom, out var dateFrom))
         {
             filters.Add(builder.Gte(r => r.CreatedAt, dateFrom));
         }
 
-        if (!string.IsNullOrEmpty(req.DateTo) && DateTimeOffset.TryParse(req.DateTo, out var dateTo))
+        if (!string.IsNullOrEmpty(req.DateTo) && TryParseFilterDate(req.DateTo, out var dateTo))
         {
             filters.Add(builder.Lte(r => r.CreatedAt, dateTo));
         }
@@ -263,6 +264,21 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
         }
 
         return filters;
+    }
+
+    /// <summary>
+    /// Parses a date filter to UTC. The result must be a DateTime because CreatedAt is one:
+    /// comparing it against a DateTimeOffset compiles via the implicit conversion, but
+    /// leaves the field expression a Convert node the driver cannot translate, so every
+    /// date-filtered query throws instead of running.
+    /// AssumeUniversal fixes a bare date to the same window whatever the server's timezone;
+    /// a value carrying its own offset keeps it.
+    /// </summary>
+    private static bool TryParseFilterDate(string value, out DateTime parsed)
+    {
+        const DateTimeStyles styles = DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal;
+
+        return DateTime.TryParse(value, CultureInfo.InvariantCulture, styles, out parsed);
     }
 
     /// <summary>

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -388,4 +388,23 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
         var result = await collection.UpdateManyAsync(filter, pipeline, cancellationToken: ct);
         return result.ModifiedCount;
     }
+
+    /// <summary>
+    /// One-shot backfill of PlayerCount onto documents written before the field existed —
+    /// BackfillSearchFields' pattern: idempotent via the exists guard, one server-side
+    /// pipeline UpdateMany. Returns documents updated.
+    /// </summary>
+    public async Task<long> BackfillPlayerCounts(CancellationToken ct = default)
+    {
+        var collection = CreateCollection<LagReport>();
+
+        var filter = Builders<LagReport>.Filter.Exists(r => r.PlayerCount, false);
+
+        var setStage = new BsonDocument("$set", new BsonDocument("PlayerCount",
+            new BsonDocument("$size", new BsonDocument("$ifNull", new BsonArray { "$Players", new BsonArray() }))));
+
+        var pipeline = new BsonDocumentStagePipelineDefinition<LagReport, LagReport>(new[] { setStage });
+        var result = await collection.UpdateManyAsync(filter, pipeline, cancellationToken: ct);
+        return result.ModifiedCount;
+    }
 }

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -221,6 +221,7 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
             LagReportAggregateDimensions.Category => await AggregateByCategory(collection, match),
             LagReportAggregateDimensions.Server => await AggregateByServer(collection, match),
             LagReportAggregateDimensions.Proxy => await AggregateByProxy(collection, match),
+            LagReportAggregateDimensions.BattleTag => await AggregateByBattleTag(collection, match, req.Limit),
             _ => throw new ArgumentException($"Unsupported groupBy '{req.GroupBy}'", nameof(req)),
         };
     }
@@ -449,6 +450,43 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
             ProxyName = d["_id"].AsString,
             Count = d["count"].ToInt64(),
         }).ToList();
+    }
+
+    private static async Task<List<LagReportAggregateBucket>> AggregateByBattleTag(
+        IMongoCollection<LagReport> collection, FilterDefinition<LagReport> match, int limit)
+    {
+        var docs = await collection.Aggregate()
+            .Match(match)
+            .AppendStage<BsonDocument>(ThinProject("Players.BattleTag", "Players.IsExplicit", "ServerNodeId"))
+            .AppendStage<BsonDocument>(Stage("$unwind", "$Players"))
+            .AppendStage<BsonDocument>(Stage("$group", new BsonDocument
+            {
+                { "_id", "$Players.BattleTag" },
+                { "count", new BsonDocument("$sum", 1) },
+                { "submittedCount", new BsonDocument("$sum", new BsonDocument("$cond", new BsonArray { "$Players.IsExplicit", 1, 0 })) },
+                { "nodes", new BsonDocument("$addToSet", "$ServerNodeId") },
+            }))
+            .AppendStage<BsonDocument>(Stage("$project", new BsonDocument
+            {
+                { "count", 1 },
+                { "submittedCount", 1 },
+                { "distinctNodes", new BsonDocument("$size", "$nodes") },
+            }))
+            // Submissions first: appearance count tracks activity, not distress, so
+            // the ranking (and the Limit cap) must protect actual submitters.
+            .AppendStage<BsonDocument>(Stage("$sort", new BsonDocument { { "submittedCount", -1 }, { "count", -1 }, { "_id", 1 } }))
+            .AppendStage<BsonDocument>(Stage("$limit", limit))
+            .ToListAsync();
+
+        return docs
+            .Where(d => !d["_id"].IsBsonNull)
+            .Select(d => new LagReportAggregateBucket
+            {
+                BattleTag = d["_id"].AsString,
+                Count = d["count"].ToInt64(),
+                SubmittedCount = d["submittedCount"].ToInt64(),
+                DistinctNodes = d["distinctNodes"].ToInt32(),
+            }).ToList();
     }
 
     /// <summary>Enums live in BSON as ints (no BsonRepresentation on the model); map

--- a/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
+++ b/W3ChampionsStatisticService/LagReports/LagReportRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -221,9 +222,14 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
             filters.Add(builder.Or(gameFilters));
         }
 
-        if (!string.IsNullOrEmpty(req.ServerName))
+        // A report matches when its server name starts with any of the given values.
+        // Each value stays a starts-with match, which MongoDB can answer from the
+        // index on ServerNodeNameSearch instead of checking every report.
+        var serverNames = (req.ServerName ?? []).Where(n => !string.IsNullOrEmpty(n)).ToList();
+        if (serverNames.Count > 0)
         {
-            filters.Add(builder.Regex(r => r.ServerNodeNameSearch, PrefixPattern(req.ServerName)));
+            filters.Add(builder.Or(serverNames.Select(n =>
+                builder.Regex(r => r.ServerNodeNameSearch, PrefixPattern(n)))));
         }
 
         if (!string.IsNullOrEmpty(req.ProxyName))
@@ -250,16 +256,30 @@ public class LagReportRepository(MongoClient mongoClient) : MongoDbRepositoryBas
                 : builder.Lte(r => r.CreatedAt, dateTo));
         }
 
-        if (!string.IsNullOrEmpty(req.IssueCategory) && Enum.TryParse<EIssueCategory>(req.IssueCategory, out var category))
+        // A report matches when any of its players reports any of the given categories.
+        // Values that don't name a known category are skipped, as before. The string
+        // field path makes this a plain "value in list" query that the index on
+        // Players.IssueCategories answers directly.
+        var categories = (req.IssueCategory ?? [])
+            .Select(c => Enum.TryParse<EIssueCategory>(c, out var parsed) ? parsed : (EIssueCategory?)null)
+            .Where(c => c.HasValue)
+            .Select(c => c.Value)
+            .ToList();
+        if (categories.Count > 0)
         {
-            filters.Add(builder.ElemMatch(r => r.Players, p => p.IssueCategories.Contains(category)));
+            filters.Add(builder.AnyIn("Players.IssueCategories", categories));
         }
 
         // ignoreCase: true — ELagReportTag has mixed-case members (LAN, LastMile); URL query params
         // shouldn't need exact casing (matches the wire converter's case-insensitive read).
-        if (!string.IsNullOrEmpty(req.ConnectionIssueTag) && Enum.TryParse<ELagReportTag>(req.ConnectionIssueTag, ignoreCase: true, out var tag))
+        var tags = (req.ConnectionIssueTag ?? [])
+            .Select(t => Enum.TryParse<ELagReportTag>(t, ignoreCase: true, out var parsed) ? parsed : (ELagReportTag?)null)
+            .Where(t => t.HasValue)
+            .Select(t => t.Value)
+            .ToList();
+        if (tags.Count > 0)
         {
-            filters.Add(builder.ElemMatch(r => r.Players, p => p.ConnectionIssueTags.Contains(tag)));
+            filters.Add(builder.AnyIn("Players.ConnectionIssueTags", tags));
         }
 
         if (req.ExplicitOnly == true)

--- a/W3ChampionsStatisticService/Program.cs
+++ b/W3ChampionsStatisticService/Program.cs
@@ -333,6 +333,7 @@ if (runBackfill == "true")
 // One-shot, self-gating backfill of the LagReport lowercased *Search fields onto pre-existing
 // documents. Runs automatically once (marker in HandlerVersions); a cheap no-op on later startups.
 builder.Services.AddHostedService<W3ChampionsStatisticService.LagReports.LagReportSearchBackfillService>();
+builder.Services.AddHostedService<W3ChampionsStatisticService.LagReports.LagReportPlayerCountBackfillService>();
 
 var app = builder.Build();
 

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -506,6 +506,101 @@ public class LagReportRepositoryTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task GetAggregate_ByDay_CountsPerUtcDay()
+    {
+        // 23:30 and 00:30 straddle a UTC midnight — each must land in its own bucket.
+        await SeedReportOnNode(30001, new DateTime(2026, 3, 1, 23, 30, 0, DateTimeKind.Utc), 1, "EU West");
+        await SeedReportOnNode(30002, new DateTime(2026, 3, 2, 0, 30, 0, DateTimeKind.Utc), 1, "EU West");
+        await SeedReportOnNode(30003, new DateTime(2026, 3, 2, 12, 0, 0, DateTimeKind.Utc), 1, "EU West");
+
+        var buckets = await _repo.GetAggregate(new LagReportAggregateRequest { GroupBy = LagReportAggregateDimensions.Day });
+
+        Assert.AreEqual(2, buckets.Count);
+        Assert.AreEqual("2026-03-01", buckets[0].Day);
+        Assert.AreEqual(1, buckets[0].Count);
+        Assert.AreEqual("2026-03-02", buckets[1].Day);
+        Assert.AreEqual(2, buckets[1].Count);
+    }
+
+    [Test]
+    public async Task GetAggregate_HonorsListFilters()
+    {
+        await SeedReportOnNode(31001, new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc), 1, "EU West");
+        await SeedReportOnNode(31002, new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc), 2, "US East");
+        await SeedReportOnNode(31003, new DateTime(2026, 3, 2, 12, 0, 0, DateTimeKind.Utc), 1, "EU West");
+
+        var byServer = await _repo.GetAggregate(new LagReportAggregateRequest
+        {
+            GroupBy = LagReportAggregateDimensions.Day,
+            ServerName = ["EU"],
+        });
+        Assert.AreEqual(2, byServer.Count);
+        Assert.IsTrue(byServer.TrueForAll(b => b.Count == 1));
+
+        var byDate = await _repo.GetAggregate(new LagReportAggregateRequest
+        {
+            GroupBy = LagReportAggregateDimensions.Day,
+            DateFrom = "2026-03-02",
+        });
+        Assert.AreEqual(1, byDate.Count);
+        Assert.AreEqual("2026-03-02", byDate[0].Day);
+    }
+
+    [Test]
+    public async Task GetAggregate_ByCategory_CountsOccurrencesPerPlayer()
+    {
+        var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);
+        var p1 = CreatePlayer("P1#1");
+        p1.IssueCategories = [EIssueCategory.Desync];
+        var p2 = CreatePlayer("P2#2");
+        p2.IssueCategories = [EIssueCategory.Desync, EIssueCategory.SpikeLag];
+        await SeedReportOnNode(33001, noon, 1, "EU West", p1, p2);
+
+        var buckets = await _repo.GetAggregate(new LagReportAggregateRequest { GroupBy = LagReportAggregateDimensions.Category });
+
+        // Two players naming Desync in one report count twice — occurrence semantics,
+        // matching the admin UI's facet counts.
+        Assert.AreEqual(2, buckets.Count);
+        Assert.AreEqual("Desync", buckets[0].Category);
+        Assert.AreEqual(2, buckets[0].Count);
+        Assert.AreEqual("SpikeLag", buckets[1].Category);
+        Assert.AreEqual(1, buckets[1].Count);
+    }
+
+    [Test]
+    public async Task GetAggregate_ByServer_CountsReportsPerNode()
+    {
+        var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);
+        await SeedReportOnNode(34001, noon, 1, "EU West");
+        await SeedReportOnNode(34002, noon, 1, "EU West");
+        await SeedReportOnNode(34003, noon, 2, "US East");
+
+        var buckets = await _repo.GetAggregate(new LagReportAggregateRequest { GroupBy = LagReportAggregateDimensions.Server });
+
+        Assert.AreEqual(2, buckets.Count);
+        Assert.AreEqual(1, buckets[0].ServerNodeId);
+        Assert.AreEqual("EU West", buckets[0].ServerNodeName);
+        Assert.AreEqual(2, buckets[0].Count);
+        Assert.AreEqual(2, buckets[1].ServerNodeId);
+        Assert.AreEqual(1, buckets[1].Count);
+    }
+
+    [Test]
+    public async Task GetAggregate_ByProxy_SkipsDirectPlayers()
+    {
+        var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);
+        var proxied = CreatePlayer("P1#1");
+        proxied.ProxyName = "EU-Proxy-1";
+        await SeedReportOnNode(35001, noon, 1, "EU West", proxied, CreatePlayer("P2#2"));
+
+        var buckets = await _repo.GetAggregate(new LagReportAggregateRequest { GroupBy = LagReportAggregateDimensions.Proxy });
+
+        Assert.AreEqual(1, buckets.Count);
+        Assert.AreEqual("EU-Proxy-1", buckets[0].ProxyName);
+        Assert.AreEqual(1, buckets[0].Count);
+    }
+
+    [Test]
     public async Task UpsertPlayerData_MaintainsPlayerCount()
     {
         // Two players added one at a time via UpsertPlayerData; the stored PlayerCount

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -506,6 +506,42 @@ public class LagReportRepositoryTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task UpsertPlayerData_MaintainsPlayerCount()
+    {
+        // Two players added one at a time via UpsertPlayerData; the stored PlayerCount
+        // must keep step with the Players array on its own.
+        var template = CreateTemplate(floGameId: 37001, gameId: 37001);
+
+        var id = await _repo.UpsertPlayerData(template.FloGameId, CreatePlayer("P1#1"), template);
+        await _repo.UpsertPlayerData(template.FloGameId, CreatePlayer("P2#2"), template);
+
+        var report = await _repo.GetById(id);
+        Assert.AreEqual(2, report.Players.Count);
+        Assert.AreEqual(2, report.PlayerCount, "PlayerCount must track Players.Count through the $inc");
+    }
+
+    [Test]
+    public async Task GetReports_FiltersByPlayerCountBounds()
+    {
+        // One solo report and one three-player report; the lower bound, the upper
+        // bound, and the two combined must each pick out the right one.
+        var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);
+        await SeedReportOnNode(37101, noon, 1, "EU West", CreatePlayer("Solo#1"));
+        await SeedReportOnNode(37102, noon, 1, "EU West",
+            CreatePlayer("A#1"), CreatePlayer("B#2"), CreatePlayer("C#3"));
+
+        var (bigGames, bigTotal) = await _repo.GetReports(new LagReportQueryRequest { MinPlayers = 2 });
+        Assert.AreEqual(1, bigTotal);
+        Assert.AreEqual(3, bigGames[0].Players.Count);
+
+        var (_, soloTotal) = await _repo.GetReports(new LagReportQueryRequest { MaxPlayers = 1 });
+        Assert.AreEqual(1, soloTotal);
+
+        var (_, bandTotal) = await _repo.GetReports(new LagReportQueryRequest { MinPlayers = 2, MaxPlayers = 3 });
+        Assert.AreEqual(1, bandTotal);
+    }
+
+    [Test]
     public async Task GetReports_FiltersByMultipleCategoriesAsOr()
     {
         var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -553,4 +553,26 @@ public class LagReportRepositoryTests : IntegrationTestBase
         var (_, total) = await _repo.GetReports(new LagReportQueryRequest { ServerNodeId = [1, 3] });
         Assert.AreEqual(2, total);
     }
+
+    [Test]
+    public void QueryValidation_RejectsUnknownValuesAndAcceptsKnownOnes()
+    {
+        // No filters sent — nothing to validate, no error.
+        Assert.IsNull(LagReportQueryValidation.FirstError(new LagReportQueryRequest()));
+
+        // Real values pass. "lan" in lowercase also passes: tag casing is forgiving
+        // on purpose (the enum member is spelled LAN).
+        Assert.IsNull(LagReportQueryValidation.FirstError(new LagReportQueryRequest
+        {
+            IssueCategory = ["Desync", "SpikeLag"],
+            ConnectionIssueTag = ["lan"],
+        }));
+
+        // Made-up values come back as an error that names the offending value,
+        // so the caller sees exactly what to correct.
+        StringAssert.Contains("Nope", LagReportQueryValidation.FirstError(
+            new LagReportQueryRequest { IssueCategory = ["Nope"] }));
+        StringAssert.Contains("wifi", LagReportQueryValidation.FirstError(
+            new LagReportQueryRequest { ConnectionIssueTag = ["wifi"] }));
+    }
 }

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -796,6 +796,63 @@ public class LagReportRepositoryTests : IntegrationTestBase
         Assert.AreEqual(2, total);
     }
 
+    /// <summary>Alice submits games A and B herself; in game C she appears without
+    /// submitting (Bob submitted it). The two repeat modes must read that differently.</summary>
+    private async Task SeedRepeatScenario()
+    {
+        var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);
+        await SeedReportOnNode(41001, noon, 1, "EU West", CreatePlayer("Alice#1", isExplicit: true));
+        await SeedReportOnNode(41002, noon.AddHours(1), 1, "EU West", CreatePlayer("Alice#1", isExplicit: true));
+        await SeedReportOnNode(41003, noon.AddHours(2), 1, "EU West",
+            CreatePlayer("Alice#1"), CreatePlayer("Bob#2", isExplicit: true));
+    }
+
+    [Test]
+    public async Task GetReports_MinRepeatSubmittedKeepsOnlyReportsTheChronicSubmitted()
+    {
+        await SeedRepeatScenario();
+
+        // Alice has 2 submissions, Bob 1 — only Alice qualifies at ≥2, and in the
+        // default submitted mode game C doesn't count: she appears there, but Bob
+        // submitted it.
+        var (submitted, submittedTotal) = await _repo.GetReports(new LagReportQueryRequest { MinRepeat = 2 });
+        Assert.AreEqual(2, submittedTotal);
+        Assert.IsTrue(submitted.TrueForAll(r => r.Players.Exists(p => p.BattleTag == "Alice#1" && p.IsExplicit)));
+
+        var (_, involvedTotal) = await _repo.GetReports(new LagReportQueryRequest
+        {
+            MinRepeat = 2,
+            RepeatMode = LagReportRepeatModes.Involved,
+        });
+        Assert.AreEqual(3, involvedTotal);
+
+        // Nobody reaches 3 — the honest result is an empty page, not an unfiltered one.
+        var (_, nobodyTotal) = await _repo.GetReports(new LagReportQueryRequest { MinRepeat = 3 });
+        Assert.AreEqual(0, nobodyTotal);
+    }
+
+    [Test]
+    public async Task GetAggregate_HonorsMinRepeat()
+    {
+        await SeedRepeatScenario();
+
+        var buckets = await _repo.GetAggregate(new LagReportAggregateRequest
+        {
+            GroupBy = LagReportAggregateDimensions.Day,
+            MinRepeat = 2,
+        });
+        Assert.AreEqual(1, buckets.Count);
+        Assert.AreEqual(2, buckets[0].Count);
+
+        var involved = await _repo.GetAggregate(new LagReportAggregateRequest
+        {
+            GroupBy = LagReportAggregateDimensions.Day,
+            MinRepeat = 2,
+            RepeatMode = LagReportRepeatModes.Involved,
+        });
+        Assert.AreEqual(3, involved[0].Count);
+    }
+
     [Test]
     public async Task GetAggregate_ByNodeDay_GroupsRenamedNodeOnce()
     {
@@ -864,6 +921,7 @@ public class LagReportRepositoryTests : IntegrationTestBase
         {
             IssueCategory = ["Desync", "SpikeLag"],
             ConnectionIssueTag = ["lan"],
+            RepeatMode = "Submitted",
         }));
 
         // Made-up values come back as an error that names the offending value,
@@ -872,5 +930,7 @@ public class LagReportRepositoryTests : IntegrationTestBase
             new LagReportQueryRequest { IssueCategory = ["Nope"] }));
         StringAssert.Contains("wifi", LagReportQueryValidation.FirstError(
             new LagReportQueryRequest { ConnectionIssueTag = ["wifi"] }));
+        StringAssert.Contains("repeatMode", LagReportQueryValidation.FirstError(
+            new LagReportQueryRequest { RepeatMode = "sometimes" }));
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -542,6 +542,48 @@ public class LagReportRepositoryTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task BackfillPlayerCounts_SetsSizeAndIsIdempotent()
+    {
+        // Simulate a document written before PlayerCount existed (field absent, not zero).
+        var collection = MongoClient
+            .GetDatabase("W3Champions-Statistic-Service")
+            .GetCollection<BsonDocument>("LagReport");
+        await collection.InsertOneAsync(new BsonDocument
+        {
+            { "_id", Guid.NewGuid().ToString() },
+            { "GameId", 38001 },
+            { "FloGameId", 38001 },
+            { "GameName", "Legacy Count Game" },
+            { "ServerNodeId", 1 },
+            { "ServerNodeName", "EU West" },
+            { "HasExplicitReport", false },
+            {
+                "Players",
+                new BsonArray
+                {
+                    new BsonDocument { { "BattleTag", "L1#1" } },
+                    new BsonDocument { { "BattleTag", "L2#2" } },
+                }
+            },
+            { "CreatedAt", DateTime.UtcNow },
+            { "UpdatedAt", DateTime.UtcNow },
+        });
+
+        // Before backfill the missing field matches no bound.
+        var (_, before) = await _repo.GetReports(new LagReportQueryRequest { MinPlayers = 1 });
+        Assert.AreEqual(0, before);
+
+        Assert.AreEqual(1, await _repo.BackfillPlayerCounts());
+
+        var (after, afterTotal) = await _repo.GetReports(new LagReportQueryRequest { MinPlayers = 2 });
+        Assert.AreEqual(1, afterTotal);
+        Assert.AreEqual(2, after[0].PlayerCount);
+
+        // Re-running is a no-op (idempotent guard).
+        Assert.AreEqual(0, await _repo.BackfillPlayerCounts());
+    }
+
+    [Test]
     public async Task GetReports_FiltersByMultipleCategoriesAsOr()
     {
         var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -491,6 +491,21 @@ public class LagReportRepositoryTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task GetReports_FiltersByServerNodeId()
+    {
+        // Reports live on nodes 1 and 2; asking for node 2 returns exactly the one
+        // report from that node.
+        var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);
+        await SeedReportOnNode(29001, noon, nodeId: 1, nodeName: "EU West");
+        await SeedReportOnNode(29002, noon, nodeId: 2, nodeName: "US East");
+
+        var (items, total) = await _repo.GetReports(new LagReportQueryRequest { ServerNodeId = [2] });
+
+        Assert.AreEqual(1, total);
+        Assert.AreEqual(2, items[0].ServerNodeId);
+    }
+
+    [Test]
     public async Task GetReports_FiltersByMultipleCategoriesAsOr()
     {
         var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);
@@ -522,6 +537,20 @@ public class LagReportRepositoryTests : IntegrationTestBase
         await SeedReportOnNode(40003, noon, 3, "Korea Central");
 
         var (_, total) = await _repo.GetReports(new LagReportQueryRequest { ServerName = ["eu", "us"] });
+        Assert.AreEqual(2, total);
+    }
+
+    [Test]
+    public async Task GetReports_FiltersByMultipleServerNodeIds()
+    {
+        // Asking for several node ids returns the reports from any of them —
+        // here nodes 1 and 3, leaving node 2's report out.
+        var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);
+        await SeedReportOnNode(40101, noon, 1, "EU West");
+        await SeedReportOnNode(40102, noon, 2, "US East");
+        await SeedReportOnNode(40103, noon, 3, "Korea Central");
+
+        var (_, total) = await _repo.GetReports(new LagReportQueryRequest { ServerNodeId = [1, 3] });
         Assert.AreEqual(2, total);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -249,6 +249,38 @@ public class LagReportRepositoryTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task GetReports_DateToCoversTheWholeDayItNames()
+    {
+        // A bare date carries no time, so an inclusive upper bound read literally is midnight —
+        // which excludes every report of the very day the admin asked for.
+        await SeedReportCreatedAt(21001, new DateTime(2026, 3, 5, 14, 30, 0, DateTimeKind.Utc));
+        await SeedReportCreatedAt(21002, new DateTime(2026, 3, 6, 0, 30, 0, DateTimeKind.Utc));
+
+        var (items, total) = await _repo.GetReports(new LagReportQueryRequest { DateTo = "2026-03-05" });
+
+        Assert.AreEqual(1, total);
+        Assert.AreEqual(21001, items[0].FloGameId);
+    }
+
+    [Test]
+    public async Task GetReports_FiltersByDateRange()
+    {
+        await SeedReportCreatedAt(22001, new DateTime(2026, 3, 1, 23, 59, 59, DateTimeKind.Utc));
+        await SeedReportCreatedAt(22002, new DateTime(2026, 3, 2, 0, 0, 0, DateTimeKind.Utc));
+        await SeedReportCreatedAt(22003, new DateTime(2026, 3, 3, 23, 59, 59, DateTimeKind.Utc));
+        await SeedReportCreatedAt(22004, new DateTime(2026, 3, 4, 0, 0, 0, DateTimeKind.Utc));
+
+        var (items, total) = await _repo.GetReports(new LagReportQueryRequest
+        {
+            DateFrom = "2026-03-02",
+            DateTo = "2026-03-03",
+        });
+
+        Assert.AreEqual(2, total);
+        CollectionAssert.AreEquivalent(new[] { 22003, 22002 }, items.ConvertAll(r => r.FloGameId));
+    }
+
+    [Test]
     public async Task GetReports_DateFiltersAcceptFullTimestamps()
     {
         // Clients that need sub-day precision (or a timezone other than UTC) send a full

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -218,6 +218,83 @@ public class LagReportRepositoryTests : IntegrationTestBase
         Assert.AreEqual(1, items.Count);
     }
 
+    /// <summary>
+    /// Seeds a report and forces its CreatedAt. UpsertPlayerData always stamps DateTime.UtcNow,
+    /// and the stamp is precisely what the date filters are tested against.
+    /// </summary>
+    private async Task SeedReportCreatedAt(int floGameId, DateTime createdAt)
+    {
+        var template = CreateTemplate(floGameId: floGameId, gameId: floGameId);
+        await _repo.UpsertPlayerData(template.FloGameId, CreatePlayer($"P{floGameId}#1"), template);
+
+        var collection = MongoClient
+            .GetDatabase("W3Champions-Statistic-Service")
+            .GetCollection<LagReport>("LagReport");
+        await collection.UpdateOneAsync(
+            Builders<LagReport>.Filter.Eq(r => r.FloGameId, floGameId),
+            Builders<LagReport>.Update.Set(r => r.CreatedAt, createdAt));
+    }
+
+    [Test]
+    public async Task GetReports_FiltersByDateFrom()
+    {
+        await SeedReportCreatedAt(20001, new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc));
+        await SeedReportCreatedAt(20002, new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc));
+        await SeedReportCreatedAt(20003, new DateTime(2026, 3, 9, 12, 0, 0, DateTimeKind.Utc));
+
+        var (items, total) = await _repo.GetReports(new LagReportQueryRequest { DateFrom = "2026-03-05" });
+
+        Assert.AreEqual(2, total);
+        CollectionAssert.AreEquivalent(new[] { 20003, 20002 }, items.ConvertAll(r => r.FloGameId));
+    }
+
+    [Test]
+    public async Task GetReports_DateFiltersAcceptFullTimestamps()
+    {
+        // Clients that need sub-day precision (or a timezone other than UTC) send a full
+        // timestamp, which is then honoured to the instant rather than widened to a day.
+        await SeedReportCreatedAt(23001, new DateTime(2026, 3, 5, 9, 0, 0, DateTimeKind.Utc));
+        await SeedReportCreatedAt(23002, new DateTime(2026, 3, 5, 15, 0, 0, DateTimeKind.Utc));
+
+        var (utc, _) = await _repo.GetReports(new LagReportQueryRequest { DateFrom = "2026-03-05T12:00:00Z" });
+        Assert.AreEqual(1, utc.Count);
+        Assert.AreEqual(23002, utc[0].FloGameId);
+
+        // 14:00+02:00 is 12:00 UTC — the offset must be applied, not discarded.
+        var (offset, _) = await _repo.GetReports(new LagReportQueryRequest { DateFrom = "2026-03-05T14:00:00+02:00" });
+        Assert.AreEqual(1, offset.Count);
+        Assert.AreEqual(23002, offset[0].FloGameId);
+    }
+
+    [Test]
+    public async Task GetReports_DateFiltersReadBareDatesAsUtcRegardlessOfServerTimezone()
+    {
+        // A bare date must mean the same window on every host: parsing it in the server's
+        // local time would shift the boundary by that host's UTC offset.
+        await SeedReportCreatedAt(24001, new DateTime(2026, 3, 4, 23, 0, 0, DateTimeKind.Utc));
+        await SeedReportCreatedAt(24002, new DateTime(2026, 3, 5, 1, 0, 0, DateTimeKind.Utc));
+
+        var (items, total) = await _repo.GetReports(new LagReportQueryRequest { DateFrom = "2026-03-05" });
+
+        Assert.AreEqual(1, total);
+        Assert.AreEqual(24002, items[0].FloGameId);
+    }
+
+    [Test]
+    public async Task GetReports_IgnoresUnparseableDates()
+    {
+        await SeedReportCreatedAt(25001, new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc));
+
+        var (items, total) = await _repo.GetReports(new LagReportQueryRequest
+        {
+            DateFrom = "not-a-date",
+            DateTo = "also-not-a-date",
+        });
+
+        Assert.AreEqual(1, total);
+        Assert.AreEqual(1, items.Count);
+    }
+
     [Test]
     public async Task GetReports_Pagination()
     {

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -640,6 +640,36 @@ public class LagReportRepositoryTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task GetAggregate_ByBattleTag_CountsDistinctNodesAndHonorsLimit()
+    {
+        var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);
+        // Alice appears twice without submitting; Bob appears once but pressed
+        // submit — submissions outrank appearances.
+        await SeedReportOnNode(36001, noon, 1, "EU West", CreatePlayer("Alice#1"));
+        await SeedReportOnNode(36002, noon, 2, "US East", CreatePlayer("Alice#1"), CreatePlayer("Bob#2", isExplicit: true));
+
+        var buckets = await _repo.GetAggregate(new LagReportAggregateRequest { GroupBy = LagReportAggregateDimensions.BattleTag });
+
+        Assert.AreEqual(2, buckets.Count);
+        Assert.AreEqual("Bob#2", buckets[0].BattleTag);
+        Assert.AreEqual(1, buckets[0].Count);
+        Assert.AreEqual(1, buckets[0].SubmittedCount);
+        Assert.AreEqual(1, buckets[0].DistinctNodes);
+        Assert.AreEqual("Alice#1", buckets[1].BattleTag);
+        Assert.AreEqual(2, buckets[1].Count);
+        Assert.AreEqual(0, buckets[1].SubmittedCount);
+        Assert.AreEqual(2, buckets[1].DistinctNodes);
+
+        var limited = await _repo.GetAggregate(new LagReportAggregateRequest
+        {
+            GroupBy = LagReportAggregateDimensions.BattleTag,
+            Limit = 1,
+        });
+        Assert.AreEqual(1, limited.Count);
+        Assert.AreEqual("Bob#2", limited[0].BattleTag);
+    }
+
+    [Test]
     public async Task UpsertPlayerData_MaintainsPlayerCount()
     {
         // Two players added one at a time via UpsertPlayerData; the stored PlayerCount

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -547,6 +547,45 @@ public class LagReportRepositoryTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task GetAggregate_ByNodeDay_CountsExplicitDistinctPlayersAndTopCategories()
+    {
+        var day = new DateTime(2026, 3, 5, 10, 0, 0, DateTimeKind.Utc);
+        var aliceAgain = CreatePlayer("Alice#1");
+        aliceAgain.IssueCategories = [EIssueCategory.SpikeLag, EIssueCategory.Reconnecting];
+
+        // Node 1: two reports; Alice appears in both (distinct players must dedupe her),
+        // one report is explicit, SpikeLag occurs twice vs Reconnecting once.
+        await SeedReportOnNode(32001, day, 1, "EU West",
+            CreatePlayer("Alice#1", isExplicit: true), CreatePlayer("Bob#2"));
+        await SeedReportOnNode(32002, day.AddHours(1), 1, "EU West", aliceAgain);
+        await SeedReportOnNode(32003, day.AddHours(2), 2, "US East", CreatePlayer("Carol#3"));
+
+        var buckets = await _repo.GetAggregate(new LagReportAggregateRequest { GroupBy = LagReportAggregateDimensions.NodeDay });
+
+        Assert.AreEqual(2, buckets.Count);
+
+        var eu = buckets[0]; // higher count sorts first within the day
+        Assert.AreEqual("2026-03-05", eu.Day);
+        Assert.AreEqual(1, eu.ServerNodeId);
+        Assert.AreEqual("EU West", eu.ServerNodeName);
+        Assert.AreEqual(2, eu.Count);
+        Assert.AreEqual(1, eu.ExplicitCount);
+        Assert.AreEqual(2, eu.DistinctPlayers);
+        Assert.AreEqual(2, eu.TopCategories.Count);
+        Assert.AreEqual("SpikeLag", eu.TopCategories[0].Category);
+        Assert.AreEqual(2, eu.TopCategories[0].Count);
+        Assert.AreEqual("Reconnecting", eu.TopCategories[1].Category);
+        Assert.AreEqual(1, eu.TopCategories[1].Count);
+
+        var us = buckets[1];
+        Assert.AreEqual(2, us.ServerNodeId);
+        Assert.AreEqual(1, us.Count);
+        Assert.AreEqual(0, us.ExplicitCount);
+        Assert.AreEqual(1, us.DistinctPlayers);
+        Assert.IsEmpty(us.TopCategories);
+    }
+
+    [Test]
     public async Task GetAggregate_ByCategory_CountsOccurrencesPerPlayer()
     {
         var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);
@@ -725,6 +764,62 @@ public class LagReportRepositoryTests : IntegrationTestBase
 
         var (_, total) = await _repo.GetReports(new LagReportQueryRequest { ServerNodeId = [1, 3] });
         Assert.AreEqual(2, total);
+    }
+
+    [Test]
+    public async Task GetAggregate_ByNodeDay_GroupsRenamedNodeOnce()
+    {
+        var day = new DateTime(2026, 3, 5, 10, 0, 0, DateTimeKind.Utc);
+        var p1 = CreatePlayer("P1#1");
+        p1.IssueCategories = [EIssueCategory.Desync];
+        var p2 = CreatePlayer("P2#2");
+        p2.IssueCategories = [EIssueCategory.Desync];
+
+        // Same node id under two display names (renamed mid-window): one bucket,
+        // and the category join must attach once, not once per name.
+        await SeedReportOnNode(43001, day, 5, "Old Name", p1);
+        await SeedReportOnNode(43002, day.AddHours(1), 5, "New Name", p2);
+
+        var buckets = await _repo.GetAggregate(new LagReportAggregateRequest { GroupBy = LagReportAggregateDimensions.NodeDay });
+
+        Assert.AreEqual(1, buckets.Count);
+        Assert.AreEqual(5, buckets[0].ServerNodeId);
+        Assert.AreEqual(2, buckets[0].Count);
+        Assert.That(buckets[0].ServerNodeName, Is.AnyOf("Old Name", "New Name"));
+        Assert.AreEqual(1, buckets[0].TopCategories.Count);
+        Assert.AreEqual("Desync", buckets[0].TopCategories[0].Category);
+        Assert.AreEqual(2, buckets[0].TopCategories[0].Count);
+    }
+
+    [Test]
+    public async Task GetAggregate_SurvivesNullServerNodeName()
+    {
+        // A legacy document with a null node name must not 500 the aggregation.
+        var collection = MongoClient
+            .GetDatabase("W3Champions-Statistic-Service")
+            .GetCollection<BsonDocument>("LagReport");
+        await collection.InsertOneAsync(new BsonDocument
+        {
+            { "_id", Guid.NewGuid().ToString() },
+            { "GameId", 44001 },
+            { "FloGameId", 44001 },
+            { "GameName", "Null Node Game" },
+            { "ServerNodeId", 7 },
+            { "ServerNodeName", BsonNull.Value },
+            { "HasExplicitReport", false },
+            { "Players", new BsonArray { new BsonDocument { { "BattleTag", "N#1" } } } },
+            { "CreatedAt", DateTime.UtcNow },
+            { "UpdatedAt", DateTime.UtcNow },
+        });
+
+        var nodeDay = await _repo.GetAggregate(new LagReportAggregateRequest { GroupBy = LagReportAggregateDimensions.NodeDay });
+        Assert.AreEqual(1, nodeDay.Count);
+        Assert.AreEqual(7, nodeDay[0].ServerNodeId);
+        Assert.AreEqual("", nodeDay[0].ServerNodeName);
+
+        var servers = await _repo.GetAggregate(new LagReportAggregateRequest { GroupBy = LagReportAggregateDimensions.Server });
+        Assert.AreEqual(1, servers.Count);
+        Assert.AreEqual("", servers[0].ServerNodeName);
     }
 
     [Test]

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportRepositoryTests.cs
@@ -157,7 +157,7 @@ public class LagReportRepositoryTests : IntegrationTestBase
         await _repo.UpsertPlayerData(t1.FloGameId, CreatePlayer("P1#1"), t1);
         await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("P2#2"), t2);
 
-        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { ServerName = "EU" });
+        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { ServerName = ["EU"] });
         Assert.AreEqual(1, items.Count);
         Assert.AreEqual("EU West", items[0].ServerNodeName);
     }
@@ -214,7 +214,7 @@ public class LagReportRepositoryTests : IntegrationTestBase
         await _repo.UpsertPlayerData(t1.FloGameId, player1, t1);
         await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("P2#2"), t2);
 
-        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { IssueCategory = "Reconnecting" });
+        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { IssueCategory = ["Reconnecting"] });
         Assert.AreEqual(1, items.Count);
     }
 
@@ -464,5 +464,64 @@ public class LagReportRepositoryTests : IntegrationTestBase
 
         Assert.IsFalse(names.Contains("Players.BattleTag_1"), "superseded raw-field index should be dropped");
         Assert.IsTrue(names.Contains("Players.BattleTagSearch_1"), "new shadow-field index should exist");
+    }
+
+    /// <summary>
+    /// Seeds a report on a chosen node with chosen players and a forced CreatedAt —
+    /// the three axes every aggregation dimension groups or counts over.
+    /// </summary>
+    private async Task SeedReportOnNode(int floGameId, DateTime createdAt, int nodeId, string nodeName, params LagReportPlayer[] players)
+    {
+        var template = CreateTemplate(floGameId: floGameId, gameId: floGameId);
+        template.ServerNodeId = nodeId;
+        template.ServerNodeName = nodeName;
+
+        var seedPlayers = players.Length > 0 ? players : [CreatePlayer($"P{floGameId}#1")];
+        foreach (var player in seedPlayers)
+        {
+            await _repo.UpsertPlayerData(template.FloGameId, player, template);
+        }
+
+        var collection = MongoClient
+            .GetDatabase("W3Champions-Statistic-Service")
+            .GetCollection<LagReport>("LagReport");
+        await collection.UpdateOneAsync(
+            Builders<LagReport>.Filter.Eq(r => r.FloGameId, floGameId),
+            Builders<LagReport>.Update.Set(r => r.CreatedAt, createdAt));
+    }
+
+    [Test]
+    public async Task GetReports_FiltersByMultipleCategoriesAsOr()
+    {
+        var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);
+        var desync = CreatePlayer("P1#1");
+        desync.IssueCategories = [EIssueCategory.Desync];
+        var reconnecting = CreatePlayer("P2#2");
+        reconnecting.IssueCategories = [EIssueCategory.Reconnecting];
+        var spike = CreatePlayer("P3#3");
+        spike.IssueCategories = [EIssueCategory.SpikeLag];
+
+        await SeedReportOnNode(39001, noon, 1, "EU West", desync);
+        await SeedReportOnNode(39002, noon, 1, "EU West", reconnecting);
+        await SeedReportOnNode(39003, noon, 1, "EU West", spike);
+
+        // OR semantics: any player carrying any selected category qualifies the report.
+        var (_, total) = await _repo.GetReports(new LagReportQueryRequest
+        {
+            IssueCategory = ["Desync", "Reconnecting"],
+        });
+        Assert.AreEqual(2, total);
+    }
+
+    [Test]
+    public async Task GetReports_FiltersByMultipleServerNamesAsOr()
+    {
+        var noon = new DateTime(2026, 3, 5, 12, 0, 0, DateTimeKind.Utc);
+        await SeedReportOnNode(40001, noon, 1, "EU West");
+        await SeedReportOnNode(40002, noon, 2, "US East");
+        await SeedReportOnNode(40003, noon, 3, "Korea Central");
+
+        var (_, total) = await _repo.GetReports(new LagReportQueryRequest { ServerName = ["eu", "us"] });
+        Assert.AreEqual(2, total);
     }
 }

--- a/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagRepositoryTests.cs
+++ b/WC3ChampionsStatisticService.UnitTests/LagReports/LagReportTagRepositoryTests.cs
@@ -114,13 +114,13 @@ public class LagReportTagRepositoryTests
         await _repo.UpsertPlayerData(t1.FloGameId, CreatePlayer("Lan#1", [ELagReportTag.LAN]), t1);
         await _repo.UpsertPlayerData(t2.FloGameId, CreatePlayer("LastMile#2", [ELagReportTag.LastMile]), t2);
 
-        var (lan, lanTotal) = await _repo.GetReports(new LagReportQueryRequest { ConnectionIssueTag = "LAN" });
+        var (lan, lanTotal) = await _repo.GetReports(new LagReportQueryRequest { ConnectionIssueTag = ["LAN"] });
         Assert.AreEqual(1, lanTotal);
         Assert.AreEqual(1, lan.Count);
         CollectionAssert.Contains(lan.Select(r => r.GameId).ToList(), 6001);
         CollectionAssert.DoesNotContain(lan.Select(r => r.GameId).ToList(), 6002);
 
-        var (lastMile, lmTotal) = await _repo.GetReports(new LagReportQueryRequest { ConnectionIssueTag = "LastMile" });
+        var (lastMile, lmTotal) = await _repo.GetReports(new LagReportQueryRequest { ConnectionIssueTag = ["LastMile"] });
         Assert.AreEqual(1, lmTotal);
         Assert.AreEqual(1, lastMile.Count);
         CollectionAssert.Contains(lastMile.Select(r => r.GameId).ToList(), 6002);
@@ -134,7 +134,7 @@ public class LagReportTagRepositoryTests
         await _repo.UpsertPlayerData(t.FloGameId, CreatePlayer("Lan#1", [ELagReportTag.LAN]), t);
 
         // Enum.TryParse(ignoreCase: true) → "lan" still resolves to LAN.
-        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { ConnectionIssueTag = "lan" });
+        var (items, _) = await _repo.GetReports(new LagReportQueryRequest { ConnectionIssueTag = ["lan"] });
         Assert.AreEqual(1, items.Count);
     }
 


### PR DESCRIPTION
The admin lag-report page gets the filtering it was designed for, plus one counts endpoint so it can group and facet server-side. Eleven commits, each with its own tests.

**Deploy order: this PR before website#1120.** The reworked page always sends a date window, and date-filtered requests against the current backend return HTTP 500 (shipped broken in #506). In the reverse order the new page fails on load.

## What changes when

| Live on deploy | Dormant until website#1120 deploys |
|---|---|
| Date filters return results; a range covers its end date's whole day | `serverName`, `issueCategory`, `connection_issue_tag` accept lists (a single value binds as before) |
| Unknown `issueCategory` / `connection_issue_tag` values answer 400 | `serverNodeId`, `minPlayers` / `maxPlayers`, `minRepeat` / `repeatMode` |
| `PlayerCount` is stored on new reports and backfilled on old ones | `GET api/lag-reports/aggregate` (`groupBy` = day, node-day, category, server, proxy, battleTag) |

## Worth knowing before prod

1. **A shipped endpoint answers differently.** A typo'd category used to return the unfiltered list as if the filter had applied. It now returns 400. Only caller: the admin page, behind the `Proxies` permission.
2. **A startup service writes to every document lacking `PlayerCount`.** One server-side `UpdateMany`, gated by a run-once marker in `HandlerVersions`. Same pattern as `LagReportSearchBackfillService`, already in production on this collection, which has a 90-day TTL.
3. **Rolling-deploy window.** Old instances write reports without the field until they cycle. The min/max player filters skip those rows; everything else shows them. Nothing reads the field until the website deploys.

Malformed dates are still skipped rather than rejected, as before.

## Verify on test

Use the admin page's bearer token (Proxies permission), e.g. copied from devtools.

1. `GET api/lag-reports?dateFrom=<yesterday>&dateTo=<today>` → 200 with rows. On master this is a 500.
2. `GET api/lag-reports/aggregate?groupBy=day&dateFrom=<yesterday>&dateTo=<today>` → 200 with one bucket per day.
3. `GET api/lag-reports?issueCategory=Nope` → 400.
4. Startup log contains `LagReport player-count backfill complete: N document(s) updated`; a second restart logs nothing (marker present).
5. The current admin lag-report page still loads and filters (single-value params bind as before).

## Reading this

Start with the two date commits: their tests fail on master with `ExpressionNotSupportedException` before the query reaches the server. The backfill commit is the only one with an operational footprint. The rest add parameters, each pinned by tests.

```
dotnet test --filter LagReport
```

## Rollback

Revert the squash commit. The `PlayerCount` field and the `HandlerVersions` marker stay in the database and are inert.

## Scope

Filtering and counting only. Submission, detail and the report schema are untouched apart from `PlayerCount`. Consumer: website#1120. A follow-up website PR for the report detail page depends on this one only for the date fix.
